### PR TITLE
basic support for importing packages with proto rules

### DIFF
--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelper.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFileHelper.java
@@ -53,11 +53,10 @@ public class BazelBuildFileHelper {
      * The line must begin with one of these tokens (leading whitespace is ignored). This prevents false positives when
      * comments include one of these tokens. Also, this means that just loading a Java rule in a load() statement is not
      * enough to trigger the detector.
-     * <p>
-     * If you change the contents of this list, please also update TestBazelWorkspaceCreator.java.
      */
     public static final String[] JAVA_PROJECT_INDICATORS =
-            { "java_binary", "java_library", "java_test", "java_web_test_suite", "springboot", "springboot_test" };
+            { "java_binary", "java_library", "java_test", "java_web_test_suite", "springboot", "springboot_test", 
+                    "java_proto_library", "java_lite_proto_library", "java_grpc_library" };
 
     /**
      * Parses a File, presumed to be a Bazel BUILD file, looking for indications that it contains Java rules.

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/TargetKind.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/TargetKind.java
@@ -89,6 +89,46 @@ public enum TargetKind {
         public boolean isTestable() {
             return true;
         }
+    },
+    
+    JAVA_PROTO_LIBRARY("java_proto_library") {
+
+        @Override
+        public boolean isRunnable() {
+            return false;
+        }
+
+        @Override
+        public boolean isTestable() {
+            return false;
+        }
+    },
+    
+    JAVA_LITE_PROTO_LIBRARY("java_lite_proto_library") {
+
+        @Override
+        public boolean isRunnable() {
+            return false;
+        }
+
+        @Override
+        public boolean isTestable() {
+            return false;
+        }
+    },
+    
+    
+    JAVA_GRPC_LIBRARY("java_grpc_library") {
+
+        @Override
+        public boolean isRunnable() {
+            return false;
+        }
+
+        @Override
+        public boolean isTestable() {
+            return false;
+        }
     };
     
     private final String targetKind;


### PR DESCRIPTION
Adds recognition that BUILD files with proto/grpc-java rules are interesting, and allows the user to import such packages as Eclipse projects. In some cases will display the .proto files in Project Expolorer.

Since convention (at least internally at SFDC) is to splat the .proto file in the same dir as the the BUILD file, the BEF technically hasn't supported that (only src/main/java for source). I made a minimal effort to enable that in this PR, but only partially addressed it. I defer to Issue #8 when we can fully support source files in flexible locations (inc .proto).

Also, this ticket does not add a Project Reference from the consuming project to the project that generates the proto_java_library. I will add a low priority follow up ticket for actually using Eclipse/BEF for iterating on protobuf files.