### PR TITLE
pin org.json imported version, set BEF version to 1.0.3 for release

### DIFF
--- a/feature/feature.xml
+++ b/feature/feature.xml
@@ -6,7 +6,7 @@
 <feature
       id="com.salesforce.bazel.eclipse.feature"
       label="Bazel Eclipse Feature"
-      version="1.1.0.qualifier"
+      version="1.0.3.qualifier"
       provider-name="Salesforce"
       >
 

--- a/plugin-core/META-INF/MANIFEST.MF
+++ b/plugin-core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Core Plugin
 Automatic-Module-Name: com.salesforce.bazel.eclipse.core
 Bundle-SymbolicName: com.salesforce.bazel.eclipse.core;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: com.salesforce.bazel.eclipse.BazelPluginActivator
 Bundle-Vendor: Salesforce
 Require-Bundle: org.eclipse.ui.console;bundle-version="3.8.100.v20180821-1744",
@@ -31,11 +31,11 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: bin/,
  .
-Import-Package: com.salesforce.bazel.eclipse.abstractions;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.command;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.logging;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.model;version="1.1.0.qualifier",
+Import-Package: com.salesforce.bazel.eclipse.abstractions;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.command;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.logging;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.model;version="1.0.3.qualifier",
  com.google.common.base;version="21.0",
  com.google.common.collect;version="21.0"
-Export-Package: com.salesforce.bazel.eclipse;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.launch;version="1.1.0.qualifier"
+Export-Package: com.salesforce.bazel.eclipse;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.launch;version="1.0.3.qualifier"

--- a/plugin-libs/plugin-abstractions/META-INF/MANIFEST.MF
+++ b/plugin-libs/plugin-abstractions/META-INF/MANIFEST.MF
@@ -3,9 +3,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Abstractions Plugin
 Bundle-SymbolicName: com.salesforce.bazel.eclipse.abstractions;singleton:=true
 Automatic-Module-Name: com.salesforce.bazel.eclipse.abstractions
-Bundle-Version: 1.1.0.qualifier
-Export-Package: com.salesforce.bazel.eclipse.abstractions;version="1.1.0.qualifier"
-Import-Package: com.salesforce.bazel.eclipse.model;version="1.1.0.qualifier"
+Bundle-Version: 1.0.3.qualifier
+Export-Package: com.salesforce.bazel.eclipse.abstractions;version="1.0.3.qualifier"
+Import-Package: com.salesforce.bazel.eclipse.model;version="1.0.3.qualifier"
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/plugin-libs/plugin-command/META-INF/MANIFEST.MF
+++ b/plugin-libs/plugin-command/META-INF/MANIFEST.MF
@@ -3,15 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Command Plugin
 Bundle-SymbolicName: com.salesforce.bazel.eclipse.command;singleton:=true
 Automatic-Module-Name: com.salesforce.bazel.eclipse.command
-Bundle-Version: 1.1.0.qualifier
-Export-Package: com.salesforce.bazel.eclipse.command;version="1.1.0.qualifier",
+Bundle-Version: 1.0.3.qualifier
+Export-Package: com.salesforce.bazel.eclipse.command;version="1.0.3.qualifier",
  com.salesforce.bazel.eclipse.command.mock,
  com.salesforce.bazel.eclipse.command.shell
-Import-Package: com.google.common.base,
- com.google.common.collect,
- com.salesforce.bazel.eclipse.abstractions;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.logging;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.model;version="1.1.0.qualifier"
+Import-Package: com.google.common.base;version="21.0",
+ com.google.common.collect;version="21.0",
+ com.salesforce.bazel.eclipse.abstractions;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.logging;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.model;version="1.0.3.qualifier"
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/plugin-libs/plugin-deps/META-INF/MANIFEST.MF
+++ b/plugin-libs/plugin-deps/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Dev Deps Plugin
 Automatic-Module-Name: com.salesforce.bazel.eclipse.deps
 Bundle-SymbolicName: com.salesforce.bazel.eclipse.deps;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/plugin-libs/plugin-model/META-INF/MANIFEST.MF
+++ b/plugin-libs/plugin-model/META-INF/MANIFEST.MF
@@ -3,13 +3,13 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Model Plugin
 Bundle-SymbolicName: com.salesforce.bazel.eclipse.model;singleton:=true
 Automatic-Module-Name: com.salesforce.bazel.eclipse.model
-Bundle-Version: 1.1.0.qualifier
-Export-Package:  com.salesforce.bazel.eclipse.model;version="1.1.0.qualifier",
- com.salesforce.bazel.eclipse.logging;version="1.1.0.qualifier"
-Import-Package: com.google.common.base,
- com.google.common.collect,
- com.salesforce.bazel.eclipse.logging,
- org.json
+Bundle-Version: 1.0.3.qualifier
+Export-Package:  com.salesforce.bazel.eclipse.model;version="1.0.3.qualifier",
+ com.salesforce.bazel.eclipse.logging;version="1.0.3.qualifier"
+Import-Package: com.google.common.base;version="21.0",
+ com.google.common.collect;version="21.0",
+ com.salesforce.bazel.eclipse.logging;version="1.0.3.qualifier",
+ org.json;version="20160212"
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/tools/feature_version_def.bzl
+++ b/tools/feature_version_def.bzl
@@ -1,3 +1,3 @@
 # This file is both a shell script and a skylark file used by the
 # currently unused Bazel Eclipse packaging rules (//tools/eclipse_updatesite)
-VERSION="1.1.0.qualifier"
+VERSION="1.0.3.qualifier"


### PR DESCRIPTION
Fixes #54 

We had let several open source package versions float in a few places, including org.json (the reported issue) as well as some google packages. This PR pins those versions to the versions provided by our deps plugin.