### PR TITLE
allow additive import of more Bazel packages to existing Eclipse workspace

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
@@ -121,9 +121,12 @@ public class BazelImportWizard extends Wizard implements IImportWizard {
         BazelPackageInfo workspaceRootProject = page.workspaceRootPackage;
 
         Object[] selectedBazelPackages = page.projectTree.projectTreeViewer.getCheckedElements();
+        List<Object> grayedBazelPackages = Arrays.asList(page.projectTree.projectTreeViewer.getGrayedElements());
+
         List<BazelPackageLocation> bazelPackagesToImport =
-                Arrays.asList(selectedBazelPackages).stream().filter(bpi -> bpi != workspaceRootProject)
-                        .map(bpi -> (BazelPackageInfo) bpi).collect(Collectors.toList());
+                Arrays.asList(selectedBazelPackages).stream().filter(bpi -> bpi != workspaceRootProject).
+                        filter(bpi -> !grayedBazelPackages.contains(bpi)).
+                        map(bpi -> (BazelPackageInfo) bpi).collect(Collectors.toList());
 
         BazelProjectImporter.run(workspaceRootProject, bazelPackagesToImport);
 

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java
@@ -111,6 +111,33 @@ public class BazelLabel {
     }
 
     /**
+     * Returns the package path of this label, which is the "path part" of the label, excluding any specific target or
+     * target wildcard pattern.
+     * 
+     * For example, given a label //foo/blah/goo:t1, the package path is foo/blah/goo.
+     * 
+     * @param includePrefix if true, will prepend the path with "//"
+     * @return the package path of this label
+     */
+    public String getPackagePath(boolean includePrefix) {
+        String packagePath = this.label;
+        int i = packagePath.lastIndexOf("...");
+        if (i != -1) {
+            packagePath = packagePath.substring(0, i);
+            if (packagePath.endsWith("/")) {
+                packagePath = packagePath.substring(0, packagePath.length() - 1);
+            }
+        } else {
+            i = this.label.lastIndexOf(":");
+            if (i != -1) {
+                packagePath = packagePath.substring(0, i);
+            }
+        }
+        String prefix = includePrefix ? "//" : "";
+        return prefix + packagePath;
+    }
+    
+    /**
      * Returns the package name of this label, which is the right-most path component of the package path.
      * 
      * For example, given a label //foo/blah/goo:t1, the package name is goo.


### PR DESCRIPTION
This solves the main feature for #25 

The remaining issue is that the existing projects need to recompute their classpath, as the additive projects may now be a project reference to a classpath.