### PR TITLE
Stream build results as they occur into the Eclipse Problems view

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserver.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserver.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.eclipse.builder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.LinkedList; 
+import java.util.Map;
+import java.util.Queue; 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
+import com.salesforce.bazel.eclipse.builder.BazelMarkerSupport;
+import com.salesforce.bazel.eclipse.logging.LogHelper;
+import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelLabel;
+import com.salesforce.bazel.eclipse.model.BazelOutputParser;
+
+/**
+ * Implementation of {@link OutputStreamObserver} that observes error output and publishes errors to Problems View
+ */
+public class BazelErrorStreamObserver implements OutputStreamObserver {
+    private final IProgressMonitor monitor;
+    private final Map<BazelLabel, IProject> labelToProject;
+    private final IProject rootProject;
+    private static final BazelOutputParser outputParser = new BazelOutputParser();
+    private final Queue<String> errorLines = new LinkedList<>();
+    private static final LogHelper LOG = LogHelper.log(BazelErrorStreamObserver.class);
+    static final String UNKNOWN_PROJECT_ERROR_MSG_PREFIX = "ERROR IN UNKNOWN PROJECT: ";
+
+    public BazelErrorStreamObserver(final IProgressMonitor monitor, final Map<BazelLabel, IProject> labelToProject,
+            IProject rootProject) {
+        this.monitor = monitor;
+        this.labelToProject = labelToProject;
+        this.rootProject = rootProject;
+    }
+    
+    /**
+     * Starts the observer, clears Problems View for every project
+     */
+    @Override
+    public void startObserver() {
+        final Set<IProject> projectSet = new HashSet<>(this.labelToProject.values());
+        for (IProject project : projectSet) {
+            BazelMarkerSupport.publishToProblemsView(project, Collections.emptyList(), monitor);
+        }
+    }
+
+    /**
+     * Launch a thread to parse latest error line and publish to Problems View if applicable
+     */
+    @Override
+    public void update(String error) {
+        synchronized (this.errorLines) {
+            this.errorLines.add(error);
+        }
+        new Thread(() -> updateProblemsView()).start();
+    }
+
+    private void updateProblemsView() {
+        String latestLine = null;
+        synchronized (this.errorLines) {
+            latestLine = this.errorLines.remove();
+        }
+        
+        List<BazelBuildError> bazelBuildErrors = outputParser.getErrorBazelMarkerDetails(latestLine);
+        if (! bazelBuildErrors.isEmpty()) {
+            Multimap<IProject, BazelBuildError> projectToErrors =
+                    assignErrorsToOwningProject(bazelBuildErrors, this.labelToProject, this.rootProject);
+            for (IProject project : projectToErrors.keySet()) {
+                BazelMarkerSupport.publishToProblemsViewWithoutClearing(project, projectToErrors.get(project), monitor);
+            }
+        }
+    }
+    
+    // maps the specified errors to the project instances they belong to, and returns that mapping
+    static Multimap<IProject, BazelBuildError> assignErrorsToOwningProject(List<BazelBuildError> errors,
+            Map<BazelLabel, IProject> labelToProject, IProject rootProject) {
+        Multimap<IProject, BazelBuildError> projectToErrors = HashMultimap.create();
+        List<BazelBuildError> remainingErrors = new LinkedList<>(errors);
+        for (BazelBuildError error : errors) {
+            BazelLabel owningLabel = error.getOwningLabel(labelToProject.keySet());
+            if (owningLabel != null) {
+                IProject project = labelToProject.get(owningLabel);
+                projectToErrors.put(project, error.toErrorWithRelativizedResourcePath(owningLabel));
+                remainingErrors.remove(error);
+            }
+        }
+        if (!remainingErrors.isEmpty()) {
+            if (rootProject != null) {
+                projectToErrors.putAll(rootProject,
+                    remainingErrors.stream().map(e -> e.toGenericWorkspaceLevelError(UNKNOWN_PROJECT_ERROR_MSG_PREFIX))
+                            .collect(Collectors.toList()));
+            } else {
+                // getting here is a bug - at least log the errors we didn't assign to any project
+                for (BazelBuildError error : remainingErrors) {
+                    LOG.error("Unhandled error: " + error);
+                }
+            }
+        }
+        return projectToErrors;
+    }
+}

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
@@ -58,9 +58,9 @@ public class BazelMarkerSupport {
     /**
      * Publishes the specified build errors to the Problems View.
      *
-     * This method first clears the problem markers associated with the specified project,
-     * before publishing the specified BazelBuildError instances as problem markers to
-     * the Problems View.
+     * This method publishes the specified BazelBuildError instances as problem markers to
+     * the Problems View. If you want to clear Problems View before publishing, call 
+     * clearProblemMarkersForProject before this method.
      *
      * Note that this method runs within a WorkspaceModifyOperation.
      *
@@ -72,34 +72,17 @@ public class BazelMarkerSupport {
         BazelEclipseProjectSupport.runWithProgress(monitor, new WorkspaceModifyOperation() {
             @Override
             protected void execute(IProgressMonitor monitor) throws CoreException {
-                clearProblemMarkersForProject(project);
-                publishProblemMarkersForProject(project, errors);
-            }
-        });
-    }
-    
-    /**
-     * Publishes the specified build errors to the Problems View without clearing it first.
-     *
-     * This method publishes the specified BazelBuildError instances as problem markers to
-     * the Problems View without clearing the problem markers first.
-     *
-     * Note that this method runs within a WorkspaceModifyOperation.
-     *
-     * @param project  the project for which to publish the specified errors
-     * @param errors  the errors to publish to the Problems View
-     * @param monitor  progress monitor
-     */
-    public static void publishToProblemsViewWithoutClearing(IProject project, Collection<BazelBuildError> errors, IProgressMonitor monitor) {
-        BazelEclipseProjectSupport.runWithProgress(monitor, new WorkspaceModifyOperation() {
-            @Override
-            protected void execute(IProgressMonitor monitor) throws CoreException {
                 publishProblemMarkersForProject(project, errors);
             }
         });
     }
 
-    private static void clearProblemMarkersForProject(IProject project) throws CoreException {
+    /**
+     * Clears the Problems View for the specified project
+     *
+     * @param project  the project for which to clear Problems View
+     */
+    public static void clearProblemMarkersForProject(IProject project) throws CoreException {
         project.deleteMarkers(BazelMarkerSupport.BAZEL_MARKER, true, IResource.DEPTH_INFINITE);
     }
 

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
@@ -77,6 +77,27 @@ public class BazelMarkerSupport {
             }
         });
     }
