### PR TITLE
fix launcher tests

### DIFF
--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
@@ -60,7 +60,7 @@ public class BazelLaunchConfigurationDelegateFTest {
         ILaunchConfiguration launchConfig = createLaunchConfiguration("run");
         ILaunch launch = new MockILaunch(launchConfig);
         IProgressMonitor progress = new EclipseWorkProgressMonitor();
-        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), "run", "bazel run result");
+        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), 0, "bazel-bin/projects/libs/javalib0/javalib0", "bazel run result");
         BazelLaunchConfigurationDelegate delegate = mockEclipse.getLaunchDelegate();
         
         // method under test
@@ -83,7 +83,7 @@ public class BazelLaunchConfigurationDelegateFTest {
         ILaunchConfiguration launchConfig = createLaunchConfiguration("test");
         ILaunch launch = new MockILaunch(launchConfig);
         IProgressMonitor progress = new EclipseWorkProgressMonitor();
-        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), "test", "bazel test result");
+        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), 1, "test", "bazel test result");
         BazelLaunchConfigurationDelegate delegate = mockEclipse.getLaunchDelegate();
         
         // method under test
@@ -110,7 +110,7 @@ public class BazelLaunchConfigurationDelegateFTest {
         ILaunchConfiguration launchConfig = createLaunchConfiguration("selenium");
         ILaunch launch = new MockILaunch(launchConfig);
         IProgressMonitor progress = new EclipseWorkProgressMonitor();
-        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), "test", "bazel test result");
+        addBazelCommandOutput(mockEclipse.getBazelCommandEnvironmentFactory(), 1, "test", "bazel test result");
         BazelLaunchConfigurationDelegate delegate = mockEclipse.getLaunchDelegate();
         
         // method under test
@@ -140,7 +140,7 @@ public class BazelLaunchConfigurationDelegateFTest {
         //testTempDir.mkdirs();
 
         // create the mock Eclipse runtime in the correct state
-        int numberOfJavaPackages = 2;
+        int numberOfJavaPackages = 1;
         boolean computeClasspaths = true; 
         MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(
             testTempDir, numberOfJavaPackages, computeClasspaths, false);
@@ -170,14 +170,14 @@ public class BazelLaunchConfigurationDelegateFTest {
         return testConfig;
     }
 
-    private void addBazelCommandOutput(TestBazelCommandEnvironmentFactory env, String verb, String resultLine) {
+    private void addBazelCommandOutput(TestBazelCommandEnvironmentFactory env, int verbIndex, String verb, String resultLine) {
         List<String> outputLines = new ArrayList<>();
         outputLines.add(resultLine);
         List<String> errorLines = new ArrayList<>();
         
         // create a matcher such that the resultLine is only returned if a command uses the specific verb
         List<MockCommandSimulatedOutputMatcher> matchers = new ArrayList<>();
-        matchers.add(new MockCommandSimulatedOutputMatcher(0, verb));
+        matchers.add(new MockCommandSimulatedOutputMatcher(verbIndex, verb));
         
         env.commandBuilder.addSimulatedOutput("launcherbuildertest", outputLines, errorLines, matchers);
     }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
@@ -97,6 +97,8 @@ public class EclipseFunctionalTestEnvironmentFactory {
         // create base configuration, which includes the real bazel workspace on disk
         MockEclipse mockEclipse = createMockEnvironment_PriorToImport_JavaPackages(testTempDir, numberOfJavaPackages,
             explicitJavaTestDeps, false);
+        mockEclipse.getMockCommandBuilder().addAspectJsonFileResponses(mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.aspectFileSets);
+
 
         // scan the bazel workspace filesystem to build the list of Java projects
         BazelProjectImportScanner scanner = new BazelProjectImportScanner();

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
@@ -62,7 +62,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyMap());
         
-        addBazelCommandOutput(env, "run", "bazel run result");
+        addBazelCommandOutput(env, 0, "bazel-bin/a/b/c/c", "fake bazel launcher script result");
         
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
         assertEquals("bazel-bin/a/b/c/c", cmdTokens.get(0));
@@ -81,7 +81,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyMap());
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
 
-        addBazelCommandOutput(env, "run", "bazel run result");
+        addBazelCommandOutput(env, 0, "bazel-bin/a/b/c/c", "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -100,7 +100,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyMap());
 
-        addBazelCommandOutput(env, "test", "bazel test result");
+        addBazelCommandOutput(env, 1, "test", "bazel test result");
         
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -121,7 +121,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyMap());
 
-        addBazelCommandOutput(env, "test", "bazel test result");
+        addBazelCommandOutput(env, 1, "test", "bazel test result");
         
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -144,7 +144,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(bazelArgs);
         
-        addBazelCommandOutput(env, "test", "bazel test result");
+        addBazelCommandOutput(env, 1, "test", "bazel test result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -167,7 +167,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyMap());
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
         
-        addBazelCommandOutput(env, "test", "bazel test result");
+        addBazelCommandOutput(env, 1, "test", "bazel test result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -194,14 +194,14 @@ public class BazelLauncherBuilderTest {
         return env;
     }
     
-    private void addBazelCommandOutput(TestBazelCommandEnvironmentFactory env, String verb, String resultLine) {
+    private void addBazelCommandOutput(TestBazelCommandEnvironmentFactory env, int verbIndex, String verb, String resultLine) {
         List<String> outputLines = new ArrayList<>();
         outputLines.add(resultLine);
         List<String> errorLines = new ArrayList<>();
         
         // create a matcher such that the resultLine is only returned if a command uses the specific verb
         List<MockCommandSimulatedOutputMatcher> matchers = new ArrayList<>();
-        matchers.add(new MockCommandSimulatedOutputMatcher(0, verb));
+        matchers.add(new MockCommandSimulatedOutputMatcher(verbIndex, verb));
         
         env.commandBuilder.addSimulatedOutput("launcherbuildertest", outputLines, errorLines, matchers);
     }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/MockCommandBuilder.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/MockCommandBuilder.java
@@ -159,7 +159,7 @@ public class MockCommandBuilder extends CommandBuilder {
      * @param matchers one or more matchers that will specifically target a command
      */
     public void addSimulatedOutput(String nameForLog, List<String> outputLines, List<String> errorLines, List<MockCommandSimulatedOutputMatcher> matchers) {
-        MockCommandSimulatedOutput out = new MockCommandSimulatedOutput(nameForLog, outputLines, errorLines);
+        MockCommandSimulatedOutput out = new MockCommandSimulatedOutput(nameForLog, outputLines, errorLines, matchers);
         simulatedOutputLines.add(out);
     }
     
@@ -243,7 +243,9 @@ public class MockCommandBuilder extends CommandBuilder {
 
                 handled = true;
             }
-        } 
+        } else if (mockCommand.commandTokens.get(0).startsWith("bazel-bin")) {
+            // launcher script
+        }
         
         // if it wasn't a standard command, get ready for it
         if (!handled) {


### PR DESCRIPTION
the test framework had a bug, such that when we switched to using the launcher script for bazel run, the tests didn't break as expected. fixed the bug, and updated the tests