### PR TITLE
test support for implicit/explicit java test deps

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -144,7 +144,10 @@ public class BazelPluginActivator extends AbstractUIPlugin {
      */
     public void startInternal(BazelAspectLocation aspectLocation, CommandBuilder commandBuilder, CommandConsoleFactory consoleFactory, 
             ResourceHelper rh, JavaCoreHelper javac, OperatingEnvironmentDetectionStrategy osEnv) throws Exception {
-
+        // reset internal state (this is so tests run in a clean env)
+        bazelWorkspace = null;
+        bazelWorkspaceCommandRunner = null;
+        
         // global collaborators
         resourceHelper = rh;
         plugin = this;

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
@@ -28,7 +28,7 @@ import com.salesforce.bazel.eclipse.model.BazelWorkspaceCommandOptions;
  * considerations for this class.
  * <p>
  * This code is isolated from the classpath container code because this is somewhat of a
- * hack and it is nice to have it isolated.
+ * hack and it is nice to have it isolated. 
  */
 public class ImplicitDependencyHelper {
 
@@ -76,6 +76,8 @@ public class ImplicitDependencyHelper {
     String computeFilePathForRunnerJar(BazelWorkspace bazelWorkspace, AspectPackageInfo packageInfo) {
         // The IJ plugin gets this path somehow from query/aspect but we are going to wedge it in via path here since we need to
         // overhaul our query/aspect in the near future TODO stop using file system hacking for implicit deps
+        // Because of the way we are doing this, there is no aspect json file written on disk that we can consume.
+        // Just write the path to the file directly.
 
         File bazelBinDir = bazelWorkspace.getBazelBinDirectory();
         File testRunnerDir = new File(bazelBinDir, "external/bazel_tools/tools/jdk/_ijar/TestRunner");

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
@@ -64,7 +64,8 @@ public class BazelCommandRunnerFTest {
         File testTempDir = tmpFolder.newFolder();
 
         // create the mock Eclipse runtime in the correct state
-        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_PriorToImport_JavaPackages(testTempDir, 5);
+        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_PriorToImport_JavaPackages(
+            testTempDir, 5, false);
         
         // the Bazel commands will run after the bazel root directory is chosen in the UI, so simulate the selection here
         BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory("test", mockEclipse.getBazelWorkspaceRoot());

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
@@ -66,7 +66,8 @@ public class BazelEclipseProjectFactoryFTest {
         // create the mock Eclipse runtime in the correct state, which is two java projects javalib0 and javalib1
         int numberOfJavaPackages = 2;
         boolean computeClasspaths = true;
-        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(testTempDir, numberOfJavaPackages, computeClasspaths);
+        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(
+            testTempDir, numberOfJavaPackages, computeClasspaths, false);
         workspace_IProject = mockEclipse.getImportedProject("Bazel Workspace ("+MockEclipse.BAZEL_WORKSPACE_NAME+")");
         javalib0_IProject = mockEclipse.getImportedProject("javalib0");
         javalib1_IProject = mockEclipse.getImportedProject("javalib1");

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
@@ -145,7 +145,8 @@ public class BazelLaunchConfigurationDelegateFTest {
         // create the mock Eclipse runtime in the correct state
         int numberOfJavaPackages = 2;
         boolean computeClasspaths = true; 
-        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(testTempDir, numberOfJavaPackages, computeClasspaths);
+        MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(
+            testTempDir, numberOfJavaPackages, computeClasspaths, false);
         
         return mockEclipse;
     }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockEclipse.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockEclipse.java
@@ -104,17 +104,17 @@ public class MockEclipse {
      */
     public MockEclipse(TestBazelWorkspaceFactory bazelWorkspace, File testTempDir) throws Exception {
         this.bazelCommandEnvironment = new TestBazelCommandEnvironmentFactory();
-        this.bazelCommandEnvironment.createTestEnvironment(bazelWorkspace, testTempDir);
+        this.bazelCommandEnvironment.createTestEnvironment(bazelWorkspace, testTempDir, bazelWorkspace.commandOptions);
         
         setup(bazelWorkspace, testTempDir);
     }
     
-    private void setup(TestBazelWorkspaceFactory bazelWorkspace, File testTempDir) throws Exception {
-        this.bazelWorkspaceFactory = bazelWorkspace;
-        this.bazelWorkspaceRoot = bazelWorkspace.dirWorkspaceRoot;
-        this.bazelOutputBase = bazelWorkspace.dirOutputBase;
-        this.bazelExecutionRoot = bazelWorkspace.dirExecRoot;
-        this.bazelBin = bazelWorkspace.dirBazelBin;
+    private void setup(TestBazelWorkspaceFactory bazelWorkspaceFactory, File testTempDir) throws Exception {
+        this.bazelWorkspaceFactory = bazelWorkspaceFactory;
+        this.bazelWorkspaceRoot = bazelWorkspaceFactory.dirWorkspaceRoot;
+        this.bazelOutputBase = bazelWorkspaceFactory.dirOutputBase;
+        this.bazelExecutionRoot = bazelWorkspaceFactory.dirExecRoot;
+        this.bazelBin = bazelWorkspaceFactory.dirBazelBin;
 
         this.eclipseWorkspaceRoot = new File(testTempDir, "eclipse-workspace");
         this.eclipseWorkspaceRoot.mkdir();

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
@@ -193,7 +193,7 @@ public class BazelLauncherBuilderTest {
         outputbaseDir.mkdirs();
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(workspaceDir, outputbaseDir).javaPackages(3).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir);
+        env.createTestEnvironment(workspace, testDir, null);
         
         return env;
     }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunnerTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunnerTest.java
@@ -65,7 +65,7 @@ public class BazelWorkspaceCommandRunnerTest {
         outputbaseDir.mkdirs();
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(workspaceDir, outputbaseDir).javaPackages(3).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir);
+        env.createTestEnvironment(workspace, testDir, null);
 
         // verify that the command runner has the Bazel exec path
         assertEquals(env.bazelExecutable.getAbsolutePath(), BazelWorkspaceCommandRunner.getBazelExecutablePath());
@@ -77,8 +77,8 @@ public class BazelWorkspaceCommandRunnerTest {
         targets.add("//projects/libs/javalib0:*");
         Map<String, AspectPackageInfo> aspectMap = workspaceRunner.getAspectPackageInfos("javalib0", targets, new MockWorkProgressMonitor(),
             "testWorkspaceRunner");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
         
         // run a clean, should not throw an exception
         workspaceRunner.runBazelClean(new MockWorkProgressMonitor());

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutorTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutorTest.java
@@ -113,7 +113,7 @@ public class BazelCommandExecutorTest {
         outputbaseDir.mkdirs();
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(workspaceDir, outputbaseDir).javaPackages(1).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir);
+        env.createTestEnvironment(workspace, testDir, null);
         
         return env;
     }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelperTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelperTest.java
@@ -59,17 +59,17 @@ public class BazelWorkspaceAspectHelperTest {
         targets.add("//projects/libs/javalib0:*");
         Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
         
         // now check that the caches are populated
-        assertEquals(6, aspectHelper.aspectInfoCache_current.size());
-        assertEquals(6, aspectHelper.aspectInfoCache_lastgood.size());
+        assertEquals(4, aspectHelper.aspectInfoCache_current.size());
+        assertEquals(4, aspectHelper.aspectInfoCache_lastgood.size());
         
         // the purpose of the wildcard cache is to map wildcard targets (e.g. //projects/libs/javalib0:*)
         // to the list of actual targets (//projects/libs/javalib0:javalib0, //projects/libs/javalib0:javalib0-test)
         assertEquals(1, aspectHelper.aspectInfoCache_wildcards.size());
-        assertEquals(6, aspectHelper.aspectInfoCache_wildcards.get("//projects/libs/javalib0:*").size());
+        assertEquals(4, aspectHelper.aspectInfoCache_wildcards.get("//projects/libs/javalib0:*").size());
     }
 
     @Test
@@ -82,16 +82,16 @@ public class BazelWorkspaceAspectHelperTest {
         targets.add("//projects/libs/javalib0:*");
         Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
         assertEquals(0, aspectHelper.numberCacheHits);
         
         // ask for the same target again
         aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
-        assertEquals(6, aspectHelper.numberCacheHits); // the entries all came from cache
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
+        assertEquals(4, aspectHelper.numberCacheHits); // the entries all came from cache
     }
     
     @Test
@@ -104,29 +104,29 @@ public class BazelWorkspaceAspectHelperTest {
         targets.add("//projects/libs/javalib0:*");
         Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
         assertEquals(0, aspectHelper.numberCacheHits);
         
         // ask for the same target again
         aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
-        assertEquals(6, aspectHelper.numberCacheHits); // the entries all came from cache
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
+        assertEquals(4, aspectHelper.numberCacheHits); // the entries all came from cache
 
         // flush the cache (we do this when the user executes a 'clean' in Eclipse
         aspectHelper.flushAspectInfoCache();
         assertEquals(0, aspectHelper.aspectInfoCache_current.size());
         assertEquals(0, aspectHelper.aspectInfoCache_wildcards.size());
-        assertEquals(6, aspectHelper.aspectInfoCache_lastgood.size()); // last good is an emergency fallback, not flushed
+        assertEquals(4, aspectHelper.aspectInfoCache_lastgood.size()); // last good is an emergency fallback, not flushed
         
         // ask for the same target again
         aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
-        assertEquals(6, aspectMap.size());
-        assertEquals(6, aspectHelper.numberCacheHits); // the entries all came from cache
+        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        assertEquals(4, aspectMap.size());
+        assertEquals(4, aspectHelper.numberCacheHits); // the entries all came from cache
     }
     
     
@@ -140,7 +140,7 @@ public class BazelWorkspaceAspectHelperTest {
         outputbaseDir.mkdirs();
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(workspaceDir, outputbaseDir).javaPackages(1).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir);
+        env.createTestEnvironment(workspace, testDir, null);
         
         return env;
     }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/TestBazelCommandEnvironmentFactory.java
@@ -24,6 +24,7 @@
 package com.salesforce.bazel.eclipse.command.mock;
 
 import java.io.File;
+import java.util.Map;
 
 import org.mockito.Mockito;
 
@@ -64,14 +65,14 @@ public class TestBazelCommandEnvironmentFactory {
         
         TestBazelWorkspaceFactory testWorkspace = new TestBazelWorkspaceFactory(workspaceDir, outputBase, "bazel_command_executor_test");
         testWorkspace.build();
-        createTestEnvironment(testWorkspace, tempDir);
+        createTestEnvironment(testWorkspace, tempDir, null);
     }
     
     /**
      * Creates a testing environment based on a test workspace passed in from the caller. If you are testing
      * commands in the context of actual Bazel packages (e.g. Java) this is the form to use.
      */
-    public void createTestEnvironment(TestBazelWorkspaceFactory testWorkspace, File tempDir) {
+    public void createTestEnvironment(TestBazelWorkspaceFactory testWorkspace, File tempDir, Map<String, String> commandOptions) {
         this.testWorkspace = testWorkspace;
         
         File execDir = new File(tempDir, "executable");
@@ -82,7 +83,7 @@ public class TestBazelCommandEnvironmentFactory {
         this.commandConsole = new MockCommandConsole();
 
         this.commandBuilder = new MockCommandBuilder(commandConsole, testWorkspace.dirWorkspaceRoot, testWorkspace.dirOutputBase, 
-            testWorkspace.dirExecRoot, testWorkspace.dirBazelBin);
+            testWorkspace.dirExecRoot, testWorkspace.dirBazelBin, commandOptions);
         // when the workspace factory built out the Bazel workspace file system, it wrote a collection of aspect json files
         // we need to tell the MockCommandBuilder where they are, since it will need to return them in command results
         this.commandBuilder.addAspectJsonFileResponses(this.testWorkspace.aspectFileSets);
@@ -92,6 +93,8 @@ public class TestBazelCommandEnvironmentFactory {
         bazelCommandManager.setBazelExecutablePath(bazelExecutable.bazelExecutableFile.getAbsolutePath());
         
         BazelWorkspace bazelWorkspace = new BazelWorkspace("test", testWorkspace.dirWorkspaceRoot, Mockito.mock(OperatingEnvironmentDetectionStrategy.class));
+        bazelWorkspace.setBazelWorkspaceMetadataStrategy(bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace));
+        
         this.globalCommandRunner = bazelCommandManager.getGlobalCommandRunner();
         this.bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
     }

--- a/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestJavaRuleCreator.java
+++ b/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestJavaRuleCreator.java
@@ -3,13 +3,15 @@ package com.salesforce.bazel.eclipse.test;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 
 public class TestJavaRuleCreator {
-    public static void createJavaBuildFile(File buildFile, String projectName, int projectIndex) throws Exception {
+    public static void createJavaBuildFile(Map<String, String> commandOptions, File buildFile, String projectName, int projectIndex) 
+            throws Exception {
         try (PrintStream out = new PrintStream(new FileOutputStream(buildFile))) {
             
             String build_java_library =  createJavaLibraryRule(projectName);
-            String build_java_test = createJavaTestRule(projectName);
+            String build_java_test = createJavaTestRule(projectName, commandOptions);
                         
             out.print(build_java_library+"\n\n"+build_java_test);
         } 
@@ -39,13 +41,19 @@ public class TestJavaRuleCreator {
         return sb.toString();
     }
     
-    private static String createJavaTestRule(String projectName) {
+    private static String createJavaTestRule(String projectName, Map<String, String> commandOptions) {
+        boolean explicitJavaTestDeps = "true".equals(commandOptions.get("explicit_java_test_deps"));
+        
         StringBuffer sb = new StringBuffer();
         sb.append("java_test(\n   name=\"");
         sb.append(projectName);
         sb.append("Test\",\n");
-        sb.append("   srcs = glob([\"src/main/java/**/*.java\"]),\n");
-        sb.append("   visibility = [\"//visibility:public\"],");
+        sb.append("   srcs = glob([\"src/test/java/**/*.java\"]),\n");
+        sb.append("   visibility = [\"//visibility:public\"],\n");
+        if (explicitJavaTestDeps) {
+            // see ImplicitDependencyHelper.java for more details about this block
+            sb.append("   deps = [ \"@junit_junit//jar\", \"@org_hamcrest_hamcrest_core//jar\", \"@ch_qos_logback_logback_core//jar\", ],\n");
+        }
         sb.append(")");
         return sb.toString();
     }


### PR DESCRIPTION
Finishing adding test support for the Issue #43 implicit test dependency feature. Adding in command option (--explicit_java_test_deps=true) support to the test framework uncovered a few existing bugs in the test framework.