### PR TITLE
isolate test deps to the test classpath in JDT

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactory.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.resources.ICommand;
@@ -612,9 +613,13 @@ public class BazelEclipseProjectFactory {
         // run the aspect for specified targets and get an AspectPackageInfo for each
         AspectPackageInfos aspectPackageInfos = null;
         try {
-            Map<String, AspectPackageInfo> packageInfos = bazelWorkspaceCmdRunner.getAspectPackageInfos(rootEclipseProject.getName(),
+            Map<String, Set<AspectPackageInfo>> packageInfos = bazelWorkspaceCmdRunner.getAspectPackageInfos(rootEclipseProject.getName(),
                 packageBazelTargets, progressMonitor, "importWorkspace");
-            aspectPackageInfos = new AspectPackageInfos(packageInfos.values());
+            List<AspectPackageInfo> allPackageInfos = new ArrayList<>();
+            for (Set<AspectPackageInfo> targetPackageInfos : packageInfos.values()) {
+                allPackageInfos.addAll(targetPackageInfos);
+            }
+            aspectPackageInfos = new AspectPackageInfos(allPackageInfos);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
@@ -40,6 +40,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -207,9 +208,9 @@ class BazelLaunchConfigurationSupport {
         try {
             // TODO switch this to use the BazelBuildFile value object
             EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(project, false);
-            Map<String, AspectPackageInfo> packageInfos = bazelRunner.getAspectPackageInfos(project.getName(), targets.getConfiguredTargets(),
+            Map<String, Set<AspectPackageInfo>> packageInfos = bazelRunner.getAspectPackageInfos(project.getName(), targets.getConfiguredTargets(),
                 monitor, "launcher:computeAspectPackageInfos");
-            return new AspectPackageInfos(packageInfos.values());
+            return AspectPackageInfos.fromSets(packageInfos.values());
         } catch (IOException | InterruptedException | BazelCommandLineToolConfigurationException ex) {
             throw new IllegalStateException(ex);
         }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunnerTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunnerTest.java
@@ -75,10 +75,10 @@ public class BazelWorkspaceCommandRunnerTest {
         // test getting aspects from the file system
         Set<String> targets = new TreeSet<>();
         targets.add("//projects/libs/javalib0:*");
-        Map<String, AspectPackageInfo> aspectMap = workspaceRunner.getAspectPackageInfos("javalib0", targets, new MockWorkProgressMonitor(),
+        Map<String, Set<AspectPackageInfo>> aspectMap = workspaceRunner.getAspectPackageInfos("javalib0", targets, new MockWorkProgressMonitor(),
             "testWorkspaceRunner");
         // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
-        assertEquals(4, aspectMap.size());
+        assertEquals(4, aspectMap.get("//projects/libs/javalib0:*").size());
         
         // run a clean, should not throw an exception
         workspaceRunner.runBazelClean(new MockWorkProgressMonitor());

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelperTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelperTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class BazelWorkspaceAspectHelperTest {
         // retrieve the aspects for the target
         List<String> targets = new ArrayList<>();
         targets.add("//projects/libs/javalib0:*");
-        Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
+        Map<String, Set<AspectPackageInfo>> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
         // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
         assertEquals(4, aspectMap.size());
@@ -80,7 +81,7 @@ public class BazelWorkspaceAspectHelperTest {
         // retrieve the aspects for the target
         List<String> targets = new ArrayList<>();
         targets.add("//projects/libs/javalib0:*");
-        Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
+        Map<String, Set<AspectPackageInfo>> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
         // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
         assertEquals(4, aspectMap.size());
@@ -102,7 +103,7 @@ public class BazelWorkspaceAspectHelperTest {
         // retrieve the aspects for the target
         List<String> targets = new ArrayList<>();
         targets.add("//projects/libs/javalib0:*");
-        Map<String, AspectPackageInfo> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
+        Map<String, Set<AspectPackageInfo>> aspectMap = aspectHelper.getAspectPackageInfos("test-project", targets, 
             new MockWorkProgressMonitor(), "testAspectLoading");
         // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
         assertEquals(4, aspectMap.size());

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfos.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/AspectPackageInfos.java
@@ -42,7 +42,9 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A container for AspectPackageInfo instances.
@@ -70,6 +72,16 @@ public class AspectPackageInfos {
         }
     }
 
+    public static AspectPackageInfos fromSets(Collection<Set<AspectPackageInfo>> aspectPackageInfoSets) {
+        Set<AspectPackageInfo> infoList = new TreeSet<>();
+        for (Set<AspectPackageInfo> set : aspectPackageInfoSets) {
+            for (AspectPackageInfo info : set) {
+                infoList.add(info);
+            }
+        }
+        return new AspectPackageInfos(infoList);
+    }
+    
     public AspectPackageInfo lookupByLabel(String label) {
         return labelToAspectPackageInfo.get(label);
     }


### PR DESCRIPTION
Tracks the target type (java_library, java_test) as it adds jars to the classpath of the JDT project so that test jars are added only to the JDT test classpath, not the main classpath.