### PR TITLE
Fix for issue #76: Can change bazel runtime as long as file exists

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -254,6 +254,9 @@ public class BazelPluginActivator extends AbstractUIPlugin {
      */
     public BazelWorkspaceCommandRunner getWorkspaceCommandRunner() {
         if (bazelWorkspaceCommandRunner == null) {
+            if (bazelWorkspace == null) {
+                return null;
+            }
             if (bazelWorkspace.hasBazelWorkspaceRootDirectory()) {
                 bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
             }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferencePage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferencePage.java
@@ -35,6 +35,8 @@
  */
 package com.salesforce.bazel.eclipse.preferences;
 
+import java.io.File;
+
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.swt.widgets.Composite;
@@ -42,7 +44,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
-import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
+import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
 
 /**
  * Page to configure the Bazel Eclipse plugin. The only configuration parameter is the path to the Bazel binary so this
@@ -63,9 +65,15 @@ public class BazelPreferencePage extends FieldEditorPreferencePage implements IW
         @Override
         protected boolean doCheckState() {
             try {
-                BazelPluginActivator.getInstance().getWorkspaceCommandRunner().runBazelVersionCheck();
+                BazelPluginActivator activator = BazelPluginActivator.getInstance();
+                BazelWorkspaceCommandRunner runner = activator.getWorkspaceCommandRunner();
+                if (runner == null) {
+                    String bazelPath = getStringValue();
+                    return new File(bazelPath).exists();
+                }
+                runner.runBazelVersionCheck();
                 return true;
-            } catch (BazelCommandLineToolConfigurationException e) {
+            } catch (Exception e) {
                 setErrorMessage(e.getMessage());
                 return false;
             }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockIJavaProject.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockIJavaProject.java
@@ -544,4 +544,10 @@ public class MockIJavaProject implements IJavaProject {
         throw new UnsupportedOperationException(UOE_MSG);
     }
 
+
+	@Override
+	public IModuleDescription getOwnModuleDescription() throws JavaModelException {
+		throw new UnsupportedOperationException(UOE_MSG);
+	}
+
 }

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelProcessBuilder.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelProcessBuilder.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 /**
  * A lightweight wrapper around java.lang.ProcessBuilder. To make functional testing
- * possible where ProcessBuilder shoudl be mocked (it is a final class) we created this thin
+ * possible where ProcessBuilder should be mocked (it is a final class) we created this thin
  * wrapper around it exposing the methods that we use. This class gets mocked during 
  * some test executions.
  */


### PR DESCRIPTION
Simple change to enable bazel runtime to be changed. There's still an issue with path - java runtime is only pulling certain directories and I believe it's just the basic ones on bootup. Will continue digging.