### PR TITLE
prep work for splitting test classpath

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
@@ -62,7 +62,6 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.osgi.service.prefs.BackingStoreException;
-import org.osgi.service.prefs.Preferences;
 
 import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.BazelNature;
@@ -284,7 +283,8 @@ public class BazelEclipseProjectFactory {
         try {
             addNatureToEclipseProject(eclipseProject, BazelNature.BAZEL_NATURE_ID);
             addNatureToEclipseProject(eclipseProject, JavaCore.NATURE_ID);
-            addSettingsToEclipseProject(eclipseProject, bazelWorkspaceRootDirectory, bazelTargets, ImmutableList.of()); // TODO pass buildFlags
+            BazelProjectPreferences.addSettingsToEclipseProject(eclipseProject, bazelWorkspaceRootDirectory.getAbsolutePath(), 
+                packageFSPath, bazelTargets, ImmutableList.of()); // TODO pass buildFlags
 
             // this may throw if the user has deleted the .project file on disk while the project is open for import
             // but it will try to recover so we should catch now instead of allowing the entire flow to fail.
@@ -309,26 +309,6 @@ public class BazelEclipseProjectFactory {
         }
 
         return eclipseProject;
-    }
-
-    private static void addSettingsToEclipseProject(IProject eclipseProject, File bazelWorkspaceRootDirectory,
-            List<String> bazelTargets, List<String> bazelBuildFlags) throws BackingStoreException {
-
-        Preferences eclipseProjectBazelPrefs =
-                BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
-
-        int i = 0;
-        for (String bazelTarget : bazelTargets) {
-            eclipseProjectBazelPrefs.put(BazelEclipseProjectSupport.TARGET_PROPERTY_PREFIX + i, bazelTarget);
-            i++;
-        }
-        eclipseProjectBazelPrefs.put(BazelEclipseProjectSupport.WORKSPACE_ROOT_PROPERTY, bazelWorkspaceRootDirectory.getAbsolutePath());
-        i = 0;
-        for (String bazelBuildFlag : bazelBuildFlags) {
-            eclipseProjectBazelPrefs.put(BazelEclipseProjectSupport.BUILDFLAG_PROPERTY_PREFIX + i, bazelBuildFlag);
-            i++;
-        }
-        eclipseProjectBazelPrefs.flush();
     }
 
     private static void setBuildersOnEclipseProject(IProject eclipseProject) throws CoreException {

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectSupport.java
@@ -57,37 +57,10 @@ import com.salesforce.bazel.eclipse.model.BazelMarkerDetails;
  */
 public class BazelEclipseProjectSupport {
     static final String WORKSPACE_ROOT_PROPERTY = "bazel.workspace.root";
-    static final String TARGET_PROPERTY_PREFIX = "bazel.target";
+    static final String TARGET_PROPERTY_PREFIX = "bazel.activated.target";
     static final String BUILDFLAG_PROPERTY_PREFIX = "bazel.build.flag";
 
     private static final BazelMarkerManagerSingleton MARKER_MANAGER = BazelMarkerManagerSingleton.getInstance();
-
-    /**
-     * List the Bazel targets configured for this Eclipse project. Each project configured for Bazel is configured to
-     * track certain targets and this function fetches this list from the project preferences.
-     */
-    public static List<String> getBazelTargetsForEclipseProject(IProject eclipseProject, boolean addWildcardIfNoTargets) {
-        // Get the list of targets from the preferences
-        Preferences eclipseProjectBazelPrefs = BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
-        ImmutableList.Builder<String> listBuilder = ImmutableList.builder();
-
-        boolean addedTarget = false;
-        for (String propertyName : getKeys(eclipseProjectBazelPrefs)) {
-            if (propertyName.startsWith(TARGET_PROPERTY_PREFIX)) {
-                String target = eclipseProjectBazelPrefs.get(propertyName, "");
-                if (!"//...".equals(target) && !target.isEmpty()) {
-                    listBuilder.add(target);
-                    addedTarget = true;
-                }
-            }
-        }
-
-        if (!addedTarget && addWildcardIfNoTargets) {
-            listBuilder.add("//...");
-        }
-
-        return listBuilder.build();
-    }
 
     /**
      * List of Bazel build flags for this Eclipse project, taken from the project configuration

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelProjectPreferences.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelProjectPreferences.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2019, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.eclipse.config;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IProject;
+import org.osgi.service.prefs.BackingStoreException;
+import org.osgi.service.prefs.Preferences;
+
+import com.google.common.collect.ImmutableList;
+import com.salesforce.bazel.eclipse.BazelPluginActivator;
+
+// TODO migrate this away from static methods
+public class BazelProjectPreferences { 
+    // TODO ideally these constants would be private, impl details
+    /**
+     * Absolute path of the Bazel workspace root 
+     */
+    public static final String BAZEL_WORKSPACE_ROOT_ABSPATH_PROPERTY = "bazel.workspace.root";
+    
+    /**
+     * The label that identifies the Bazel package that represents this Eclipse project. This will
+     * be the 'module' label when we start supporting multiple BUILD files in a single 'module'.
+     * Example:  //projects/libs/foo
+     * See https://github.com/salesforce/bazel-eclipse/issues/24
+     */
+    private static final String PROJECT_PACKAGE_LABEL = "bazel.package.label";
+    
+    /**
+     * After import, the activated target is a single line, like: 
+     *   bazel.activated.target0=//projects/libs/foo:*
+     * which activates all targets by use of the wildcard. But users may wish to activate a subset
+     * of the targets for builds, in which the prefs lines will look like:
+     *   bazel.activated.target0=//projects/libs/foo:barlib
+     *   bazel.activated.target1=//projects/libs/foo:bazlib
+     */
+    public static final String TARGET_PROPERTY_PREFIX = "bazel.activated.target";
+    
+    /**
+     * Property that allows a user to set project specific build flags that get
+     * passed to the Bazel executable.
+     */
+    static final String BUILDFLAG_PROPERTY_PREFIX = "bazel.build.flag";
+
+    
+    /**
+     * The label that identifies the Bazel package that represents this Eclipse project. This will
+     * be the 'module' label when we start supporting multiple BUILD files in a single 'module'.
+     * Example:  //projects/libs/foo
+     * See https://github.com/salesforce/bazel-eclipse/issues/24
+     */
+    public static String getBazelLabelForEclipseProject(IProject eclipseProject) {
+        Preferences eclipseProjectBazelPrefs = BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
+        return eclipseProjectBazelPrefs.get(PROJECT_PACKAGE_LABEL, null);
+    }
+
+    
+    /**
+     * List the Bazel targets the user has chosen to activate for this Eclipse project. Each project configured 
+     * for Bazel is configured to track certain targets and this function fetches this list from the project preferences.
+     * After initial import, this will be just the wildcard target (:*) which means all targets are activated. This
+     * is the safest choice as new targets that are added to the BUILD file will implicitly get picked up. But users
+     * may choose to be explicit if one or more targets in a BUILD file is not needed for development.
+     * <p>
+     * By contract, this method will return only one target if the there is a wildcard target, even if the user does
+     * funny things in their prefs file and sets multiple targets along with the wildcard target.
+     */
+    public static EclipseProjectBazelTargets getConfiguredBazelTargets(IProject eclipseProject, boolean addWildcardIfNoTargets) {
+        Preferences eclipseProjectBazelPrefs = BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
+        String projectLabel = eclipseProjectBazelPrefs.get(PROJECT_PACKAGE_LABEL, null);
+
+        EclipseProjectBazelTargets activatedTargets = new EclipseProjectBazelTargets(eclipseProject, projectLabel);
+        
+        boolean addedTarget = false;
+        Set<String> activeTargets = new TreeSet<>();
+        for (String propertyName : getKeys(eclipseProjectBazelPrefs)) {
+            if (propertyName.startsWith(TARGET_PROPERTY_PREFIX)) {
+                String target = eclipseProjectBazelPrefs.get(propertyName, "");
+                if (!target.isEmpty()) {
+                    if (!target.startsWith(projectLabel)) {
+                        // the user jammed in a label not associated with this project, ignore
+                        //continue;
+                    }
+                    if (target.endsWith(":*")) {
+                        // we have a wildcard target, so discard any existing targets we gathered (if the user messed up their prefs)
+                        // and just go with that.
+                        activatedTargets.activateWildcardTarget();
+                        return activatedTargets;
+                    }
+                    activeTargets.add(target);
+                    addedTarget = true;
+                }
+            }
+        }
+        if (!addedTarget && addWildcardIfNoTargets) {
+            activeTargets.add("//...");
+        }
+
+        activatedTargets.activateSpecificTargets(activeTargets);
+        
+        
+        return activatedTargets;
+    }
+    
+    /**
+     * List of Bazel build flags for this Eclipse project, taken from the project configuration
+     */
+    public static List<String> getBazelBuildFlagsForEclipseProject(IProject eclipseProject) {
+        Preferences eclipseProjectBazelPrefs = BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
+        
+        ImmutableList.Builder<String> listBuilder = ImmutableList.builder();
+        for (String property : getKeys(eclipseProjectBazelPrefs)) {
+            if (property.startsWith(BUILDFLAG_PROPERTY_PREFIX)) {
+                listBuilder.add(eclipseProjectBazelPrefs.get(property, ""));
+            }
+        }
+        return listBuilder.build();
+    }
+    
+    
+    public static void addSettingsToEclipseProject(IProject eclipseProject, String bazelWorkspaceRoot,
+            String bazelProjectLabel, List<String> bazelTargets, List<String> bazelBuildFlags) throws BackingStoreException {
+
+        Preferences eclipseProjectBazelPrefs = BazelPluginActivator.getResourceHelper().getProjectBazelPreferences(eclipseProject);
+
+        eclipseProjectBazelPrefs.put(BAZEL_WORKSPACE_ROOT_ABSPATH_PROPERTY, bazelWorkspaceRoot);
+        if (!bazelProjectLabel.startsWith("//")) {
+            bazelProjectLabel = "//"+bazelProjectLabel;
+        }
+        eclipseProjectBazelPrefs.put(PROJECT_PACKAGE_LABEL, bazelProjectLabel);
+        
+        int i = 0;
+        for (String bazelTarget : bazelTargets) {
+            eclipseProjectBazelPrefs.put(TARGET_PROPERTY_PREFIX + i, bazelTarget);
+            i++;
+        }
+        i = 0;
+        for (String bazelBuildFlag : bazelBuildFlags) {
+            eclipseProjectBazelPrefs.put(BUILDFLAG_PROPERTY_PREFIX + i, bazelBuildFlag);
+            i++;
+        }
+        eclipseProjectBazelPrefs.flush();
+    }
+    
+
+    // HELPERS
+    
+    private static String[] getKeys(Preferences prefs) {
+        try {
+            return prefs.keys();
+        } catch (BackingStoreException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+}

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseProjectBazelTargets.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseProjectBazelTargets.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2019, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.eclipse.config;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IProject;
+
+import com.salesforce.bazel.eclipse.model.BazelBuildFile;
+
+/**
+ * Object that encapsulates the logic and state regarding the active targets configured for an
+ * Eclipse project.
+ */
+public class EclipseProjectBazelTargets {
+    private IProject project;
+    private String projectBazelLabel;
+    
+    /**
+     * This is the list of targets listed as listed in the project preferences.
+     * This may contain a single entry that is the wildcard target (:*), or it can be a list
+     * of specific targets
+     */
+    private Set<String> configuredTargets = new TreeSet<>();
+    
+    /**
+     * Convenience flag that indicates that the activatedTargets list contains one entry and it is
+     * the wildcard entry
+     */
+    private boolean isActivatedWildcardTarget = false;
+    
+    /**
+     * Contains the list of targets configured for building/testing. This will be the same as
+     * configuredTargets if isActivatedWildcardTarget==false, or will be the actual list of all targets
+     * found in the BUILD file if isActivatedWildcardTarget==true
+     */
+    private Set<String> actualTargets;
+    
+    
+    public EclipseProjectBazelTargets(IProject project, String projectBazelLabel) {
+         this.project = project;
+         this.projectBazelLabel = projectBazelLabel;
+    }
+    
+    // TODO weave these into the constructor
+    
+    public void activateWildcardTarget() {
+        this.isActivatedWildcardTarget = true;
+        this.configuredTargets.add(projectBazelLabel+":*");
+    }
+
+    public void activateSpecificTargets(Set<String> activatedTargets) {
+        this.isActivatedWildcardTarget = false;
+        this.configuredTargets = activatedTargets;
+        this.actualTargets = activatedTargets;
+    }
+
+    // CONSUMER API
+    
+    public IProject getProject() {
+        return this.project;
+    }
+    
+    public Set<String> getConfiguredTargets() {
+        return this.configuredTargets;
+    }
+
+    public Set<String> getActualTargets(BazelBuildFile bazelBuildFile) {
+        if (this.isActivatedWildcardTarget) {
+            this.actualTargets = bazelBuildFile.getAllTargetLabels();
+        }
+        
+        return this.actualTargets;
+    }
+
+    public boolean isActivatedWildcardTarget() {
+        return this.isActivatedWildcardTarget;
+    }
+
+    public boolean isAllTargetsDeactivated() {
+        return this.configuredTargets.size() == 0;
+    }
+
+}

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
@@ -48,7 +48,8 @@ import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
-import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
+import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
+import com.salesforce.bazel.eclipse.config.EclipseProjectBazelTargets;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfos;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
@@ -204,8 +205,9 @@ class BazelLaunchConfigurationSupport {
     private static AspectPackageInfos computeAspectPackageInfos(IProject project, BazelWorkspaceCommandRunner bazelRunner,
             WorkProgressMonitor monitor) {
         try {
-            List<String> targets = BazelEclipseProjectSupport.getBazelTargetsForEclipseProject(project, false);
-            Map<String, AspectPackageInfo> packageInfos = bazelRunner.getAspectPackageInfos(project.getName(), targets,
+            // TODO switch this to use the BazelBuildFile value object
+            EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(project, false);
+            Map<String, AspectPackageInfo> packageInfos = bazelRunner.getAspectPackageInfos(project.getName(), targets.getConfiguredTargets(),
                 monitor, "launcher:computeAspectPackageInfos");
             return new AspectPackageInfos(packageInfos.values());
         } catch (IOException | InterruptedException | BazelCommandLineToolConfigurationException ex) {

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProvider.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProvider.java
@@ -62,8 +62,9 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
-import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
 import com.salesforce.bazel.eclipse.config.BazelProjectHelper;
+import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
+import com.salesforce.bazel.eclipse.config.EclipseProjectBazelTargets;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 
 /**
@@ -140,10 +141,10 @@ public class BazelRuntimeClasspathProvider extends StandardClasspathProvider {
         String testClassName = configuration.getAttribute("org.eclipse.jdt.launching.MAIN_TYPE", (String) null);
         String suffix = getParamsJarSuffix(isSource);
 
-        List<String> targets = BazelEclipseProjectSupport.getBazelTargetsForEclipseProject(project.getProject(), false);
+        EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(project.getProject(), false);
         Set<File> paramFiles = new HashSet<File>();
         
-        for (String eachTarget : targets) {
+        for (String eachTarget : targets.getConfiguredTargets()) {
         	
         	if( testClassName == null || testClassName.equals("")) {
                 String query = "tests("+ eachTarget +")";

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -26,6 +27,7 @@ import org.eclipse.ui.texteditor.AbstractDecoratedTextEditor;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
+import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelMarkerDetails;
@@ -104,13 +106,14 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
         List<BazelPackageLocation> packageLocations = new ArrayList<>(projects.length);
         for (IJavaProject project : projects) {
             // get the target to get at the package path
-            List<String> targets = BazelEclipseProjectSupport.getBazelTargetsForEclipseProject(project.getProject(), false);
+            Set<String> targets = BazelProjectPreferences.getConfiguredBazelTargets(project.getProject(), false).getConfiguredTargets();
             if (targets == null || targets.isEmpty()) {
                 // this shouldn't happen, but if it does, we do not want to blow up here
                 // instead return null to force re-import
                 return null;
             }
-            String target = BazelEclipseProjectSupport.getBazelTargetsForEclipseProject(project.getProject(), false).get(0);
+            // TODO it is possible there are no targets configured for a project
+            String target = BazelProjectPreferences.getConfiguredBazelTargets(project.getProject(), false).getConfiguredTargets().iterator().next();
             BazelLabel label = new BazelLabel(target);
             packageLocations.add(new ProjectViewPackageLocation(this.rootDirectory, label.getPackagePath()));
         }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -56,7 +56,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
-import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
+import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.importer.BazelProjectImportScanner;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
@@ -186,7 +186,8 @@ public class BazelImportWizardPage extends WizardPage {
         List<BazelPackageInfo> importedPackages = new ArrayList<>();
         IJavaProject[] javaProjects = BazelPluginActivator.getJavaCoreHelper().getAllBazelJavaProjects(false);
         for (IJavaProject javaProject : javaProjects) {
-            String target = BazelEclipseProjectSupport.getBazelTargetsForEclipseProject(javaProject.getProject(), false).get(0);
+            // TODO it is possible there are no targets configured for a project
+            String target = BazelProjectPreferences.getConfiguredBazelTargets(javaProject.getProject(), false).getConfiguredTargets().iterator().next();
             BazelLabel label = new BazelLabel(target);
             String pack = label.getDefaultPackageLabel().getLabel();
             BazelPackageInfo bpi = rootPackage.findByPackage(pack);

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
@@ -79,7 +79,7 @@ public class BazelEclipseProjectFactoryFTest {
         // workspace preferences
         IPreferenceStore prefsStore = BazelPluginActivator.getResourceHelper().getPreferenceStore(BazelPluginActivator.getInstance());
         String expectedBazelWorkspaceRoot = mockEclipse.getBazelWorkspaceRoot().getCanonicalPath();
-        assertEquals(expectedBazelWorkspaceRoot, prefsStore.getString(BazelPluginActivator.BAZEL_WORKSPACE_PATH_PREF_NAME));
+        assertEquals(expectedBazelWorkspaceRoot, prefsStore.getString(BazelProjectPreferences.BAZEL_WORKSPACE_ROOT_ABSPATH_PROPERTY));
         
         // Eclipse project for the Bazel workspace
         assertNotNull(workspace_IProject);

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -393,7 +394,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
      * @throws IOException
      * @throws BazelCommandLineToolConfigurationException
      */
-    public synchronized List<BazelMarkerDetails> runBazelBuild(List<String> bazelTargets,
+    public synchronized List<BazelMarkerDetails> runBazelBuild(Set<String> bazelTargets,
             WorkProgressMonitor progressMonitor, List<String> extraArgs)
             throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         List<String> extraArgsList = ImmutableList.<String> builder().add("build").addAll(this.buildOptions)
@@ -444,7 +445,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     /**
      * Clear the AspectPackageInfo cache for the passed targets. This flushes the dependency graph for those targets.
      */
-    public synchronized void flushAspectInfoCache(List<String> targets) {
+    public synchronized void flushAspectInfoCache(Set<String> targets) {
         this.aspectHelper.flushAspectInfoCache(targets);
     }
     

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
@@ -157,7 +157,7 @@ public class BazelWorkspaceAspectHelper {
     /**
      * Clear the AspectPackageInfo cache for the passed targets. This flushes the dependency graph for those targets.
      */
-    public synchronized void flushAspectInfoCache(List<String> targets) {
+    public synchronized void flushAspectInfoCache(Set<String> targets) {
         for (String target : targets) {
             // the target may not even be in cache, that is ok, just try to remove it from both current and wildcard caches
             // if the target exists in either it will get flushed
@@ -165,7 +165,6 @@ public class BazelWorkspaceAspectHelper {
             this.aspectInfoCache_wildcards.remove(target);
         }
     }
-
 
     // INTERNALS
     

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFile.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildFile.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2019, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package com.salesforce.bazel.eclipse.model;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Abstraction over the internal details of a BUILD file.
+ * Depending on how this object was built, it may not contain all of the information.
+ */
+public class BazelBuildFile {
+    
+    /**
+     * The label that identifies the package associated with this BUILD file, e.g. //projects/libs/foo
+     */
+    String label;
+    
+    /**
+     * Maps the String rule type (e.g. java_library) to the target labels (e.g. "//projects/libs/foo:foolib", 
+     *   "//projects/libs/foo:barlib")
+     */
+    private Map<String, Set<String>> typeToTargetMap = new TreeMap<>();
+
+    /**
+     * Maps the String target label (e.g. //projects/libs/foo:foolib) to the rule type  (e.g. java_library)
+     */
+    private Map<String, String> targetToTypeMap = new TreeMap<>();
+
+    private Set<String> allTargets = new TreeSet<>();
+    
+    
+    public BazelBuildFile(String label) {
+        this.label = label;
+    }
+    
+    public void addTarget(String ruleType, String targetLabel) {
+        this.targetToTypeMap.put(targetLabel, ruleType);
+        this.allTargets.add(targetLabel);
+        
+        Set<String> targetsForRuleType = typeToTargetMap.get(ruleType);
+        if (targetsForRuleType == null) {
+            targetsForRuleType = new TreeSet<>();
+            this.typeToTargetMap.put(ruleType, targetsForRuleType);
+        }
+        if (!targetsForRuleType.contains(targetLabel)) {
+            targetsForRuleType.add(targetLabel);
+        }
+        
+    }
+    
+    public String getLabel() {
+        return this.label;
+    }
+    
+    public Set<String> getRuleTypes() {
+        return this.typeToTargetMap.keySet();
+    }
+    
+    public Set<String> getTargetsForRuleType(String ruleType) {
+        return this.typeToTargetMap.get(ruleType);
+    }
+    
+    public String getRuleTypeForTarget(String targetLabel) {
+        return this.targetToTypeMap.get(targetLabel);
+    }
+    
+    public Set<String> getAllTargetLabels() {
+        return this.allTargets;
+    }
+}


### PR DESCRIPTION
I have had a branch set aside where I did the classpath changes to recognize test jars as such in JDT (so they aren't visible to main classes). These refactorings were helpful in implementing that the first time. I am carrying forward these changes before I actually implement the test classpath.

Introduced some new classes to model:
- Eclipse preferences container
- Set of Bazel targets
- Build file

and a lot of code changes to reroute callers into the model objects. And use Set instead of List in places where dupes are not wanted.