### PR TITLE
partial support for Selenium java tests

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProvider.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProvider.java
@@ -83,7 +83,8 @@ public class BazelRuntimeClasspathProvider extends StandardClasspathProvider {
     
     // computeUnresolvedClassPathEntries() is called multiple times while trying to run a single test, 
     // we need this variable to keep track of when to open the error dialog
-    public static AtomicBoolean canOpen = new AtomicBoolean(true); 
+    public static AtomicBoolean canOpenErrorDialog = new AtomicBoolean(true);
+    
     /**
      * Compute classpath entries for test
      */
@@ -145,9 +146,10 @@ public class BazelRuntimeClasspathProvider extends StandardClasspathProvider {
                 Display.getDefault().asyncExec(new Runnable() {
                     @Override
                     public void run() {
-                        if(canOpen.get()) {
-                            canOpen.set(false);
-                            MessageDialog.openError(Display.getDefault().getActiveShell(), "Unknown Target", "One or all of the tests trying to be executed are not part of a Bazel java_test target");
+                        if(canOpenErrorDialog.get()) {
+                            canOpenErrorDialog.set(false);
+                            MessageDialog.openError(Display.getDefault().getActiveShell(), "Unknown Target", 
+                                "One or all of the tests trying to be executed are not part of a Bazel Java test target");
                         }
                     }
                 });

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
@@ -116,6 +116,27 @@ public class BazelLauncherBuilderTest {
     }
 
     @Test
+    public void testBuildSeleniumTestCommand() throws Exception {
+        TestBazelCommandEnvironmentFactory env = createEnv();
+        BazelLabel label = new BazelLabel("//a/b/c");
+        TargetKind targetKind = TargetKind.JAVA_WEB_TEST_SUITE;
+        
+        BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
+        launcherBuilder.setLabel(label);
+        launcherBuilder.setTargetKind(targetKind);
+        launcherBuilder.setArgs(Collections.emptyMap());
+
+        addBazelCommandOutput(env, "test", "bazel test result");
+        
+        List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
+
+        assertEquals(env.bazelExecutable.getAbsolutePath(), cmdTokens.get(0));
+        assertEquals("test", cmdTokens.get(1));
+        assertTrue(cmdTokens.contains(label.getLabel()));
+        assertFalse(cmdTokens.toString().contains("debug"));
+    }
+    
+    @Test
     public void testBuildTestCommandWithFilter() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
         BazelLabel label = new BazelLabel("//a/b/c");

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfo.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfo.java
@@ -172,7 +172,7 @@ public final class AspectPackageInfo {
     }
 
     /**
-     * Kind of the target (e.g., java_test or java_binary).
+     * Kind of the target (e.g., java_test, java_binary, java_web_test_suite, etc).
      */
     public String getKind() {
         return kind;

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelper.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelper.java
@@ -57,7 +57,7 @@ public class BazelBuildFileHelper {
      * If you change the contents of this list, please also update TestBazelWorkspaceCreator.java.
      */
     public static final String[] JAVA_PROJECT_INDICATORS =
-            { "java_binary", "java_library", "java_test", "springboot", "springboot_test" };
+            { "java_binary", "java_library", "java_test", "java_web_test_suite", "springboot", "springboot_test" };
 
     /**
      * Parses a File, presumed to be a Bazel BUILD file, looking for indications that it contains Java rules.

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/TargetKind.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/TargetKind.java
@@ -75,8 +75,22 @@ public enum TargetKind {
         public boolean isTestable() {
             return true;
         }
-    };
+    },
 
+    // Selenium https://github.com/bazelbuild/rules_webtesting
+    JAVA_WEB_TEST_SUITE("java_web_test_suite") {
+
+        @Override
+        public boolean isRunnable() {
+            return false;
+        }
+
+        @Override
+        public boolean isTestable() {
+            return true;
+        }
+    };
+    
     private final String targetKind;
 
     private TargetKind(String targetKind) {

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/AspectPackageInfosTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/AspectPackageInfosTest.java
@@ -53,12 +53,14 @@ public class AspectPackageInfosTest {
         AspectPackageInfo lib = getAspectPackageInfo("foo1", TargetKind.JAVA_LIBRARY, "a/b/c/d/Foo.java");
         AspectPackageInfo test = getAspectPackageInfo("foo2", TargetKind.JAVA_TEST, "a/b/c/d/Foo.java");
         AspectPackageInfo bin = getAspectPackageInfo("foo3", TargetKind.JAVA_BINARY, "a/b/c/d/Foo.java");
+        AspectPackageInfo seleniumTest = getAspectPackageInfo("foo4", TargetKind.JAVA_WEB_TEST_SUITE, "a/b/c/d/Foo.java");
 
-        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin);
+        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin, seleniumTest);
 
         assertSame(lib, apis.lookupByLabel("foo1"));
         assertSame(test, apis.lookupByLabel("foo2"));
         assertSame(bin, apis.lookupByLabel("foo3"));
+        assertSame(seleniumTest, apis.lookupByLabel("foo4"));
         assertNull(apis.lookupByLabel("blah"));
     }
 
@@ -67,22 +69,27 @@ public class AspectPackageInfosTest {
         AspectPackageInfo lib = getAspectPackageInfo("foo1", TargetKind.JAVA_LIBRARY, "a/b/c/d/Foo.java");
         AspectPackageInfo test = getAspectPackageInfo("foo2", TargetKind.JAVA_TEST, "a/b/c/d/Foo.java");
         AspectPackageInfo bin = getAspectPackageInfo("foo3", TargetKind.JAVA_BINARY, "a/b/c/d/Foo.java");
+        AspectPackageInfo seleniumTest = getAspectPackageInfo("foo4", TargetKind.JAVA_WEB_TEST_SUITE, "a/b/c/d/Foo.java");
 
-        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin);
+        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin, seleniumTest);
 
         Collection<AspectPackageInfo> infos = apis.lookupByTargetKind(EnumSet.of(TargetKind.JAVA_TEST));
-
         assertEquals(1, infos.size());
         assertSame(test, infos.iterator().next());
-    }
+
+        infos = apis.lookupByTargetKind(EnumSet.of(TargetKind.JAVA_WEB_TEST_SUITE));
+        assertEquals(1, infos.size());
+        assertSame(seleniumTest, infos.iterator().next());
+}
 
     @Test
     public void testLookupByTargetKind__multipleTargetKinds() {
         AspectPackageInfo lib = getAspectPackageInfo("foo1", TargetKind.JAVA_LIBRARY, "a/b/c/d/Foo.java");
         AspectPackageInfo test = getAspectPackageInfo("foo2", TargetKind.JAVA_TEST, "a/b/c/d/Foo.java");
         AspectPackageInfo bin = getAspectPackageInfo("foo3", TargetKind.JAVA_BINARY, "a/b/c/d/Foo.java");
+        AspectPackageInfo seleniumTest = getAspectPackageInfo("foo4", TargetKind.JAVA_WEB_TEST_SUITE, "a/b/c/d/Foo.java");
 
-        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin);
+        AspectPackageInfos apis = new AspectPackageInfos(lib, test, bin, seleniumTest);
 
         Collection<AspectPackageInfo> infos =
                 apis.lookupByTargetKind(EnumSet.of(TargetKind.JAVA_TEST, TargetKind.JAVA_BINARY));

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelperTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelperTest.java
@@ -51,6 +51,7 @@ public class BazelBuildFileHelperTest {
         assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("java_binary("));
         assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("java_library("));
         assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("java_test("));
+        assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("java_web_test_suite("));
         assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("springboot"));
         assertTrue(BazelBuildFileHelper.hasJavaRulesInLine("springboot_test("));
 


### PR DESCRIPTION
This PR makes BEF aware that Selenium Java targets are interesting. But BEF doesn't really do anything interesting with Selenium targets beyond that. See the #47 work item for more details on follow up work.