### PR TITLE
added command options model for looking up bazelrc flags

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -50,6 +50,7 @@ import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
 import com.salesforce.bazel.eclipse.command.CommandBuilder;
 import com.salesforce.bazel.eclipse.command.shell.ShellCommandBuilder;
 import com.salesforce.bazel.eclipse.config.BazelAspectLocationImpl;
+import com.salesforce.bazel.eclipse.config.BazelEclipseProjectFactory;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.model.OperatingEnvironmentDetectionStrategy;
@@ -169,7 +170,8 @@ public class BazelPluginActivator extends AbstractUIPlugin {
         // Get the bazel workspace path from the settings, defaults to /usr/local/bin/bazel
         String bazelWorkspacePathFromPrefs = prefsStore.getString(BAZEL_WORKSPACE_PATH_PREF_NAME);
         if (bazelWorkspacePathFromPrefs != null && !bazelWorkspacePathFromPrefs.isEmpty()) {
-            this.setBazelWorkspaceRootDirectory(new File(bazelWorkspacePathFromPrefs));
+            String workspaceName = BazelEclipseProjectFactory.getBazelWorkspaceName(bazelWorkspacePathFromPrefs);
+            this.setBazelWorkspaceRootDirectory(workspaceName, new File(bazelWorkspacePathFromPrefs));
         }
 }
     