+    
+    /**
+     * Publishes the specified build errors to the Problems View without clearing it first.
+     *
+     * This method publishes the specified BazelBuildError instances as problem markers to
+     * the Problems View without clearing the problem markers first.
+     *
+     * Note that this method runs within a WorkspaceModifyOperation.
+     *
+     * @param project  the project for which to publish the specified errors
+     * @param errors  the errors to publish to the Problems View
+     * @param monitor  progress monitor
+     */
+    public static void publishToProblemsViewWithoutClearing(IProject project, Collection<BazelBuildError> errors, IProgressMonitor monitor) {
+        BazelEclipseProjectSupport.runWithProgress(monitor, new WorkspaceModifyOperation() {
+            @Override
+            protected void execute(IProgressMonitor monitor) throws CoreException {
+                publishProblemMarkersForProject(project, errors);
+            }
+        });
+    }
 
     private static void clearProblemMarkersForProject(IProject project) throws CoreException {
         project.deleteMarkers(BazelMarkerSupport.BAZEL_MARKER, true, IResource.DEPTH_INFINITE);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
@@ -45,14 +45,11 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -321,13 +318,7 @@ public class BazelClasspathContainer implements IClasspathContainer {
                 return true;
             }
             EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(this.eclipseProject.getProject(), false);
-            List<BazelLabel> labels = targets.getConfiguredTargets().stream().map(t -> new BazelLabel(t)).collect(Collectors.toList());
-            Map<BazelLabel, IProject> labelToProject = new HashMap<>();
-            for (BazelLabel label : labels) {
-                labelToProject.merge(label, this.eclipseProject.getProject(), (k1, k2) -> {
-                    throw new IllegalStateException("Duplicate label: " + label + " - this is bug");
-                });
-            }
+            Map<BazelLabel, IProject> labelToProject = BazelProjectPreferences.getBazelLabelToEclipseProjectMap(Collections.singletonList(this.eclipseProject));
             OutputStreamObserver errorStreamObserver = new BazelErrorStreamObserver(null, labelToProject, null);
             List<BazelBuildError> details = bazelWorkspaceCmdRunner.runBazelBuild(targets.getConfiguredTargets(), null, Collections.emptyList(), null, errorStreamObserver);
             for (BazelBuildError detail : details) {

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -81,7 +81,12 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
             problemMarkers.add(new BazelBuildError(PROJECT_VIEW_RESOURCE, projectView.getLineNumber(invalidPackage),
                 "Bad Bazel Package: " + invalidPackage.getBazelPackageFSRelativePath()));
         }
-        // publishProblemMarkers also takes care of clearing old markers
+        // Clear old markers and publish to Problems View
+        try {
+            BazelMarkerSupport.clearProblemMarkersForProject(this.rootProject);
+        } catch (CoreException e) {
+            e.printStackTrace();
+        }
         BazelMarkerSupport.publishToProblemsView(this.rootProject, problemMarkers, getProgressMonitor());
         if (problemMarkers.isEmpty()) {
             IJavaProject[] currentlyImportedProjects = getAllJavaBazelProjects();

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
@@ -1,0 +1,96 @@
+package com.salesforce.bazel.eclipse.builder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.junit.Test;
+
+import com.google.common.collect.Multimap;
+import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelLabel;
+
+public class BazelErrorStreamObserverTest {
+    
+    @Test
+    public void testAssignErrorsToOwningProject() throws Exception {
+        IProject project1 = getMockedProject("P1").getProject();
+        BazelLabel l1 = new BazelLabel("projects/libs/lib1:*");
+        BazelBuildError error1 = new BazelBuildError("projects/libs/lib1/src/Test.java", 21, "foo");
+        IProject project2 = getMockedProject("P2").getProject();
+        BazelLabel l2 = new BazelLabel("projects/libs/lib2:*");
+        BazelBuildError error2 = new BazelBuildError("projects/libs/lib2/src/Test2.java", 22, "blah");
+        Map<BazelLabel, IProject> labelToProject = new HashMap<>();
+        labelToProject.put(l1, project1);
+        labelToProject.put(l2, project2);
+        IProject rootProject = getMockedProject("ROOT").getProject();
+
+        Multimap<IProject, BazelBuildError> projectToErrors =
+                BazelErrorStreamObserver.assignErrorsToOwningProject(Arrays.asList(error1, error2), labelToProject, rootProject);
+
+        assertEquals(2, projectToErrors.size());
+        Collection<BazelBuildError> p1Errors = projectToErrors.get(project1);
+        assertEquals(1, p1Errors.size());
+        BazelBuildError p1Error = p1Errors.iterator().next();
+        assertEquals("/src/Test.java", p1Error.getResourcePath());
+        assertEquals(21, p1Error.getLineNumber());
+        assertEquals("foo", p1Error.getDescription());
+        Collection<BazelBuildError> p2Errors = projectToErrors.get(project2);
+        assertEquals(1, p2Errors.size());
+        BazelBuildError p2Error = p2Errors.iterator().next();
+        assertEquals("/src/Test2.java", p2Error.getResourcePath());
+        assertEquals(22, p2Error.getLineNumber());
+        assertEquals("blah", p2Error.getDescription());
+    }
+    
+    @Test
+    public void testUnassignedErrors() throws Exception {
+        IProject project1 = getMockedProject("P1").getProject();
+        BazelLabel l1 = new BazelLabel("projects/libs/lib1:*");
+        BazelBuildError error1 = new BazelBuildError("projects/libs/lib1/src/Test.java", 21, "foo");
+        Map<BazelLabel, IProject> labelToProject = Collections.singletonMap(l1, project1);
+        BazelBuildError error2 = new BazelBuildError("projects/libs/lib2/src/Test2.java", 22, "blah");
+        IProject rootProject = getMockedProject("ROOT").getProject();
+
+        Multimap<IProject, BazelBuildError> projectToErrors =
+                BazelErrorStreamObserver.assignErrorsToOwningProject(Arrays.asList(error1, error2), labelToProject, rootProject);
+
+        assertEquals(2, projectToErrors.size());
+        Collection<BazelBuildError> rootLevelErrors = projectToErrors.get(rootProject);
+        BazelBuildError rootError = rootLevelErrors.iterator().next();
+        assertEquals("/WORKSPACE", rootError.getResourcePath());
+        assertEquals(0, rootError.getLineNumber());
+        assertTrue(rootError.getDescription().startsWith(BazelErrorStreamObserver.UNKNOWN_PROJECT_ERROR_MSG_PREFIX));
+        assertTrue(rootError.getDescription().contains("projects/libs/lib2/src/Test2.java"));
+        assertTrue(rootError.getDescription().contains("blah"));
+    }
+    
+    private IJavaProject getMockedProject(String projectName) throws Exception {
+        return getMockedProject(projectName, new String[]{});
+    }
+    
+    private IProgressMonitor getMockedMonitor() throws Exception {
+        IProgressMonitor progressMonitor = mock(IProgressMonitor.class);
+        return progressMonitor;
+    }
+
+    private IJavaProject getMockedProject(String projectName, String[] requiredProjectNames) throws Exception {
+        IJavaProject javaProject = mock(IJavaProject.class);
+        when(javaProject.getRequiredProjectNames()).thenReturn(requiredProjectNames);
+        IProject project = mock(IProject.class);
+        when(javaProject.getProject()).thenReturn(project);
+        when(project.getName()).thenReturn(projectName);
+        return javaProject;
+    }
+
+}

--- a/plugin-libs/plugin-abstractions/src/main/java/com/salesforce/bazel/eclipse/abstractions/OutputStreamObserver.java
+++ b/plugin-libs/plugin-abstractions/src/main/java/com/salesforce/bazel/eclipse/abstractions/OutputStreamObserver.java
@@ -34,8 +34,6 @@ package com.salesforce.bazel.eclipse.abstractions;
  */
 public interface OutputStreamObserver {
     
-    public void startObserver();
-    
     public void update(String output);
-    
+
 }

--- a/plugin-libs/plugin-abstractions/src/main/java/com/salesforce/bazel/eclipse/abstractions/OutputStreamObserver.java
+++ b/plugin-libs/plugin-abstractions/src/main/java/com/salesforce/bazel/eclipse/abstractions/OutputStreamObserver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.bazel.eclipse.abstractions;
+
+/**
+ * An interface to create an observer to observe stream output from a command. An output stream observer should be able to
+ * publish output stream for both normal ouput and error output as soon as they appear in command console. An 
+ * implementation exists that publishes error output to problems view.
+ * <p>
+ * The abstraction package is used to insulate parts of the plugin code from having direct Eclipse dependencies, which
+ * allows for easier testing and simpler builds.
+ */
+public interface OutputStreamObserver {
+    
+    public void startObserver();
+    
+    public void update(String output);
+    
+}

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.abstractions.BazelAspectLocation;
 import com.salesforce.bazel.eclipse.abstractions.CommandConsoleFactory;
+import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.command.internal.BazelCommandExecutor;
 import com.salesforce.bazel.eclipse.command.internal.BazelQueryHelper;
@@ -321,7 +322,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
             argBuilder.add("test").add("--announce_rc");
             
             List<String> outputLines = bazelCommandExecutor.runBazelAndGetErrorLines(bazelWorkspaceRootDirectory, null, 
-                argBuilder.build(), (t) -> t);
+                argBuilder.build(), (t) -> t, null, null);
             commandOptions.parseOptionsFromOutput(outputLines);
         } catch (Exception anyE) {
             throw new IllegalStateException(anyE);
@@ -423,13 +424,13 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
      * @throws BazelCommandLineToolConfigurationException
      */
     public synchronized List<BazelBuildError> runBazelBuild(Set<String> bazelTargets,
-            WorkProgressMonitor progressMonitor, List<String> extraArgs)
+            WorkProgressMonitor progressMonitor, List<String> extraArgs, OutputStreamObserver outputStreamObserver, OutputStreamObserver errorStreamObserver)
             throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         List<String> extraArgsList = ImmutableList.<String> builder().add("build").addAll(this.buildOptions)
                 .addAll(extraArgs).add("--").addAll(bazelTargets).build();
 
         List<String> output = this.bazelCommandExecutor.runBazelAndGetErrorLines(bazelWorkspaceRootDirectory, progressMonitor,
-            extraArgsList, new ErrorOutputSelector());
+            extraArgsList, new ErrorOutputSelector(), outputStreamObserver, errorStreamObserver);
         if (output.isEmpty()) {
             return Collections.emptyList();
         } else {

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/CommandBuilder.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/CommandBuilder.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import com.salesforce.bazel.eclipse.abstractions.CommandConsoleFactory;
+import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 
 /**
@@ -53,6 +54,8 @@ public abstract class CommandBuilder {
     protected List<String> args;
     protected OutputStream stdout = null;
     protected OutputStream stderr = null;
+    protected OutputStreamObserver stdoutObserver = null;
+    protected OutputStreamObserver stderrObserver = null;
     protected Function<String, String> stdoutSelector;
     protected Function<String, String> stderrSelector;
     protected final CommandConsoleFactory consoleFactory;
@@ -124,6 +127,26 @@ public abstract class CommandBuilder {
      */
     public CommandBuilder setStandardError(OutputStream stderr) {
         this.stderr = stderr;
+        return this;
+    }
+
+    /**
+     * Set an {@link OutputStreamObserver} to receive non selected lines from the standard output stream of the program in
+     * line of the console. If a selector has been set with {@link #setStdoutLineSelector(Function)}, only the lines
+     * not selected (for which the selector returns null) will be updated to the {@link OutputStreamObserver}.
+     */
+    public CommandBuilder setStandardOutObserver(OutputStreamObserver outputObserver) {
+        this.stdoutObserver = outputObserver;
+        return this;
+    }
+    
+    /**
+     * Set an {@link OutputStreamObserver} to receive non selected lines from the standard error stream of the program in
+     * line of the console. If a selector has been set with {@link #setStderrLineSelector(Function)}, only the lines
+     * not selected (for which the selector returns null) will be updated to the {@link OutputStreamObserver}.
+     */
+    public CommandBuilder setStandardErrorObserver(OutputStreamObserver errorObserver) {
+        this.stderrObserver = errorObserver;
         return this;
     }
 

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutor.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutor.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
+import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.eclipse.command.Command;
@@ -89,11 +90,11 @@ public class BazelCommandExecutor {
     // WHEN INTERESTING OUTPUT IS ON STDERR...
     
     public synchronized List<String> runBazelAndGetErrorLines(File directory, WorkProgressMonitor progressMonitor,
-            List<String> args, Function<String, String> selector)
+            List<String> args, Function<String, String> selector, OutputStreamObserver outputStreamObserver, OutputStreamObserver errorStreamObserver)
             throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         
         CommandBuilder builder = getConfiguredCommandBuilder(ConsoleType.WORKSPACE, directory, progressMonitor, args);
-        Command command = builder.setStderrLineSelector(selector).build();
+        Command command = builder.setStderrLineSelector(selector).setStandardErrorObserver(errorStreamObserver).build();
         command.run();
 
         return command.getSelectedErrorLines();

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/SelectOutputStream.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/SelectOutputStream.java
@@ -62,7 +62,7 @@ public class SelectOutputStream extends OutputStream {
     private List<String> lines = new LinkedList<>();
     private List<String> outputLines = new LinkedList<>();
     private ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    private OutputStreamObserver observer;
+    private final OutputStreamObserver observer;
 
     /**
      * Create a SelectOutputStream. <code>output<code> is the output stream where non-selected lines
@@ -117,6 +117,7 @@ public class SelectOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
+        System.out.print("Closing Output Stream");
         Preconditions.checkState(!closed);
         super.close();
         select(false);

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
@@ -181,41 +181,6 @@ public final class ShellCommand implements Command {
         }
         return null;
     }
-    
-    private static class UpdateObserverRunnable implements Runnable {
-        private InputStream inputStream;
-        private OutputStream outputStream;
-
-        UpdateObserverRunnable(InputStream inputStream, OutputStream outputStream) {
-            this.inputStream = inputStream;
-            this.outputStream = outputStream;
-        }
-
-        @Override
-        public void run() {
-            byte[] buffer = new byte[4096];
-            int read;
-            try {
-                while ((read = inputStream.read(buffer)) > 0) {
-                    synchronized (outputStream) {
-                        outputStream.write(buffer, 0, read);
-                    }
-                }
-            } catch (IOException ex) {
-                // we simply terminate the thread on exceptions
-            }
-        }
-    }
-
-    // Launch a thread to copy all data from inputStream to outputStream
-    private static Thread UpdateObserver(InputStream inputStream, OutputStream outputStream) {
-        if (outputStream != null) {
-            Thread t = new Thread(new CopyStreamRunnable(inputStream, outputStream), "CopyStream");
-            t.start();
-            return t;
-        }
-        return null;
-    }
 
     /**
      * Returns the list of lines selected from the standard error stream. Lines printed to the standard error stream by

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
@@ -46,6 +46,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.abstractions.CommandConsole;
 import com.salesforce.bazel.eclipse.abstractions.CommandConsoleFactory;
+import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
 import com.salesforce.bazel.eclipse.command.BazelProcessBuilder;
 import com.salesforce.bazel.eclipse.command.Command;
@@ -70,7 +71,7 @@ public final class ShellCommand implements Command {
 
     ShellCommand(CommandConsole console, File directory, ImmutableList<String> args,
             Function<String, String> stdoutSelector, Function<String, String> stderrSelector, OutputStream stdout,
-            OutputStream stderr, WorkProgressMonitor progressMonitor, long timeoutMS) {
+            OutputStream stderr, OutputStreamObserver stdoutObserver, OutputStreamObserver stderrObserver, WorkProgressMonitor progressMonitor, long timeoutMS) {
         this.directory = directory;
         this.args = args;
         if (console != null) {
@@ -81,8 +82,8 @@ public final class ShellCommand implements Command {
                 stderr = console.createErrorStream();
             }
         }
-        this.stderr = new SelectOutputStream(stderr, stderrSelector);
-        this.stdout = new SelectOutputStream(stdout, stdoutSelector);
+        this.stderr = new SelectOutputStream(stderr, stderrSelector, stderrObserver);
+        this.stdout = new SelectOutputStream(stdout, stdoutSelector, stdoutObserver);
         this.progressMonitor = progressMonitor;
         this.timeoutMS = timeoutMS;
     }
@@ -173,6 +174,41 @@ public final class ShellCommand implements Command {
 
     // Launch a thread to copy all data from inputStream to outputStream
     private static Thread copyStream(InputStream inputStream, OutputStream outputStream) {
+        if (outputStream != null) {
+            Thread t = new Thread(new CopyStreamRunnable(inputStream, outputStream), "CopyStream");
+            t.start();
+            return t;
+        }
+        return null;
+    }
+    
+    private static class UpdateObserverRunnable implements Runnable {
+        private InputStream inputStream;
+        private OutputStream outputStream;
+
+        UpdateObserverRunnable(InputStream inputStream, OutputStream outputStream) {
+            this.inputStream = inputStream;
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public void run() {
+            byte[] buffer = new byte[4096];
+            int read;
+            try {
+                while ((read = inputStream.read(buffer)) > 0) {
+                    synchronized (outputStream) {
+                        outputStream.write(buffer, 0, read);
+                    }
+                }
+            } catch (IOException ex) {
+                // we simply terminate the thread on exceptions
+            }
+        }
+    }
+
+    // Launch a thread to copy all data from inputStream to outputStream
+    private static Thread UpdateObserver(InputStream inputStream, OutputStream outputStream) {
         if (outputStream != null) {
             Thread t = new Thread(new CopyStreamRunnable(inputStream, outputStream), "CopyStream");
             t.start();

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommandBuilder.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommandBuilder.java
@@ -53,7 +53,7 @@ public class ShellCommandBuilder extends CommandBuilder {
         CommandConsole console = consoleName == null ? null : consoleFactory.get(consoleName,
             "Running " + String.join(" ", args) + " from " + directory.toString());
         
-        ShellCommand command = new ShellCommand(console, directory, iargs, stdoutSelector, stderrSelector, stdout, stderr,
+        ShellCommand command = new ShellCommand(console, directory, iargs, stdoutSelector, stderrSelector, stdout, stderr, stdoutObserver, stderrObserver,
             progressMonitor, timeoutMS);
         
         return command;

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutorTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/internal/BazelCommandExecutorTest.java
@@ -81,7 +81,7 @@ public class BazelCommandExecutorTest {
         
         BazelCommandExecutor executor = new BazelCommandExecutor(env.bazelExecutable.bazelExecutableFile, env.commandBuilder);
         List<String> result = executor.runBazelAndGetErrorLines(env.bazelWorkspaceCommandRunner.getBazelWorkspaceRootDirectory(), 
-            new MockWorkProgressMonitor(), args, (t) -> t);
+            new MockWorkProgressMonitor(), args, (t) -> t, null, null);
         
         assertEquals(2, result.size());
         assertEquals("result line 1", result.get(0));

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
@@ -47,15 +47,16 @@ public class BazelOutputParserTest {
     public void testSingleJavaError() {
         BazelOutputParser p = new BazelOutputParser();
         List<String> lines = ImmutableList.of(
-            "ERROR: /Users/stoens/bazel-build-example-for-eclipse/sayhello/BUILD:1:1: Building sayhello/libsayhello.jar (2 source files) failed (Exit 1)",
-            "sayhello/src/main/java/com/blah/foo/hello/Main.java:16: error: cannot find symbol");
+            "ERROR: /Users/stoens/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building libbanana-api.jar (2 source files) failed (Exit 1)",
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:50: error: cannot find symbol",
+            "    this.numSeeds = numSeeds;");
 
         List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(1, errors.size());
-        assertEquals("sayhello/src/main/java/com/blah/foo/hello/Main.java", errors.get(0).getResourcePath());
-        assertEquals(16, errors.get(0).getLineNumber());
-        assertEquals("Cannot find symbol", errors.get(0).getDescription());
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
+        assertEquals(50, errors.get(0).getLineNumber());
+        assertEquals("Cannot find symbol: this.numSeeds = numSeeds;", errors.get(0).getDescription());
     }
 
     @Test
@@ -66,7 +67,8 @@ public class BazelOutputParserTest {
             "sayhello/src/main/java/com/blah/foo/hello/Main.java:16: error: cannot find symbol", "    blah 1 2 3",
             "             ^",
             "ERROR: /Users/stoens/bazel-build-example-for-eclipse/sayhello/BUILD:1:1: Building sayhello/libsayhello.jar (2 source files) failed (Exit 1)",
-            "sayhello/src/main/java/com/blah/foo/hello/Main.java:17: error: cannot find symbols");
+            "sayhello/src/main/java/com/blah/foo/hello/Main.java:17: error: cannot find symbols",
+            "INFO: Elapsed time: 0.196s, Critical Path: 0.03s");
 
         List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
 

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
@@ -83,6 +83,55 @@ public class BazelOutputParserTest {
     }
     
     @Test
+    public void testMultipleJavaErrorsWithSameStatus() {
+        BazelOutputParser p = new BazelOutputParser();
+        List<String> lines = ImmutableList.of(
+            "ERROR: /Users/d.sang/workplace/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building projects/libs/banana/banana-api/libbanana-api.jar (2 source files) failed (Exit 1)\n", 
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:41: error: ';' expected\n",
+            "  public int numSeeds\n",
+            "                     ^\n",
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:42: error: ';' expected\n", 
+            "  private String species\n",
+            "                        ^");
+
+        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+
+        assertEquals(2, errors.size());
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
+        assertEquals(41, errors.get(0).getLineNumber());
+        assertEquals("';' expected: public int numSeeds", errors.get(0).getDescription());
+
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(1).getResourcePath());
+        assertEquals(42, errors.get(1).getLineNumber());
+        assertEquals("';' expected: private String species", errors.get(1).getDescription());
+    }
+    
+    @Test
+    public void testMultipleErrorSourceLines() {
+        BazelOutputParser p = new BazelOutputParser();
+        List<String> lines = ImmutableList.of(
+            "ERROR: /Users/d.sang/workplace/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building projects/libs/banana/banana-api/libbanana-api.jar (2 source files) failed (Exit 1)\n", 
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:41: error: ';' expected\n",
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:42: error: ';' expected\n",
+            "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:45: error: ';' expected\n",
+            "    this.species = species",
+            "                        ^");
+
+        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+
+        assertEquals(3, errors.size());
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
+        assertEquals(41, errors.get(0).getLineNumber());
+        assertEquals("';' expected", errors.get(0).getDescription());
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(1).getResourcePath());
+        assertEquals(42, errors.get(1).getLineNumber());
+        assertEquals("';' expected", errors.get(1).getDescription());
+        assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(1).getResourcePath());
+        assertEquals(45, errors.get(2).getLineNumber());
+        assertEquals("';' expected: this.species = species", errors.get(2).getDescription());
+    }
+    
+    @Test
     public void testUnformattedError() {
         BazelOutputParser p = new BazelOutputParser();
         List<String> lines = ImmutableList.of(


### PR DESCRIPTION
- Create OutputStreamObserver interface for observers of output stream
- Create BazelErrorStreamObserver that implements OutputStreamObserver, which collects build errors as soon as they occur and publish them to Problems View
- Change BazelOutputParser to implement a state so that it can parse errors line by line
- Update unit tests