### PR TITLE
classpath support for protobuf-java and grpc-java

### DIFF
--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
@@ -177,18 +177,18 @@ public class BazelWorkspaceAspectHelper {
         
         AspectPackageInfo aspectInfo = aspectInfoCache_current.get(target);
         if (aspectInfo != null) {
-            LOG.info("ASPECT CACHE HIT target: {}", target + logstr);
+            LOG.info("ASPECT CACHE HIT target: " + target + logstr);
             resultMap.put(target, aspectInfo);
             this.numberCacheHits++;
         } else {
-            LOG.info("ASPECT CACHE MISS target: {}", target + logstr);
+            LOG.info("ASPECT CACHE MISS target: " + target + logstr);
             List<String> lookupTargets = new ArrayList<>();
             lookupTargets.add(target);
             List<String> discoveredAspectFilePaths = generateAspectPackageInfoFiles(lookupTargets, progressMonitor);
             ImmutableMap<String, AspectPackageInfo> map = AspectPackageInfo.loadAspectFilePaths(discoveredAspectFilePaths);
             resultMap.putAll(map);
             for (String resultTarget : map.keySet()) {
-                LOG.info("ASPECT CACHE LOAD target: {}", resultTarget + logstr);
+                LOG.info("ASPECT CACHE LOAD target: " + resultTarget + logstr);
                 aspectInfoCache_current.put(resultTarget, map.get(resultTarget));
                 aspectInfoCache_lastgood.put(resultTarget, map.get(resultTarget));
             }
@@ -202,7 +202,7 @@ public class BazelWorkspaceAspectHelper {
                 if (aspectInfo != null) {
                     resultMap.put(target, aspectInfo);
                 } else {
-                    LOG.info("ASPECT CACHE FAIL target: {}", target + logstr);
+                    LOG.info("ASPECT CACHE FAIL target: " + target + logstr);
                 }
             }
         }

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfo.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfo.java
@@ -57,15 +57,20 @@ import com.google.common.collect.ImmutableMap;
  * The JSON document format is like this:
  *
  * <pre>
- &#64;org_slf4j_slf4j_api//jar:jar=AspectPackageInfo(
-  label = @org_slf4j_slf4j_api//jar:jar,
-  location = external/org_slf4j_slf4j_api/jar/BUILD.bazel,
-  kind = java_import,
-  jars = [Jars(jar = external/org_slf4j_slf4j_api/jar/slf4j-api-1.7.25.jar, ijar = bazel-out/darwin-fastbuild/genfiles/external/org_slf4j_slf4j_api/jar/_ijar/jar/external/org_slf4j_slf4j_api/jar/slf4j-api-1.7.25-ijar.jar)],
-  generatedJars = [],
-  deps = [],
-  sources = []
- )
+ {
+   "build_file_artifact_location":"helloworld/BUILD",
+   "dependencies":["//proto:helloworld_java_proto"],
+   "generated_jars":[],
+   "jars":[
+     {"interface_jar":"bazel-out/darwin-fastbuild/bin/helloworld/libhelloworld-hjar.jar",
+      "jar":"bazel-out/darwin-fastbuild/bin/helloworld/libhelloworld.jar",
+      "source_jar":"bazel-out/darwin-fastbuild/bin/helloworld/libhelloworld-src.jar"
+     }
+    ],
+    "kind":"java_library",
+    "label":"//helloworld:helloworld",
+    "sources":["helloworld/src/main/java/helloworld/HelloWorld.java"]
+ }
  * </pre>
  * <p>
  * See resources/bzleclipse_aspect.bzl for the code that creates the JSON files


### PR DESCRIPTION
This PR enables BEF to detect and add the output jars from **java_proto_library** and **java_grpc_library** rules to the classpath of consuming Eclipse projects. In other words, with this support Eclipse JDT will no longer put red squigglies on proto/grpc-java generated classes at point of usage in Java files.