@@ -220,14 +222,14 @@ public class BazelPluginActivator extends AbstractUIPlugin {
      * Sets the location on disk where the Bazel workspace is located. There must be a WORKSPACE file
      * in this location. Changing this location is a big deal, so use this method only during setup/import.
      */
-    public void setBazelWorkspaceRootDirectory(File rootDirectory) {
+    public void setBazelWorkspaceRootDirectory(String workspaceName, File rootDirectory) {
         File workspaceFile = new File(rootDirectory, "WORKSPACE");
         if (!workspaceFile.exists()) {
             new Throwable().printStackTrace();
             BazelPluginActivator.error("BazelPluginActivator could not set the Bazel workspace directory as there is no WORKSPACE file here: "+rootDirectory.getAbsolutePath());
             return;
         }
-        bazelWorkspace = new BazelWorkspace(rootDirectory, osEnvStrategy);
+        bazelWorkspace = new BazelWorkspace(workspaceName, rootDirectory, osEnvStrategy);
         bazelWorkspace.setBazelWorkspaceMetadataStrategy(getWorkspaceCommandRunner());
 
         // write it to the preferences file

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
@@ -12,6 +12,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
+import com.salesforce.bazel.eclipse.model.BazelWorkspaceCommandOptions;
 
 /**
  * Bazel generally requires BUILD file authors to list all dependencies explicitly.
@@ -48,7 +49,13 @@ public class ImplicitDependencyHelper {
             AspectPackageInfo packageInfo) {
         Set<IClasspathEntry> deps = new HashSet<>();
         
-        // TODO ideally we would only do this if --explicit_java_test_deps=false, but how to compute that?
+        // java_test targets do not have implicit deps if .bazelrc has --explicit_java_test_deps=true
+        BazelWorkspaceCommandOptions commandOptions = bazelWorkspace.getBazelWorkspaceCommandOptions();
+        String explicitDepsOption = commandOptions.getOption("explicit_java_test_deps");
+        if ("true".equals(explicitDepsOption)) {
+            // the workspace is configured to disallow implicit deps (hooray) so we can bail now 
+            return deps;
+        }
         
         // HAMCREST and JUNIT
         // These implicit deps come from the test runner.

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
@@ -124,24 +124,18 @@ public class BazelEclipseProjectFactory {
         subMonitor.setTaskName("Getting the Aspect Information for targets");
         subMonitor.split(1);
 
+        String bazelWorkspaceName = getBazelWorkspaceName(bazelWorkspaceRoot);
+        String eclipseProjectNameForBazelWorkspace = BazelNature.BAZELWORKSPACE_PROJECT_BASENAME+" (" + bazelWorkspaceName + ")";
+
         // Many collaborators need the Bazel workspace directory location, so we stash it in an accessible global location
         // currently we only support one Bazel workspace in an Eclipse workspace
-        BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory(bazelWorkspaceRootDirectory);
+        BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory(bazelWorkspaceName, bazelWorkspaceRootDirectory);
 
         // Set the flag that an import is in progress
         importInProgress.set(true);
 
         // clear out state flag in the Bazel classpath initializer in case there was a previous failed import run
         BazelClasspathContainerInitializer.isCorrupt.set(false);
-
-        String eclipseProjectNameForBazelWorkspace = BazelNature.BAZELWORKSPACE_PROJECT_BASENAME;
-        // TODO pull the workspace name out of the WORKSPACE file, until then use the directory name (e.g. bazel-demo)
-        int lastSlash = bazelWorkspaceRoot.lastIndexOf(File.separator);
-        if (lastSlash >= 0 && (bazelWorkspaceRoot.length() - lastSlash) > 3) {
-            // add the directory name to the label, if it is meaningful (>3 chars)
-            eclipseProjectNameForBazelWorkspace = BazelNature.BAZELWORKSPACE_PROJECT_BASENAME+
-                    " (" + bazelWorkspaceRoot.substring(lastSlash + 1) + ")";
-        }
 
         // TODO send this message to the EclipseConsole so the user actually sees it
         LOG.info("Starting import of [{}]. This may take some time, please be patient.",
@@ -180,6 +174,17 @@ public class BazelEclipseProjectFactory {
         importInProgress.set(false);
 
         return importedProjectsList;
+    }
+    
+    public static String getBazelWorkspaceName(String bazelWorkspaceRootDirectory) {
+        // TODO pull the workspace name out of the WORKSPACE file, until then use the directory name (e.g. bazel-demo)
+        String bazelWorkspaceName = "workspace";
+        int lastSlash = bazelWorkspaceRootDirectory.lastIndexOf(File.separator);
+        if (lastSlash >= 0 && (bazelWorkspaceRootDirectory.length() - lastSlash) > 3) {
+            // add the directory name to the label, if it is meaningful (>3 chars)
+            bazelWorkspaceName = bazelWorkspaceRootDirectory.substring(lastSlash + 1);
+        }
+        return bazelWorkspaceName;
     }
 
     private static void importBazelWorkspacePackagesAsProjects(BazelPackageInfo packageInfo, String bazelWorkspaceRoot,

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/old/WorkspaceWizardPage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/old/WorkspaceWizardPage.java
@@ -170,7 +170,7 @@ public class WorkspaceWizardPage extends WizardPage {
                 if (wr != null) {
                     workspaceRoot.setText(wr);
                     DirectoryTreeContentProvider.setFileTreeRoot(directories, new File(wr));
-                    BazelWorkspace bazelWorkspace = new BazelWorkspace(new File(getWorkspaceRoot()), new RealOperatingEnvironmentDetectionStrategy());
+                    BazelWorkspace bazelWorkspace = new BazelWorkspace(null, new File(getWorkspaceRoot()), new RealOperatingEnvironmentDetectionStrategy());
                     completionProvider.setBazelInstance(BazelPluginActivator.getBazelCommandManager()
                             .getWorkspaceCommandRunner(bazelWorkspace));
                 }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
@@ -67,7 +67,7 @@ public class BazelCommandRunnerFTest {
         MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_PriorToImport_JavaPackages(testTempDir, 5);
         
         // the Bazel commands will run after the bazel root directory is chosen in the UI, so simulate the selection here
-        BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory(mockEclipse.getBazelWorkspaceRoot());
+        BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory("test", mockEclipse.getBazelWorkspaceRoot());
         
         // run the method under test
         BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
@@ -91,7 +91,7 @@ public class TestBazelCommandEnvironmentFactory {
             bazelExecutable.bazelExecutableFile);
         bazelCommandManager.setBazelExecutablePath(bazelExecutable.bazelExecutableFile.getAbsolutePath());
         
-        BazelWorkspace bazelWorkspace = new BazelWorkspace(testWorkspace.dirWorkspaceRoot, Mockito.mock(OperatingEnvironmentDetectionStrategy.class));
+        BazelWorkspace bazelWorkspace = new BazelWorkspace("test", testWorkspace.dirWorkspaceRoot, Mockito.mock(OperatingEnvironmentDetectionStrategy.class));
         this.globalCommandRunner = bazelCommandManager.getGlobalCommandRunner();
         this.bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
     }

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceCommandOptions.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceCommandOptions.java
@@ -1,0 +1,121 @@
+package com.salesforce.bazel.eclipse.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Holds the list of command options defined for the Workspace.
+ * Command options come from .bazelrc file(s) (and additional files imported therein) found
+ * in the standard file system locations.
+ * <p>
+ * https://docs.bazel.build/versions/2.0.0/guide.html#bazelrc
+ * <p>
+ * To see the list of options used for your workspace, run this command:  bazel info --announce_rc
+ */
+public class BazelWorkspaceCommandOptions {
+
+    private BazelWorkspace bazelWorkspace;
+    private Map<String, String> allExplicitOptions = new HashMap<>();
+    private Map<String, Map<String, String>> contextualExplicitOptions = new HashMap<>();
+    
+    public BazelWorkspaceCommandOptions(BazelWorkspace bazelWorkspace) {
+        this.bazelWorkspace = bazelWorkspace;
+    }
+    
+    public String getOption(String optionName) {
+        return allExplicitOptions.get(optionName);
+    }
+
+    public String getContextualOption(String context, String optionName) {
+        Map<String, String> contextualMap = contextualExplicitOptions.get(context);
+        if (contextualMap != null) {
+            return contextualMap.get(optionName);
+        }
+        return null;
+    }
+
+    public String getOptionWithDefault(String optionName) {
+        String optionValue = allExplicitOptions.get(optionName);
+        
+        if (optionValue == null) {
+            // apply the default TODO build the dictionary of default values for options
+        }
+        
+        return optionValue;
+    }
+
+    public String getContextualOptionWithDefault(String context, String optionName) {
+        String optionValue = getContextualOption(context, optionName);
+        
+        if (optionValue == null) {
+            // apply the default TODO build the dictionary of default values for options
+        }
+
+        return optionValue;
+    }
+    
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("BazelWorkspaceCommandOptions: workspace_name:");
+        sb.append(bazelWorkspace.getName());
+        for (String optionName : allExplicitOptions.keySet()) {
+            sb.append(" [");
+            sb.append(optionName);
+            sb.append(":");
+            sb.append(allExplicitOptions.get(optionName));
+            sb.append("]");
+        }
+        
+        return sb.toString();
+    }
+    
+    /**
+     * Method to parse options from a 'bazel test' command run with the --announce_rc option
+     */
+    public void parseOptionsFromOutput(List<String> outputLines) {
+        for (String line : outputLines) {
+            //   Inherited 'common' options: --isatty=1 --terminal_columns=260
+            //   Inherited 'build' options: --javacopt=-source 8 -target 8 --host_javabase=//tools/jdk:my-linux-jdk11 --javabase=//tools/jdk:my-linux-jdk8 --stamp 
+            //      --workspace_status_command tools/buildstamp/get_workspace_status --test_output=errors --verbose_explanations --explain=/tmp/bazel_explain.txt 
+            //      --output_filter=^(?!@) --incompatible_no_support_tools_in_action_inputs=false --incompatible_depset_is_not_iterable=false --incompatible_new_actions_api=false 
+            //      --incompatible_disable_deprecated_attr_params=false --incompatible_depset_union=false
+            int inheritedIndex = line.indexOf("Inherited");
+            if (inheritedIndex == -1) {
+                continue;
+            }
+            int optionsIndex = line.indexOf("options:");
+            if (optionsIndex == -1) {
+                continue;
+            }
+            String optionsContext = line.substring(inheritedIndex+11, optionsIndex-2);
+            
+            String optionsFullString = line.substring(optionsIndex+9);
+            String[] optionsSplitList = optionsFullString.split(" --");
+            for (String option : optionsSplitList) {
+                String[] optionTokens = option.split("=");
+                if (optionTokens.length > 2) {
+                    System.err.println("Did not know how to parse option ["+option+"] from line "+line);
+                    continue;
+                } else if (optionTokens.length == 1) {
+                    // if only the option name is provided, the value is implied to be 'true' (e.g. --stamp is interpreted as --stamp=true)
+                    this.allExplicitOptions.put(optionTokens[0], "true");
+                    getContextualMap(optionsContext).put(optionTokens[0], "true");
+                } else {
+                    this.allExplicitOptions.put(optionTokens[0], optionTokens[1]);
+                    getContextualMap(optionsContext).put(optionTokens[0], optionTokens[1]);
+                }
+            }
+        }
+    }
+    
+    private Map<String, String> getContextualMap(String context) {
+        Map<String, String> contextualMap = this.contextualExplicitOptions.get(context);
+        if (contextualMap == null) {
+            contextualMap = new TreeMap<>();
+            contextualExplicitOptions.put(context, contextualMap);
+        }
+        return contextualMap;
+    }
+}

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceMetadataStrategy.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelWorkspaceMetadataStrategy.java
@@ -11,16 +11,20 @@ public interface BazelWorkspaceMetadataStrategy {
     /**
      * Returns the execution root of the current Bazel workspace.
      */   
-    public File getBazelWorkspaceExecRoot();
+    public File computeBazelWorkspaceExecRoot();
     
     /**
      * Returns the output base of the current Bazel workspace.
      */    
-    public File getBazelWorkspaceOutputBase();
+    public File computeBazelWorkspaceOutputBase();
 
     /**
      * Returns the bazel-bin of the current Bazel workspace.
      */
-    public File getBazelWorkspaceBin();
+    public File computeBazelWorkspaceBin();
 
+    /**
+     * Returns the explicitly set option in the workspace config files (.bazelrc et al)
+     */
+    public void populateBazelWorkspaceCommandOptions(BazelWorkspaceCommandOptions commandOptions);
 }


### PR DESCRIPTION
One last feature for the implicit deps. If build option --explicit_java_test_deps=true is set, we do not add the implicit test deps.