### PR TITLE
Some cleanup for issue #41

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
@@ -78,15 +78,22 @@ public class BazelMarkerSupport {
     }
 
     /**
-     * Clears the Problems View for the specified project
+     * Clears the Problems View for the specified project.
+     * 
+     * Note that this method runs within a WorkspaceModifyOperation.
      *
-     * @param project  the project for which to clear Problems View
+     * @param project  the project for which to remove associated markers from the Problems View
      */
-    public static void clearProblemMarkersForProject(IProject project) throws CoreException {
-        project.deleteMarkers(BazelMarkerSupport.BAZEL_MARKER, true, IResource.DEPTH_INFINITE);
+    public static void clearProblemMarkersForProject(IProject project, IProgressMonitor monitor) {
+        BazelEclipseProjectSupport.runWithProgress(monitor, new WorkspaceModifyOperation() {
+            @Override
+            protected void execute(IProgressMonitor monitor) throws CoreException {
+                project.deleteMarkers(BazelMarkerSupport.BAZEL_MARKER, true, IResource.DEPTH_INFINITE);
+            }
+        });
     }
-
-    private static void publishProblemMarkersForProject(IProject project, Collection<BazelBuildError> errorDetails) throws CoreException {
+    
+    private static void publishProblemMarkersForProject(IProject project, Collection<BazelBuildError> errorDetails) throws CoreException {        
         for (BazelBuildError errorDetail : errorDetails) {
             String resourcePath = errorDetail.getResourcePath();
             IResource resource = project.findMember(resourcePath);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
@@ -64,9 +64,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
-import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.abstractions.WorkProgressMonitor;
-import com.salesforce.bazel.eclipse.builder.BazelErrorStreamObserver;
 import com.salesforce.bazel.eclipse.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.eclipse.command.BazelCommandManager;
 import com.salesforce.bazel.eclipse.command.BazelWorkspaceCommandRunner;
@@ -76,9 +74,8 @@ import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.config.EclipseProjectBazelTargets;
 import com.salesforce.bazel.eclipse.model.AspectOutputJarSet;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
-import com.salesforce.bazel.eclipse.model.BazelBuildFile;
-import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelBuildFile;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
 import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
@@ -318,9 +315,7 @@ public class BazelClasspathContainer implements IClasspathContainer {
                 return true;
             }
             EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(this.eclipseProject.getProject(), false);
-            Map<BazelLabel, IProject> labelToProject = BazelProjectPreferences.getBazelLabelToEclipseProjectMap(Collections.singletonList(this.eclipseProject));
-            OutputStreamObserver errorStreamObserver = new BazelErrorStreamObserver(null, labelToProject, null);
-            List<BazelBuildError> details = bazelWorkspaceCmdRunner.runBazelBuild(targets.getConfiguredTargets(), null, Collections.emptyList(), null, errorStreamObserver);
+            List<BazelBuildError> details = bazelWorkspaceCmdRunner.runBazelBuild(targets.getConfiguredTargets(), null, Collections.emptyList(), null, null);
             for (BazelBuildError detail : details) {
                 BazelPluginActivator.error(detail.toString());
             }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -81,12 +81,7 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
             problemMarkers.add(new BazelBuildError(PROJECT_VIEW_RESOURCE, projectView.getLineNumber(invalidPackage),
                 "Bad Bazel Package: " + invalidPackage.getBazelPackageFSRelativePath()));
         }
-        // Clear old markers and publish to Problems View
-        try {
-            BazelMarkerSupport.clearProblemMarkersForProject(this.rootProject);
-        } catch (CoreException e) {
-            e.printStackTrace();
-        }
+        BazelMarkerSupport.clearProblemMarkersForProject(this.rootProject, getProgressMonitor());
         BazelMarkerSupport.publishToProblemsView(this.rootProject, problemMarkers, getProgressMonitor());
         if (problemMarkers.isEmpty()) {
             IJavaProject[] currentlyImportedProjects = getAllJavaBazelProjects();

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.junit.Test;
 
@@ -79,11 +78,6 @@ public class BazelErrorStreamObserverTest {
         return getMockedProject(projectName, new String[]{});
     }
     
-    private IProgressMonitor getMockedMonitor() throws Exception {
-        IProgressMonitor progressMonitor = mock(IProgressMonitor.class);
-        return progressMonitor;
-    }
-
     private IJavaProject getMockedProject(String projectName, String[] requiredProjectNames) throws Exception {
         IJavaProject javaProject = mock(IJavaProject.class);
         when(javaProject.getRequiredProjectNames()).thenReturn(requiredProjectNames);

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/SelectOutputStream.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/SelectOutputStream.java
@@ -117,7 +117,6 @@ public class SelectOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        System.out.print("Closing Output Stream");
         Preconditions.checkState(!closed);
         super.close();
         select(false);


### PR DESCRIPTION
This is not working correctly yet, because, although the problem markers are
now created right away, as we parse Bazel output, the problems view doesn't
visually show the markers until after BazelBuilder has completed.

I will create a follow up issue.