### PR TITLE
Replace BazelPackageInfo usage with new Interface during import

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
@@ -65,6 +65,7 @@ import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectFactory;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelPackageInfo;
+import com.salesforce.bazel.eclipse.model.BazelPackageLocation;
 import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
 import com.salesforce.bazel.eclipse.util.SelectionUtil;
 
@@ -129,7 +130,7 @@ public class BazelImportWizard extends Wizard implements IImportWizard {
         BazelPackageInfo workspaceRootProject = page.workspaceRootPackage;
 
         Object[] selectedBazelPackages = page.projectTree.projectTreeViewer.getCheckedElements();
-        List<BazelPackageInfo> bazelPackagesToImport =
+        List<BazelPackageLocation> bazelPackagesToImport =
                 Arrays.asList(selectedBazelPackages).stream().filter(bpi -> bpi != workspaceRootProject)
                         .map(bpi -> (BazelPackageInfo) bpi).collect(Collectors.toList());
 

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
@@ -36,6 +36,7 @@ import org.eclipse.core.resources.IProject;
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectFactory;
 import com.salesforce.bazel.eclipse.importer.BazelProjectImportScanner;
 import com.salesforce.bazel.eclipse.model.BazelPackageInfo;
+import com.salesforce.bazel.eclipse.model.BazelPackageLocation;
 import com.salesforce.bazel.eclipse.runtime.api.JavaCoreHelper;
 import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
 import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
@@ -100,7 +101,7 @@ public class EclipseFunctionalTestEnvironmentFactory {
         BazelPackageInfo workspaceRootProject = scanner.getProjects(mockEclipse.getBazelWorkspaceRoot());
         
         // choose the list of Bazel packages to import, in this case we assume the user selected all Java packages
-        List<BazelPackageInfo> bazelPackagesToImport = new ArrayList<>();
+        List<BazelPackageLocation> bazelPackagesToImport = new ArrayList<>();
         bazelPackagesToImport.add(workspaceRootProject);
         addBazelPackageInfosToSelectedList(workspaceRootProject, bazelPackagesToImport);
                 
@@ -119,7 +120,7 @@ public class EclipseFunctionalTestEnvironmentFactory {
         return mockEclipse;
     }
     
-    private static void addBazelPackageInfosToSelectedList(BazelPackageInfo currentNode, List<BazelPackageInfo> bazelPackagesToImport) {
+    private static void addBazelPackageInfosToSelectedList(BazelPackageInfo currentNode, List<BazelPackageLocation> bazelPackagesToImport) {
         Collection<BazelPackageInfo> children = currentNode.getChildPackageInfos();
         for (BazelPackageInfo child : children) {
             // eventually this method should accept filter criteria, but for now we are just importing all packages

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java
@@ -50,7 +50,7 @@ public class BazelLabel {
     private final String label;
 
     /**
-     * A BazelLabel instance can be created with any syntacticly valid Bazel Label String.
+     * A BazelLabel instance can be created with any syntactically valid Bazel Label String.
      * </p>
      * Examples:<br>
      * //foo/blah:t1<br>

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelPackageInfo.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelPackageInfo.java
@@ -56,7 +56,7 @@ import java.util.Map;
  * 
  * @author plaird
  */
-public class BazelPackageInfo {
+public class BazelPackageInfo implements BazelPackageLocation {
 
     private final String relativeWorkspacePath;
     private final File directory;
@@ -192,6 +192,7 @@ public class BazelPackageInfo {
      * 
      * @return true if the root, false otherwise
      */
+    @Override
     public boolean isWorkspaceRoot() {
         return this.isWorkspaceRoot;
     }
@@ -201,6 +202,7 @@ public class BazelPackageInfo {
      * 
      * @return the root directory
      */
+    @Override
     public File getWorkspaceRootDirectory() {
         // now is a good time to check that the root directory is still there
         if (!this.workspaceRoot.exists()) {
@@ -251,6 +253,7 @@ public class BazelPackageInfo {
      * 
      * e.g. "projects/libs/apple" or "projects\libs\apple"
      */
+    @Override
     public String getBazelPackageFSRelativePath() {
         return relativeWorkspacePath;
     }
@@ -324,6 +327,7 @@ public class BazelPackageInfo {
      * <p>
      * e.g. if "//projects/libs/apple" is the package name, will return 'apple'
      */
+    @Override
     public String getBazelPackageNameLastSegment() {
         if (computedPackageNameLastSegment != null) {
             return computedPackageNameLastSegment;

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelPackageLocation.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelPackageLocation.java
@@ -1,0 +1,43 @@
+package com.salesforce.bazel.eclipse.model;
+
+import java.io.File;
+
+/**
+ * Minimal representation of a Bazel Package location on the file system.
+ * 
+ * @see BazelLabel for a container that is also Bazel Target aware. 
+ * @author stoens
+ * @since March 2020
+ */
+public interface BazelPackageLocation {
+    
+    /**
+     * Returns the name of this Bazel Package - this is name of the final directory in the path.
+     * 
+     * For example, if this Bazel Package is at the abs path ~/projects/bazel-workspace/a/b/c,
+     * this method returns "c". 
+     */
+    String getBazelPackageNameLastSegment();
+    
+    /**
+     * Returns the path of this Bazel Package, relative to the WORKSPACE root directory.
+     * 
+     * For example, if this Bazel Package is at the abs path ~/projects/bazel-workspace/a/b/c, 
+     * this method returns a/b/c.
+     */
+    String getBazelPackageFSRelativePath();
+    
+    /**
+     * Returns the abs path of the directory containing the WORKSPACE file for this Bazel Package.
+     * 
+     * For example, if this Bazel Package is at the abs path ~/projects/bazel-workspace/a/b/c,
+     * this method return ~/projects/bazel-workspace.
+
+     */
+    File getWorkspaceRootDirectory();
+    
+    /**
+     * True if this is the root Bazel Package that contains the WORKSPACE file.  
+     */
+    boolean isWorkspaceRoot();
+}


### PR DESCRIPTION
This is to allow different import code paths - the one based on projectview
file changes won't construct BazelPackageInfo instances.