### PR TITLE
Rename BazelBuildError -> BazelProblem

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
@@ -65,7 +65,7 @@ import com.salesforce.bazel.eclipse.config.BazelEclipseProjectFactory;
 import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.config.EclipseProjectBazelTargets;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.runtime.api.JavaCoreHelper;
@@ -164,7 +164,7 @@ public class BazelBuilder extends IncrementalProjectBuilder {
             // Start error observer and clear Problems View
             errorStreamObserver.startObserver();
             // now run the actual build
-            List<BazelBuildError> errors = cmdRunner.runBazelBuild(bazelTargets, progressMonitor, bazelBuildFlags, null, errorStreamObserver);
+            List<BazelProblem> errors = cmdRunner.runBazelBuild(bazelTargets, progressMonitor, bazelBuildFlags, null, errorStreamObserver);
             return errors.isEmpty();
         }
     }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserver.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserver.java
@@ -51,7 +51,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.salesforce.bazel.eclipse.abstractions.OutputStreamObserver;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 import com.salesforce.bazel.eclipse.model.BazelOutputParser;
 
@@ -93,9 +93,9 @@ public class BazelErrorStreamObserver implements OutputStreamObserver {
     }
     
     private void updateProblemsView(String error) {
-        List<BazelBuildError> bazelBuildErrors = outputParser.getErrorBazelMarkerDetails(error);
+        List<BazelProblem> bazelBuildErrors = outputParser.getErrorBazelMarkerDetails(error);
         if (!bazelBuildErrors.isEmpty()) {
-            Multimap<IProject, BazelBuildError> projectToErrors =
+            Multimap<IProject, BazelProblem> projectToErrors =
                     assignErrorsToOwningProject(bazelBuildErrors, this.labelToProject, this.rootProject);
             for (IProject project : projectToErrors.keySet()) {
                 BazelMarkerSupport.publishToProblemsView(project, projectToErrors.get(project), monitor);
@@ -104,11 +104,11 @@ public class BazelErrorStreamObserver implements OutputStreamObserver {
     }
     
     // maps the specified errors to the project instances they belong to, and returns that mapping
-    static Multimap<IProject, BazelBuildError> assignErrorsToOwningProject(List<BazelBuildError> errors,
+    static Multimap<IProject, BazelProblem> assignErrorsToOwningProject(List<BazelProblem> errors,
             Map<BazelLabel, IProject> labelToProject, IProject rootProject) {
-        Multimap<IProject, BazelBuildError> projectToErrors = HashMultimap.create();
-        List<BazelBuildError> remainingErrors = new LinkedList<>(errors);
-        for (BazelBuildError error : errors) {
+        Multimap<IProject, BazelProblem> projectToErrors = HashMultimap.create();
+        List<BazelProblem> remainingErrors = new LinkedList<>(errors);
+        for (BazelProblem error : errors) {
             BazelLabel owningLabel = error.getOwningLabel(labelToProject.keySet());
             if (owningLabel != null) {
                 IProject project = labelToProject.get(owningLabel);
@@ -123,7 +123,7 @@ public class BazelErrorStreamObserver implements OutputStreamObserver {
                             .collect(Collectors.toList()));
             } else {
                 // getting here is a bug - at least log the errors we didn't assign to any project
-                for (BazelBuildError error : remainingErrors) {
+                for (BazelProblem error : remainingErrors) {
                     LOG.error("Unhandled error: " + error);
                 }
             }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelMarkerSupport.java
@@ -43,7 +43,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 
 import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 
 /**
  * Encapsulates Bazel Error Marker logic.
@@ -68,7 +68,7 @@ public class BazelMarkerSupport {
      * @param errors  the errors to publish to the Problems View
      * @param monitor  progress monitor
      */
-    public static void publishToProblemsView(IProject project, Collection<BazelBuildError> errors, IProgressMonitor monitor) {
+    public static void publishToProblemsView(IProject project, Collection<BazelProblem> errors, IProgressMonitor monitor) {
         BazelEclipseProjectSupport.runWithProgress(monitor, new WorkspaceModifyOperation() {
             @Override
             protected void execute(IProgressMonitor monitor) throws CoreException {
@@ -93,8 +93,8 @@ public class BazelMarkerSupport {
         });
     }
     
-    private static void publishProblemMarkersForProject(IProject project, Collection<BazelBuildError> errorDetails) throws CoreException {        
-        for (BazelBuildError errorDetail : errorDetails) {
+    private static void publishProblemMarkersForProject(IProject project, Collection<BazelProblem> errorDetails) throws CoreException {        
+        for (BazelProblem errorDetail : errorDetails) {
             String resourcePath = errorDetail.getResourcePath();
             IResource resource = project.findMember(resourcePath);
             IMarker marker = resource.createMarker(BAZEL_MARKER);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
@@ -74,7 +74,7 @@ import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.config.EclipseProjectBazelTargets;
 import com.salesforce.bazel.eclipse.model.AspectOutputJarSet;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelBuildFile;
 import com.salesforce.bazel.eclipse.model.BazelWorkspace;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
@@ -315,8 +315,8 @@ public class BazelClasspathContainer implements IClasspathContainer {
                 return true;
             }
             EclipseProjectBazelTargets targets = BazelProjectPreferences.getConfiguredBazelTargets(this.eclipseProject.getProject(), false);
-            List<BazelBuildError> details = bazelWorkspaceCmdRunner.runBazelBuild(targets.getConfiguredTargets(), null, Collections.emptyList(), null, null);
-            for (BazelBuildError detail : details) {
+            List<BazelProblem> details = bazelWorkspaceCmdRunner.runBazelBuild(targets.getConfiguredTargets(), null, Collections.emptyList(), null, null);
+            for (BazelProblem detail : details) {
                 BazelPluginActivator.error(detail.toString());
             }
             return details.isEmpty();

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -30,7 +30,7 @@ import com.salesforce.bazel.eclipse.config.BazelEclipseProjectSupport;
 import com.salesforce.bazel.eclipse.config.BazelProjectPreferences;
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelPackageLocation;
 import com.salesforce.bazel.eclipse.model.projectview.ProjectView;
 import com.salesforce.bazel.eclipse.model.projectview.ProjectViewConstants;
@@ -76,9 +76,9 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
         String projectViewContent = getSourceViewer().getTextWidget().getText();
         ProjectView projectView = new ProjectView(this.rootDirectory, projectViewContent);
         List<BazelPackageLocation> invalidPackages = projectView.getInvalidPackages();
-        Collection<BazelBuildError> problemMarkers = new ArrayList<>();
+        Collection<BazelProblem> problemMarkers = new ArrayList<>();
         for (BazelPackageLocation invalidPackage : invalidPackages) {
-            problemMarkers.add(new BazelBuildError(PROJECT_VIEW_RESOURCE, projectView.getLineNumber(invalidPackage),
+            problemMarkers.add(new BazelProblem(PROJECT_VIEW_RESOURCE, projectView.getLineNumber(invalidPackage),
                 "Bad Bazel Package: " + invalidPackage.getBazelPackageFSRelativePath()));
         }
         BazelMarkerSupport.clearProblemMarkersForProject(this.rootProject, getProgressMonitor());

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelErrorStreamObserverTest.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.junit.Test;
 
 import com.google.common.collect.Multimap;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelLabel;
 
 public class BazelErrorStreamObserverTest {
@@ -25,28 +25,28 @@ public class BazelErrorStreamObserverTest {
     public void testAssignErrorsToOwningProject() throws Exception {
         IProject project1 = getMockedProject("P1").getProject();
         BazelLabel l1 = new BazelLabel("projects/libs/lib1:*");
-        BazelBuildError error1 = new BazelBuildError("projects/libs/lib1/src/Test.java", 21, "foo");
+        BazelProblem error1 = new BazelProblem("projects/libs/lib1/src/Test.java", 21, "foo");
         IProject project2 = getMockedProject("P2").getProject();
         BazelLabel l2 = new BazelLabel("projects/libs/lib2:*");
-        BazelBuildError error2 = new BazelBuildError("projects/libs/lib2/src/Test2.java", 22, "blah");
+        BazelProblem error2 = new BazelProblem("projects/libs/lib2/src/Test2.java", 22, "blah");
         Map<BazelLabel, IProject> labelToProject = new HashMap<>();
         labelToProject.put(l1, project1);
         labelToProject.put(l2, project2);
         IProject rootProject = getMockedProject("ROOT").getProject();
 
-        Multimap<IProject, BazelBuildError> projectToErrors =
+        Multimap<IProject, BazelProblem> projectToErrors =
                 BazelErrorStreamObserver.assignErrorsToOwningProject(Arrays.asList(error1, error2), labelToProject, rootProject);
 
         assertEquals(2, projectToErrors.size());
-        Collection<BazelBuildError> p1Errors = projectToErrors.get(project1);
+        Collection<BazelProblem> p1Errors = projectToErrors.get(project1);
         assertEquals(1, p1Errors.size());
-        BazelBuildError p1Error = p1Errors.iterator().next();
+        BazelProblem p1Error = p1Errors.iterator().next();
         assertEquals("/src/Test.java", p1Error.getResourcePath());
         assertEquals(21, p1Error.getLineNumber());
         assertEquals("foo", p1Error.getDescription());
-        Collection<BazelBuildError> p2Errors = projectToErrors.get(project2);
+        Collection<BazelProblem> p2Errors = projectToErrors.get(project2);
         assertEquals(1, p2Errors.size());
-        BazelBuildError p2Error = p2Errors.iterator().next();
+        BazelProblem p2Error = p2Errors.iterator().next();
         assertEquals("/src/Test2.java", p2Error.getResourcePath());
         assertEquals(22, p2Error.getLineNumber());
         assertEquals("blah", p2Error.getDescription());
@@ -56,17 +56,17 @@ public class BazelErrorStreamObserverTest {
     public void testUnassignedErrors() throws Exception {
         IProject project1 = getMockedProject("P1").getProject();
         BazelLabel l1 = new BazelLabel("projects/libs/lib1:*");
-        BazelBuildError error1 = new BazelBuildError("projects/libs/lib1/src/Test.java", 21, "foo");
+        BazelProblem error1 = new BazelProblem("projects/libs/lib1/src/Test.java", 21, "foo");
         Map<BazelLabel, IProject> labelToProject = Collections.singletonMap(l1, project1);
-        BazelBuildError error2 = new BazelBuildError("projects/libs/lib2/src/Test2.java", 22, "blah");
+        BazelProblem error2 = new BazelProblem("projects/libs/lib2/src/Test2.java", 22, "blah");
         IProject rootProject = getMockedProject("ROOT").getProject();
 
-        Multimap<IProject, BazelBuildError> projectToErrors =
+        Multimap<IProject, BazelProblem> projectToErrors =
                 BazelErrorStreamObserver.assignErrorsToOwningProject(Arrays.asList(error1, error2), labelToProject, rootProject);
 
         assertEquals(2, projectToErrors.size());
-        Collection<BazelBuildError> rootLevelErrors = projectToErrors.get(rootProject);
-        BazelBuildError rootError = rootLevelErrors.iterator().next();
+        Collection<BazelProblem> rootLevelErrors = projectToErrors.get(rootProject);
+        BazelProblem rootError = rootLevelErrors.iterator().next();
         assertEquals("/WORKSPACE", rootError.getResourcePath());
         assertEquals(0, rootError.getLineNumber());
         assertTrue(rootError.getDescription().startsWith(BazelErrorStreamObserver.UNKNOWN_PROJECT_ERROR_MSG_PREFIX));

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
@@ -62,7 +62,7 @@ import com.salesforce.bazel.eclipse.logging.LogHelper;
 import com.salesforce.bazel.eclipse.logging.LoggerFacade;
 import com.salesforce.bazel.eclipse.model.AspectPackageInfo;
 import com.salesforce.bazel.eclipse.model.BazelBuildFile;
-import com.salesforce.bazel.eclipse.model.BazelBuildError;
+import com.salesforce.bazel.eclipse.model.BazelProblem;
 import com.salesforce.bazel.eclipse.model.BazelOutputParser;
 import com.salesforce.bazel.eclipse.model.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.eclipse.model.BazelWorkspaceMetadataStrategy;
@@ -423,7 +423,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
      * @throws IOException
      * @throws BazelCommandLineToolConfigurationException
      */
-    public synchronized List<BazelBuildError> runBazelBuild(Set<String> bazelTargets,
+    public synchronized List<BazelProblem> runBazelBuild(Set<String> bazelTargets,
             WorkProgressMonitor progressMonitor, List<String> extraArgs, OutputStreamObserver outputStreamObserver, OutputStreamObserver errorStreamObserver)
             throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         List<String> extraArgsList = ImmutableList.<String> builder().add("build").addAll(this.buildOptions)
@@ -434,7 +434,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
         if (output.isEmpty()) {
             return Collections.emptyList();
         } else {
-            List<BazelBuildError> errorDetails = outputParser.getErrorBazelMarkerDetails(output);
+            List<BazelProblem> errorDetails = outputParser.getErrorBazelMarkerDetails(output);
             getLogger().debug(getClass(),
                 "\n" + String.join("\n", errorDetails.stream().map(d -> d.toString()).collect(Collectors.toList()))
                         + "\n");

--- a/plugin-libs/plugin-model/BUILD
+++ b/plugin-libs/plugin-model/BUILD
@@ -59,11 +59,11 @@ java_test(
 )
 
 java_test(
-    name = "BazelBuildErrorTest",
+    name = "BazelProblemTest",
     srcs = [
         "src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildError.java",
-        "src/test/java/com/salesforce/bazel/eclipse/model/BazelBuildErrorTest.java",
+        "src/main/java/com/salesforce/bazel/eclipse/model/BazelProblem.java",
+        "src/test/java/com/salesforce/bazel/eclipse/model/BazelProblemTest.java",
     ],
 )
 
@@ -81,7 +81,7 @@ java_test(
     name = "BazelOutputParserTest",
     srcs = [
         "src/main/java/com/salesforce/bazel/eclipse/model/BazelLabel.java",
-        "src/main/java/com/salesforce/bazel/eclipse/model/BazelBuildError.java",
+        "src/main/java/com/salesforce/bazel/eclipse/model/BazelProblem.java",
         "src/main/java/com/salesforce/bazel/eclipse/model/BazelOutputParser.java",
         "src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java",
     ],

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelOutputParser.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelOutputParser.java
@@ -49,8 +49,8 @@ public class BazelOutputParser {
     private String errorSourcePathLine = null;
     private String moreDetailsLine = null;
 
-    public List<BazelBuildError> getErrorBazelMarkerDetails(String latestLine) {
-        List<BazelBuildError> allBazelMarkerDetails = new ArrayList<>();
+    public List<BazelProblem> getErrorBazelMarkerDetails(String latestLine) {
+        List<BazelProblem> allBazelMarkerDetails = new ArrayList<>();
         String line = latestLine.trim();
         if (this.parsingErrors) {
             if (line.isEmpty()) {
@@ -101,20 +101,20 @@ public class BazelOutputParser {
         return allBazelMarkerDetails;
     }
     
-    public List<BazelBuildError> getErrorBazelMarkerDetails(List<String> lines) {
+    public List<BazelProblem> getErrorBazelMarkerDetails(List<String> lines) {
         this.parsingErrors = false;
         this.errorSourcePathLine = null;
         this.moreDetailsLine = null;
-        List<BazelBuildError> allBazelMarkerDetails = new ArrayList<>();
+        List<BazelProblem> allBazelMarkerDetails = new ArrayList<>();
         for (String line : lines) {
-            List<BazelBuildError> bazelMarkerDetails = getErrorBazelMarkerDetails(line);
+            List<BazelProblem> bazelMarkerDetails = getErrorBazelMarkerDetails(line);
             allBazelMarkerDetails.addAll(bazelMarkerDetails);
         }
 
         return allBazelMarkerDetails;
     }
 
-    private BazelBuildError buildErrorDetails(String errorSourcePathLine, String moreDetailsLine) {
+    private BazelProblem buildErrorDetails(String errorSourcePathLine, String moreDetailsLine) {
         int i = errorSourcePathLine.lastIndexOf(JAVA_FILE_PATH_SUFFX);
         String sourcePath = errorSourcePathLine.substring(0, i + JAVA_FILE_PATH_SUFFX.length());
         i = errorSourcePathLine.indexOf(":", sourcePath.length());
@@ -130,7 +130,7 @@ public class BazelOutputParser {
         if (moreDetailsLine != null) {
             description += ": " + moreDetailsLine;
         }
-        return new BazelBuildError(sourcePath, lineNumber, description);
+        return new BazelProblem(sourcePath, lineNumber, description);
     }
 
     private boolean isInitialErrorSourcePathLine(String line) {

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelProblem.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/BazelProblem.java
@@ -38,25 +38,25 @@ import java.util.Collection;
 import java.util.Objects;
 
 /**
- * This class holds parsed Bazel error output.
+ * A wrapper for a Bazel "problem" (error/warning).
  *
  * @author nishant.dsouza
  * @since 5/3/2019
  */
-public class BazelBuildError {
+public class BazelProblem {
 
     private final String resourcePath;
     private final int lineNumber;
     private final String description;
 
-    public BazelBuildError(String resourcePath, int lineNumber, String description) {
+    public BazelProblem(String resourcePath, int lineNumber, String description) {
         this.resourcePath = Objects.requireNonNull(resourcePath);
         this.lineNumber = lineNumber;
         this.description = Objects.requireNonNull(description);
     }
 
     /**
-     * Returns the matching BazelLabel for this error's resourcePath.
+     * Returns the matching BazelLabel for this problem's resourcePath.
      *
      * @param labels  all BazelLabel instances to consider
      * @return the matching BazelLabel, null if no match is found
@@ -88,16 +88,16 @@ public class BazelBuildError {
         return lineNumber;
     }
 
-    public BazelBuildError toErrorWithRelativizedResourcePath(BazelLabel label) {
+    public BazelProblem toErrorWithRelativizedResourcePath(BazelLabel label) {
         String rel = getRelativeResourcePath(label);
         if (rel == null) {
             throw new IllegalArgumentException("Unable to build a relative path for " + resourcePath + " based on label " + label);
         }
-        return new BazelBuildError(rel, this.lineNumber, description);
+        return new BazelProblem(rel, this.lineNumber, description);
     }
 
-    public BazelBuildError toGenericWorkspaceLevelError(String descriptionPrefix) {
-        return new BazelBuildError(File.separator + "WORKSPACE", 0, descriptionPrefix + resourcePath + " " + description);
+    public BazelProblem toGenericWorkspaceLevelError(String descriptionPrefix) {
+        return new BazelProblem(File.separator + "WORKSPACE", 0, descriptionPrefix + resourcePath + " " + description);
     }
 
     @Override

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelOutputParserTest.java
@@ -51,7 +51,7 @@ public class BazelOutputParserTest {
             "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:50: error: cannot find symbol",
             "    this.numSeeds = numSeeds;");
 
-        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+        List<BazelProblem> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(1, errors.size());
         assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
@@ -70,7 +70,7 @@ public class BazelOutputParserTest {
             "sayhello/src/main/java/com/blah/foo/hello/Main.java:17: error: cannot find symbols",
             "INFO: Elapsed time: 0.196s, Critical Path: 0.03s");
 
-        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+        List<BazelProblem> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(2, errors.size());
         assertEquals("sayhello/src/main/java/com/blah/foo/hello/Main.java", errors.get(0).getResourcePath());
@@ -94,7 +94,7 @@ public class BazelOutputParserTest {
             "  private String species\n",
             "                        ^");
 
-        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+        List<BazelProblem> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(2, errors.size());
         assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
@@ -117,7 +117,7 @@ public class BazelOutputParserTest {
             "    this.species = species",
             "                        ^");
 
-        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+        List<BazelProblem> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(3, errors.size());
         assertEquals("projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java", errors.get(0).getResourcePath());
@@ -138,7 +138,7 @@ public class BazelOutputParserTest {
             "ERROR: this is just a string that we should probably handle but we don't right now"
         );                
 
-        List<BazelBuildError> errors = p.getErrorBazelMarkerDetails(lines);
+        List<BazelProblem> errors = p.getErrorBazelMarkerDetails(lines);
 
         assertEquals(0, errors.size());
     }

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelProblemTest.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/BazelProblemTest.java
@@ -40,11 +40,11 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-public class BazelBuildErrorTest {
+public class BazelProblemTest {
 
     @Test
     public void getOwningLabel__matchingLabel() {
-        BazelBuildError details = new BazelBuildError("a/b/c/d", 1, "desc");
+        BazelProblem details = new BazelProblem("a/b/c/d", 1, "desc");
         BazelLabel l1 = new BazelLabel("x/y/z");
         BazelLabel l2 = new BazelLabel("a/b/c");
 
@@ -55,7 +55,7 @@ public class BazelBuildErrorTest {
 
     @Test
     public void getOwningLabel__nestedLabel() {
-        BazelBuildError details = new BazelBuildError("a/b/c/d/e", 1, "desc");
+        BazelProblem details = new BazelProblem("a/b/c/d/e", 1, "desc");
         BazelLabel l0 = new BazelLabel("b/c/d");
         BazelLabel l1 = new BazelLabel("a/b");
         BazelLabel l2 = new BazelLabel("a/b/c");
@@ -70,8 +70,8 @@ public class BazelBuildErrorTest {
 
     @Test
     public void toErrorWithRelativizedResourcePath__matchingBazelPackage() {
-        BazelBuildError details =
-                new BazelBuildError("projects/libs/cake/abstractions/src/main/java/com/MyClass.java", 1, "desc");
+        BazelProblem details =
+                new BazelProblem("projects/libs/cake/abstractions/src/main/java/com/MyClass.java", 1, "desc");
 
         details = details.toErrorWithRelativizedResourcePath(new BazelLabel("//projects/libs/cake/abstractions"));
 
@@ -80,7 +80,7 @@ public class BazelBuildErrorTest {
 
     @Test
     public void toErrorWithRelativizedResourcePath__rootPackage() {
-        BazelBuildError details = new BazelBuildError("/bazelproject", 1, "desc");
+        BazelProblem details = new BazelProblem("/bazelproject", 1, "desc");
 
         details = details.toErrorWithRelativizedResourcePath(new BazelLabel("//..."));
 
@@ -89,15 +89,15 @@ public class BazelBuildErrorTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void toErrorWithRelativizedResourcePath__matchingBazelPackagePrefix() {
-        BazelBuildError details =
-                new BazelBuildError("projects/libs/cake/abstractions_foo/src/main/java/com/MyClass.java", 1, "desc");
+        BazelProblem details =
+                new BazelProblem("projects/libs/cake/abstractions_foo/src/main/java/com/MyClass.java", 1, "desc");
 
         details.toErrorWithRelativizedResourcePath(new BazelLabel("//projects/libs/cake/abstractions"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void toErrorWithRelativizedResourcePath__differentBazelPackage() {
-        BazelBuildError details = new BazelBuildError(
+        BazelProblem details = new BazelProblem(
                 "projects/libs/cake/metrics-abstractions/src/main/java/com/MyClass.java", 1, "desc");
 
         details.toErrorWithRelativizedResourcePath(new BazelLabel("projects/libs/cake/abstractions"));
@@ -105,9 +105,9 @@ public class BazelBuildErrorTest {
 
     @Test
     public void toGenericWorkspaceLevelError() {
-        BazelBuildError details = new BazelBuildError("a/b/c", 13, "desc");
+        BazelProblem details = new BazelProblem("a/b/c", 13, "desc");
 
-        BazelBuildError generic = details.toGenericWorkspaceLevelError("prefix:");
+        BazelProblem generic = details.toGenericWorkspaceLevelError("prefix:");
 
         assertEquals(0, generic.getLineNumber());
         assertEquals("/WORKSPACE", generic.getResourcePath());


### PR DESCRIPTION
I want to re-use BazelBuildError for publishing JDT warnings to the problems view (yes, I am still looking into that!), so I renamed it to BazelProblem.