### PR TITLE
refactor to add BazelWorkspace model object

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
@@ -61,14 +61,15 @@ import com.google.common.collect.Multimap;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.classpath.BazelClasspathContainer;
-import com.salesforce.bazel.eclipse.command.BazelCommandManager;
 import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
+import com.salesforce.bazel.eclipse.command.BazelCommandManager;
 import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectFactory;
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelMarkerDetails;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
 
 /**
@@ -92,7 +93,8 @@ public class BazelBuilder extends IncrementalProjectBuilder {
         progressMonitor.beginTask("Bazel build", 1);
         
         BazelCommandManager bazelCommandManager = BazelPluginActivator.getBazelCommandManager();
-        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(BazelPluginActivator.getBazelWorkspaceRootDirectory());
+        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
+        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
         
         try {
             boolean buildSuccessful = buildProjects(bazelWorkspaceCmdRunner, Collections.singletonList(project), progressMonitor, monitor);
@@ -117,7 +119,8 @@ public class BazelBuilder extends IncrementalProjectBuilder {
         // TODO: revisit if we want to clean only once when multiple targets are selected
         
         BazelCommandManager bazelCommandManager = BazelPluginActivator.getBazelCommandManager();
-        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(BazelPluginActivator.getBazelWorkspaceRootDirectory());
+        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
+        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
         
         if (bazelWorkspaceCmdRunner == null) {
             super.clean(monitor);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
@@ -107,6 +107,8 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
                 return;
             }
             for(IProject project: importedProjects) {
+                // TODO we need a checkbox pref to disable this; if a user in the field hits an import bug, it may be useful for them
+                // to check the 'disable import cleanup on error' checkbox so they can at least get some usable projects out of their import
                 project.delete(true, null);
             }            
         }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
@@ -1,0 +1,53 @@
+package com.salesforce.bazel.eclipse.classpath;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.IClasspathEntry;
+
+import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
+
+/**
+ * Bazel generally requires BUILD file authors to list all dependencies explicitly.
+ * However, there are a few legacy cases in which dependencies are implied.
+ * For example, java_test implicitly brings in junit and hamcrest libraries.
+ * <p>
+ * This is unfortunate because external tools that need to construct the dependency
+ * graph (ahem, that's us, for JDT) we need to know to append the implicit dependencies
+ * to the explicit ones identified by the Aspect.
+ * <p>
+ * This is a helper class for computing implicit dependencies.
+ * See https://github.com/salesforce/bazel-eclipse/issues/43 for details and design
+ * considerations for this class. 
+ *
+ */
+public class ImplicitDependencyHelper {
+
+    Set<IClasspathEntry> computeImplicitDependencies(IProject eclipseIProject, AspectPackageInfo packageInfo) {
+        Set<IClasspathEntry> deps = null;
+        
+        String ruleKind = packageInfo.getKind();        
+        if ("java_test".equals(ruleKind)) {
+            deps = computeImplicitJavaTestDependencies(eclipseIProject, packageInfo);
+        } else {
+            deps = new TreeSet<>();
+        }
+        return deps;
+    }
+    
+    private Set<IClasspathEntry> computeImplicitJavaTestDependencies(IProject eclipseIProject, AspectPackageInfo packageInfo) {
+        Set<IClasspathEntry> deps = new TreeSet<>();
+        
+        // TODO ideally we would only do this if --explicit_java_test_deps=false, but how to compute that?
+        
+        // Ultimately we need to get this jar onto the classpath
+        // bazel-bin/external/bazel_tools/tools/jdk/_ijar/TestRunner/external/remote_java_tools_darwin/java_tools/Runner_deploy-ijar.jar
+        // which comes in from the transitive graph (not sure how the toolchain points to the TestRunner though):
+        // java_test => @bazel_tools//tools/jdk:current_java_toolchain => @remote_java_tools_darwin//:toolchain  ?=> TestRunner 
+        
+        // TODO need to implement the dependency computation HERE for issue 43
+        
+        return deps;
+    }    
+}

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
@@ -76,6 +76,7 @@ import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfos;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelPackageInfo;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
 
 /**
@@ -199,7 +200,11 @@ public class BazelEclipseProjectFactory {
         }
 
         for (BazelPackageInfo childPackageInfo : packageInfo.getChildPackageInfos()) {
-            importBazelWorkspacePackagesAsProjects(childPackageInfo, bazelWorkspaceRoot, importedProjectsList);
+            try {
+                importBazelWorkspacePackagesAsProjects(childPackageInfo, bazelWorkspaceRoot, importedProjectsList);
+            } catch (Exception anyE) {
+                anyE.printStackTrace();
+            }
         }
     }
 
@@ -514,8 +519,9 @@ public class BazelEclipseProjectFactory {
      */
     private static AspectPackageInfos precomputeBazelAspectsForWorkspace(IProject rootEclipseProject, List<BazelPackageInfo> selectedBazelPackages,
             WorkProgressMonitor progressMonitor) {
+        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
         BazelCommandManager bazelCommandManager = BazelPluginActivator.getBazelCommandManager();
-        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(BazelPluginActivator.getBazelWorkspaceRootDirectory());
+        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
 
         // figure out which Bazel targets will be imported, and generated AspectPackageInfos for each
         // The AspectPackageInfos have useful information that we use during import

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/old/WorkspaceWizardPage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/old/WorkspaceWizardPage.java
@@ -41,6 +41,8 @@ import org.eclipse.swt.widgets.Text;
 import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
+import com.salesforce.bazel.eclipse.model.RealOperatingEnvironmentDetectionStrategy;
 
 /**
  * This is a quick wizard page that ask the user for the various targets and source path he wants to include.
@@ -168,8 +170,9 @@ public class WorkspaceWizardPage extends WizardPage {
                 if (wr != null) {
                     workspaceRoot.setText(wr);
                     DirectoryTreeContentProvider.setFileTreeRoot(directories, new File(wr));
+                    BazelWorkspace bazelWorkspace = new BazelWorkspace(new File(getWorkspaceRoot()), new RealOperatingEnvironmentDetectionStrategy());
                     completionProvider.setBazelInstance(BazelPluginActivator.getBazelCommandManager()
-                            .getWorkspaceCommandRunner(new File(getWorkspaceRoot())));
+                            .getWorkspaceCommandRunner(bazelWorkspace));
                 }
                 updateControls();
             }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
@@ -45,10 +45,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
-import com.salesforce.bazel.eclipse.command.BazelCommandManager;
-import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
-import com.salesforce.bazel.eclipse.mock.MockEclipse;
 import com.salesforce.bazel.eclipse.mock.EclipseFunctionalTestEnvironmentFactory;
+import com.salesforce.bazel.eclipse.mock.MockEclipse;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 
 public class BazelCommandRunnerFTest {
     @Rule
@@ -71,8 +70,9 @@ public class BazelCommandRunnerFTest {
         BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory(mockEclipse.getBazelWorkspaceRoot());
         
         // run the method under test
+        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
         BazelCommandManager bazelCommandManager = BazelPluginActivator.getBazelCommandManager();
-        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(BazelPluginActivator.getBazelWorkspaceRootDirectory());
+        BazelWorkspaceCommandRunner bazelWorkspaceCmdRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
         
         // verify
         assertNotNull(bazelWorkspaceCmdRunner);
@@ -82,8 +82,8 @@ public class BazelCommandRunnerFTest {
         
         // verify command runner 'bazel info' commands
         File expectedBazelOutputBase = mockEclipse.getBazelOutputBase();
-        assertEquals(expectedBazelOutputBase.getAbsolutePath(), bazelWorkspaceCmdRunner.getBazelWorkspaceOutputBase(null).getAbsolutePath());
+        assertEquals(expectedBazelOutputBase.getAbsolutePath(), bazelWorkspace.getBazelOutputBaseDirectory().getAbsolutePath());
         File expectedBazelExecutionRoot = mockEclipse.getBazelExecutionRoot();
-        assertEquals(expectedBazelExecutionRoot.getAbsolutePath(), bazelWorkspaceCmdRunner.getBazelWorkspaceExecRoot(null).getAbsolutePath());
+        assertEquals(expectedBazelExecutionRoot.getAbsolutePath(), bazelWorkspace.getBazelExecRootDirectory().getAbsolutePath());
     }
 }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockEclipse.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockEclipse.java
@@ -35,6 +35,7 @@ import com.salesforce.bazel.eclipse.command.mock.MockCommandBuilder;
 import com.salesforce.bazel.eclipse.command.mock.MockCommandConsole;
 import com.salesforce.bazel.eclipse.command.mock.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.eclipse.launch.BazelLaunchConfigurationDelegate;
+import com.salesforce.bazel.eclipse.model.OperatingEnvironmentDetectionStrategy;
 import com.salesforce.bazel.eclipse.preferences.BazelPreferencePage;
 import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 
@@ -62,6 +63,7 @@ public class MockEclipse {
     private MockIPreferenceStore mockPrefsStore;
     private MockResourceHelper mockResourceHelper;
     private MockJavaCoreHelper mockJavaCoreHelper;
+    private OperatingEnvironmentDetectionStrategy mockOsEnvStrategy = new MockOperatingEnvironmentDetectionStrategy();
     
     // Feature collaborators
     private BazelPluginActivator pluginActivator;
@@ -133,7 +135,7 @@ public class MockEclipse {
         // this simulates how our feature starts up when run inside of Eclipse
         this.pluginActivator.startInternal(this.bazelCommandEnvironment.bazelAspectLocation, 
             this.bazelCommandEnvironment.commandBuilder, this.bazelCommandEnvironment.commandConsole, 
-            mockResourceHelper, mockJavaCoreHelper);
+            mockResourceHelper, mockJavaCoreHelper, mockOsEnvStrategy);
         
         // At this point our plugins are wired up, the Bazel workspace is created, but the user
         // has not run a Bazel Import... wizard yet. See EclipseFunctionalTestEnvironmentFactory

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockOperatingEnvironmentDetectionStrategy.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockOperatingEnvironmentDetectionStrategy.java
@@ -1,0 +1,19 @@
+package com.salesforce.bazel.eclipse.mock;
+
+import com.salesforce.bazel.eclipse.model.OperatingEnvironmentDetectionStrategy;
+
+public class MockOperatingEnvironmentDetectionStrategy implements OperatingEnvironmentDetectionStrategy {
+
+    private String osName = "linux";
+    
+    public MockOperatingEnvironmentDetectionStrategy() {}
+    public MockOperatingEnvironmentDetectionStrategy(String osName) {
+        this.osName = osName;
+    }
+    
+    @Override
+    public String getOperatingSystemName() {
+        return osName;
+    }
+
+}

--- a/plugin-libs/plugin-command/BUILD
+++ b/plugin-libs/plugin-command/BUILD
@@ -53,6 +53,7 @@ java_library(
     deps = [
         ":plugin-command",
         "//plugin-libs/plugin-abstractions",
+        "//plugin-libs/plugin-model",
         "//plugin-libs/plugin-testdeps",
 
         "//plugin-libs/plugin-testdeps:org_junit_junit",
@@ -94,9 +95,11 @@ java_test(
         "//plugin-libs/plugin-model",
         "//plugin-libs/plugin-testdeps",
 
+        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:net_bytebuddy_byte_buddy",
         "//plugin-libs/plugin-testdeps:org_hamcrest_core",
         "//plugin-libs/plugin-testdeps:org_junit_junit",
-        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:org_objenesis_objenesis",
     ],
 )
 
@@ -127,9 +130,11 @@ java_test(
         "//plugin-libs/plugin-model",
         "//plugin-libs/plugin-testdeps",
 
+        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:net_bytebuddy_byte_buddy",
         "//plugin-libs/plugin-testdeps:org_hamcrest_core",
         "//plugin-libs/plugin-testdeps:org_junit_junit",
-        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:org_objenesis_objenesis",
     ],
 )
 
@@ -144,8 +149,10 @@ java_test(
         "//plugin-libs/plugin-abstractions",
         "//plugin-libs/plugin-testdeps",
 
+        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:net_bytebuddy_byte_buddy",
         "//plugin-libs/plugin-testdeps:org_hamcrest_core",
         "//plugin-libs/plugin-testdeps:org_junit_junit",
-        "//plugin-libs/plugin-testdeps:com_google_truth",
+        "//plugin-libs/plugin-testdeps:org_objenesis_objenesis",
     ],
 )

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelCommandManager.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelCommandManager.java
@@ -42,6 +42,7 @@ import java.util.TreeMap;
 
 import com.salesforce.bazel.eclipse.abstractions.BazelAspectLocation;
 import com.salesforce.bazel.eclipse.abstractions.CommandConsoleFactory;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 
 /**
  * API for calling bazel commands.
@@ -92,12 +93,13 @@ public class BazelCommandManager {
     public BazelWorkspaceCommandRunner getGlobalCommandRunner() {
         return genericCommandRunner;
     }
-    
+
     /**
      * Returns a {@link BazelWorkspaceCommandRunner} for the given Eclipse workspace directory. It looks for the
      * enclosing workspace and returns the instance that corresponds to it. If not in a Bazel workspace, returns null.
      */
-    public BazelWorkspaceCommandRunner getWorkspaceCommandRunner(File bazelWorkspaceRootDirectory) {
+    public BazelWorkspaceCommandRunner getWorkspaceCommandRunner(BazelWorkspace bazelWorkspace) {
+        File bazelWorkspaceRootDirectory = bazelWorkspace.getBazelWorkspaceRootDirectory();
         BazelWorkspaceCommandRunner workspaceCommandRunner = workspaceCommandRunners.get(bazelWorkspaceRootDirectory);
         if (workspaceCommandRunner == null) {
             File bazelExecutable = null;
@@ -114,6 +116,7 @@ public class BazelCommandManager {
         }
         return workspaceCommandRunner;
     }
+    
 
     
     // BAZEL EXECUTABLE

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
@@ -58,6 +58,7 @@ import com.salesforce.bazel.eclipse.logging.LoggerFacade;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
 import com.salesforce.bazel.eclipse.model.BazelMarkerDetails;
 import com.salesforce.bazel.eclipse.model.BazelOutputParser;
+import com.salesforce.bazel.eclipse.model.BazelWorkspaceMetadataStrategy;
 
 /**
  * An instance of the Bazel command interface for a specific workspace. Provides the API to run Bazel commands on a
@@ -66,7 +67,7 @@ import com.salesforce.bazel.eclipse.model.BazelOutputParser;
  * There is also an instance of this class that is not associated with a workspace (the global runner) but it is limited
  * in the commands it can run. It is intended only to run commands like the Bazel version check.
  */
-public class BazelWorkspaceCommandRunner {
+public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrategy {
     static final LogHelper LOG = LogHelper.log(BazelWorkspaceCommandRunner.class);;
     
     // WORKSPACE CONFIG
@@ -198,18 +199,15 @@ public class BazelWorkspaceCommandRunner {
     
     /**
      * Returns the execution root of the current Bazel workspace.
-     *
-     * @param progressMonitor
-     *            can be null
      */
-    public File getBazelWorkspaceExecRoot(WorkProgressMonitor progressMonitor) {
+    public File getBazelWorkspaceExecRoot() {
 
         if (bazelExecRootDirectory == null) {
             try {
                 ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
                 argBuilder.add("info").add("execution_root");
                 
-                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor, 
+                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, null, 
                     argBuilder.build(), (t) -> t);
                 outputLines = BazelCommandExecutor.stripInfoLines(outputLines);
                 bazelExecRootDirectory = new File(String.join("", outputLines));
@@ -222,17 +220,14 @@ public class BazelWorkspaceCommandRunner {
 
     /**
      * Returns the output base of the current Bazel workspace.
-     *
-     * @param progressMonitor
-     *            can be null
      */
-    public File getBazelWorkspaceOutputBase(WorkProgressMonitor progressMonitor) {
+    public File getBazelWorkspaceOutputBase() {
         if (bazelOutputBaseDirectory == null) {
             try {
                 ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
                 argBuilder.add("info").add("output_base");
                 
-                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor, 
+                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, null, 
                     argBuilder.build(), (t) -> t);
                 outputLines = BazelCommandExecutor.stripInfoLines(outputLines);
                 bazelOutputBaseDirectory = new File(String.join("", outputLines));
@@ -246,17 +241,14 @@ public class BazelWorkspaceCommandRunner {
 
     /**
      * Returns the bazel-bin of the current Bazel workspace.
-     *
-     * @param progressMonitor
-     *            can be null
      */
-    public File getBazelWorkspaceBin(WorkProgressMonitor progressMonitor) {
+    public File getBazelWorkspaceBin() {
         if (bazelBinDirectory == null) {
             try {
                 ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
                 argBuilder.add("info").add("bazel-bin");
                 
-                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor, 
+                List<String> outputLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, null, 
                     argBuilder.build(), (t) -> t);
                 outputLines = BazelCommandExecutor.stripInfoLines(outputLines);
                 bazelBinDirectory = new File(String.join("", outputLines));

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
@@ -25,8 +25,12 @@ package com.salesforce.bazel.eclipse.command.mock;
 
 import java.io.File;
 
+import org.mockito.Mockito;
+
 import com.salesforce.bazel.eclipse.command.BazelCommandManager;
 import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
+import com.salesforce.bazel.eclipse.model.BazelWorkspace;
+import com.salesforce.bazel.eclipse.model.OperatingEnvironmentDetectionStrategy;
 import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 
 /**
@@ -87,8 +91,9 @@ public class TestBazelCommandEnvironmentFactory {
             bazelExecutable.bazelExecutableFile);
         bazelCommandManager.setBazelExecutablePath(bazelExecutable.bazelExecutableFile.getAbsolutePath());
         
+        BazelWorkspace bazelWorkspace = new BazelWorkspace(testWorkspace.dirWorkspaceRoot, Mockito.mock(OperatingEnvironmentDetectionStrategy.class));
         this.globalCommandRunner = bazelCommandManager.getGlobalCommandRunner();
-        this.bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(testWorkspace.dirWorkspaceRoot);
+        this.bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
     }
     
 }

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspace.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspace.java
@@ -1,0 +1,109 @@
+package com.salesforce.bazel.eclipse.model;
+
+import java.io.File;
+
+public class BazelWorkspace {
+
+    // COLLABORATORS
+    
+    /**
+     * The location on disk for the workspace.
+     */
+    private final File bazelWorkspaceRootDirectory;
+    
+    /**
+     * Strategy delegate that can compute the data for file paths
+     */
+    private BazelWorkspaceMetadataStrategy metadataStrategy;
+
+    // COMPUTED DATA
+    
+    /**
+     * The internal location on disk for Bazel's 'execroot' for this workspace. E.g.
+     * <i>/private/var/tmp/_bazel_plaird/edb34c7f4bfffeb66012c4fc6aaab239/execroot/bazel_demo_simplejava</i>
+     * <p>
+     * Determined by running this command line: <i>bazel info execution_root</i>
+     */
+    private File bazelExecRootDirectory;
+
+    /**
+     * The internal location on disk for Bazel's 'output base' for this workspace. E.g.
+     * <i>/private/var/tmp/_bazel_plaird/edb34c7f4bfffeb66012c4fc6aaab239</i>
+     * <p>
+     * Determined by running this command line: <i>bazel info output_base</i>
+     */
+    private File bazelOutputBaseDirectory;
+
+    /**
+     * The internal location on disk for Bazel's 'bazel-bin' for this workspace. E.g.
+     * <i>/private/var/tmp/_bazel_plaird/f521799c9882dcc6330b57416b13ba81/execroot/bazel_eclipse_feature/bazel-out/darwin-fastbuild/bin</i>
+     * <p>
+     * Determined by running this command line: <i>bazel info bazel-bin</i>
+     */
+    private File bazelBinDirectory;
+    
+    /**
+     * The operating system running Bazel and our BEF: osx, linux, windows
+     * https://github.com/bazelbuild/bazel/blob/c35746d7f3708acb0d39f3082341de0ff09bd95f/src/main/java/com/google/devtools/build/lib/util/OS.java#L21
+     */
+    private String operatingSystem;
+
+    /**
+     * The OS identifier used in file system constructs: darwin, linux, windows
+     */
+    private String operatingSystemFoldername;
+
+    
+    // CTORS AND INITIALIZERS
+    
+    public BazelWorkspace(File bazelWorkspaceRootDirectory, OperatingEnvironmentDetectionStrategy osEnvStrategy) {
+        this.bazelWorkspaceRootDirectory = bazelWorkspaceRootDirectory;
+        this.operatingSystem = osEnvStrategy.getOperatingSystemName();
+        this.operatingSystemFoldername = osEnvStrategy.getOperatingSystemDirectoryName(this.operatingSystem);
+    }
+    
+    public void setBazelWorkspaceMetadataStrategy(BazelWorkspaceMetadataStrategy metadataStrategy) {
+        this.metadataStrategy = metadataStrategy;
+    }
+    
+    // GETTERS AND SETTERS    
+    
+
+    public File getBazelWorkspaceRootDirectory() {
+        return this.bazelWorkspaceRootDirectory;
+    }
+
+    public boolean hasBazelWorkspaceRootDirectory() {
+        return this.bazelWorkspaceRootDirectory != null;
+    }
+
+    public File getBazelExecRootDirectory() {
+        if (this.bazelExecRootDirectory == null && metadataStrategy != null) {
+            this.bazelExecRootDirectory = metadataStrategy.getBazelWorkspaceExecRoot();
+        }
+        return this.bazelExecRootDirectory;
+    }
+
+    public File getBazelOutputBaseDirectory() {
+        if (this.bazelOutputBaseDirectory == null && metadataStrategy != null) {
+            this.bazelOutputBaseDirectory = metadataStrategy.getBazelWorkspaceOutputBase();
+        }
+        return this.bazelOutputBaseDirectory;
+    }
+
+    public File getBazelBinDirectory() {
+        if (this.bazelBinDirectory == null && metadataStrategy != null) {
+            this.bazelBinDirectory = metadataStrategy.getBazelWorkspaceBin();
+        }
+        return this.bazelBinDirectory;
+    }
+
+    public String getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    public String getOperatingSystemFoldername() {
+        return operatingSystemFoldername;
+    }
+
+}

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceMetadataStrategy.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceMetadataStrategy.java
@@ -1,0 +1,26 @@
+package com.salesforce.bazel.eclipse.model;
+
+import java.io.File;
+
+/**
+ * Worker interface for a delegate that can retrieve metadata for the BazelWorkspace.
+ * For example, the primary implementation uses 'bazel info' commands.
+ */
+public interface BazelWorkspaceMetadataStrategy {
+
+    /**
+     * Returns the execution root of the current Bazel workspace.
+     */   
+    public File getBazelWorkspaceExecRoot();
+    
+    /**
+     * Returns the output base of the current Bazel workspace.
+     */    
+    public File getBazelWorkspaceOutputBase();
+
+    /**
+     * Returns the bazel-bin of the current Bazel workspace.
+     */
+    public File getBazelWorkspaceBin();
+
+}

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/OperatingEnvironmentDetectionStrategy.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/OperatingEnvironmentDetectionStrategy.java
@@ -1,0 +1,32 @@
+package com.salesforce.bazel.eclipse.model;
+
+/**
+ * Isolates the code that looks up operating environment data so that it can be
+ * mocked for tests.
+ *
+ */
+public interface OperatingEnvironmentDetectionStrategy {
+
+    /**
+     * Returns the operating system running Bazel and our BEF: osx, linux, windows
+     * https://github.com/bazelbuild/bazel/blob/c35746d7f3708acb0d39f3082341de0ff09bd95f/src/main/java/com/google/devtools/build/lib/util/OS.java#L21
+     */
+    String getOperatingSystemName();
+    
+    /**
+     * Returns the OS identifier used in file system constructs: darwin, linux, windows
+     */
+    default String getOperatingSystemDirectoryName(String osName) {
+        String operatingSystemFoldername = null;
+        if (osName.contains("mac")) {
+            operatingSystemFoldername = "darwin";
+        } else if (osName.contains("win")) {
+            operatingSystemFoldername = "windows";
+        } else {
+            // assume linux
+            operatingSystemFoldername = "linux";
+        }
+        return operatingSystemFoldername;
+    }
+    
+}

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/RealOperatingEnvironmentDetectionStrategy.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/RealOperatingEnvironmentDetectionStrategy.java
@@ -1,0 +1,21 @@
+package com.salesforce.bazel.eclipse.model;
+
+/**
+ * Real implementation of OperatingEnvironmentDetectionStrategy to be used when running BEF.
+ * It looks at system properties to determine the operating environment.
+ *
+ */
+public class RealOperatingEnvironmentDetectionStrategy implements OperatingEnvironmentDetectionStrategy {
+
+    @Override
+    public String getOperatingSystemName() {
+        String osName = System.getProperty("blaze.os");
+        if (osName == null) {
+            osName = System.getProperty("os.name", "unknown");
+        }
+        osName = osName.toLowerCase();
+        
+        return osName;
+    }
+
+}


### PR DESCRIPTION
In working on a fix for the implicit dependencies issue #43 I found I wanted a proper model construct for BazelWorkspace. Prior to this PR, we had workspace concepts scattered around.

Lots of files in this PR to redirect consuming code, but overall a pretty simple model object.