### PR TITLE
first phase of testlib support

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/ImplicitDependencyHelper.java
@@ -69,7 +69,11 @@ public class ImplicitDependencyHelper {
         if (filePathForRunnerJar != null) {
             // now manufacture the classpath entry
             IPath runnerJarPath = org.eclipse.core.runtime.Path.fromOSString(filePathForRunnerJar);
-            IClasspathEntry runnerJarEntry = BazelPluginActivator.getJavaCoreHelper().newLibraryEntry(runnerJarPath, null, null);
+            IPath sourceAttachmentPath = null;
+            IPath sourceAttachmentRootPath = null;
+            boolean isTestLib = true;
+            IClasspathEntry runnerJarEntry = BazelPluginActivator.getJavaCoreHelper().newLibraryEntry(runnerJarPath, sourceAttachmentPath, 
+                sourceAttachmentRootPath, isTestLib);
             deps.add(runnerJarEntry);
         }        
         return deps;

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/JavaCoreHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/JavaCoreHelper.java
@@ -240,9 +240,10 @@ public interface JavaCoreHelper {
      *   and will be automatically converted to <code>null</code>.
      * @param sourceAttachmentRootPath the location of the root of the source files within the source archive or folder
      *    or <code>null</code> if this location should be automatically detected.
+     * @param isTestLib pass true if you want this library to only be visible to test classes
      * @return a new library classpath entry
      */
-    IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath);
+    IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath, boolean isTestLib);
     
     /**
      * Creates and returns a new classpath entry of kind <code>CPE_CONTAINER</code>

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseJavaCoreHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseJavaCoreHelper.java
@@ -31,6 +31,7 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -110,8 +111,17 @@ public class EclipseJavaCoreHelper implements JavaCoreHelper {
     }
 
     @Override
-    public IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath) {
-        return JavaCore.newLibraryEntry(path, sourceAttachmentPath, sourceAttachmentRootPath);
+    public IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath, boolean isTestLib) {
+        IClasspathAttribute[] extraAttributes = {};
+        if (isTestLib) {
+            IClasspathAttribute testAttr = JavaCore.newClasspathAttribute(IClasspathAttribute.TEST, "true");
+            extraAttributes = new IClasspathAttribute[] { testAttr };
+        }
+        IAccessRule[] accessRules = null;
+        boolean isExported = false;
+
+        return JavaCore.newLibraryEntry(path, sourceAttachmentPath, sourceAttachmentRootPath, accessRules, extraAttributes,
+            isExported);
     }
 
     @Override

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockJavaCoreHelper.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockJavaCoreHelper.java
@@ -104,7 +104,7 @@ public class MockJavaCoreHelper implements JavaCoreHelper {
     }
 
     @Override
-    public IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath) {
+    public IClasspathEntry newLibraryEntry(IPath path, IPath sourceAttachmentPath, IPath sourceAttachmentRootPath, boolean isTestLib) {
         return new MockIClasspathEntry(IClasspathEntry.CPE_LIBRARY, path);
     }
     

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelQueryHelper.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelQueryHelper.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
+import com.salesforce.bazel.eclipse.model.BazelBuildFile;
 
 /**
  * Helper that knows how to run bazel query commands.
@@ -54,6 +55,7 @@ public class BazelQueryHelper {
      *            can be null
      * @throws BazelCommandLineToolConfigurationException
      */
+    @Deprecated
     public synchronized List<String> listBazelTargetsInBuildFiles(File bazelWorkspaceRootDirectory, WorkProgressMonitor progressMonitor,
             File... directories) throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
@@ -65,6 +67,42 @@ public class BazelQueryHelper {
         return bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor, 
             argBuilder.build(), (t) -> t);
     }
+    
+    /**
+     * Returns the list of targets, with type data, found in a BUILD files for the given package. Uses Bazel Query to build the list.
+     */
+    public synchronized BazelBuildFile queryBazelTargetsInBuildFile(File bazelWorkspaceRootDirectory, WorkProgressMonitor progressMonitor,
+            String bazelPackageName) throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+
+        // bazel query 'kind(rule, [label]:*)' --output label_kind
+        
+        ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
+        argBuilder.add("query");
+        argBuilder.add("kind(rule, "+bazelPackageName+":*)");
+        argBuilder.add("--output");
+        argBuilder.add("label_kind");
+        List<String> resultLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor, 
+            argBuilder.build(), (t) -> t);
+        
+        // Sample Output:  (format: rule_type 'rule' label)
+        // java_binary rule //projects/libs/apple/apple-api:apple-main
+        // java_test rule //projects/libs/apple/apple-api:apple-api-test2
+        // java_library rule //projects/libs/apple/apple-api:apple-api
+
+        BazelBuildFile buildFile = new BazelBuildFile(bazelPackageName);
+        for (String resultLine : resultLines) {
+            String[] tokens = resultLine.split(" ");
+            if (tokens.length != 3) {
+                continue;
+            }
+            String ruleType = tokens[0];
+            String targetLabel = tokens[2];
+            buildFile.addTarget(ruleType, targetLabel);
+        }
+        
+        return buildFile;
+    }
+    
 
     
     /**

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
@@ -155,6 +155,16 @@ public class BazelWorkspaceAspectHelper {
     }
 
     /**
+     * Clear the AspectPackageInfo cache for the passed target. This flushes the dependency graph for those target.
+     */
+    public synchronized void flushAspectInfoCache(String target) {
+        // the target may not even be in cache, that is ok, just try to remove it from both current and wildcard caches
+        // if the target exists in either it will get flushed
+        this.aspectInfoCache_current.remove(target);
+        this.aspectInfoCache_wildcards.remove(target);
+    }
+
+    /**
      * Clear the AspectPackageInfo cache for the passed targets. This flushes the dependency graph for those targets.
      */
     public synchronized void flushAspectInfoCache(Set<String> targets) {


### PR DESCRIPTION
First layer of infra code to support identifying test libs as such, so they are added only to the JDT test classpath.

- exposed a boolean isTestLib on the library classpath method
- support for querying a target for its type (i.e. java_test, java_library, java_binary) which is necessary to classify the outputs of the target