### PR TITLE
improve accuracy of bazel command level testing

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -273,6 +273,13 @@ public class BazelPluginActivator extends AbstractUIPlugin {
         return javaCoreHelper;
     }
     
+    /**
+     * Provides details of the operating environment (OS, real vs. tests, etc)
+     */
+    public OperatingEnvironmentDetectionStrategy getOperatingEnvironmentDetectionStrategy() {
+        return osEnvStrategy;
+    }
+    
     // LOGGING
     
     /**

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
@@ -223,6 +223,9 @@ public class BazelClasspathContainerFTest {
         javalib1_IProject = mockEclipse.getImportedProject("javalib1");
         javalib1_IJavaProject = BazelPluginActivator.getJavaCoreHelper().getJavaProjectForProject(javalib1_IProject);
         
+        assertTrue(mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdPackages.size() == 4);
+//        assertTrue(mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdTargets.size() == 4);
+        
         return mockEclipse;
     }
     

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockJavaCoreHelper.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockJavaCoreHelper.java
@@ -76,10 +76,13 @@ public class MockJavaCoreHelper implements JavaCoreHelper {
     public IClasspathEntry[] getResolvedClasspath(IJavaProject javaProject, boolean ignoreUnresolvedEntry) {
         try {
             return javaProject.getResolvedClasspath(ignoreUnresolvedEntry);
+        } catch (RuntimeException anyE) {
+            anyE.printStackTrace();
+            throw anyE;
         } catch (Exception anyE) {
             anyE.printStackTrace();
+            throw new RuntimeException(anyE);
         }
-        return null;
     }
 
     @Override

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockOperatingEnvironmentDetectionStrategy.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockOperatingEnvironmentDetectionStrategy.java
@@ -16,4 +16,17 @@ public class MockOperatingEnvironmentDetectionStrategy implements OperatingEnvir
         return osName;
     }
 
+    /**
+     * When running inside a tool (like an IDE) we sometimes want to handle errors and try to soldier on
+     * even if something went awry. In particular, situations where timing issues impact an operation, 
+     * the operation may get rerun a little later and succeed. 
+     * <p>
+     * But when we are running tests we want to be strict and fail on failures. This boolean should be set to
+     * true when we are running tests.
+     */
+    @Override
+    public boolean isTestRuntime() {
+        return true;
+    }
+
 }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/BazelLauncherBuilderTest.java
@@ -53,7 +53,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildRunCommand() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_BINARY;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -61,17 +61,17 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyList());
 
-        addBazelCommandOutput(env, 0, "bazel-bin/a/b/c/c", "fake bazel launcher script result");
+        addBazelCommandOutput(env, 0, "bazel-bin/projects/libs/javalib0/javalib0", "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
-        assertEquals("bazel-bin/a/b/c/c", cmdTokens.get(0));
+        assertEquals("bazel-bin/projects/libs/javalib0/javalib0", cmdTokens.get(0));
         assertFalse(cmdTokens.contains("debug"));
     }
 
     @Test
     public void testBuildRunCommandWithDebug() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_BINARY;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -80,18 +80,18 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyList());
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
 
-        addBazelCommandOutput(env, 0, "bazel-bin/a/b/c/c", "fake bazel launcher script result");
+        addBazelCommandOutput(env, 0, "bazel-bin/projects/libs/javalib0/javalib0", "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
-        assertEquals("bazel-bin/a/b/c/c", cmdTokens.get(0));
+        assertEquals("bazel-bin/projects/libs/javalib0/javalib0", cmdTokens.get(0));
         assertFalse(cmdTokens.contains("debug=" + DEBUG_PORT));
     }
 
     @Test
     public void testBuildTestCommand() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_TEST;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -112,7 +112,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildSeleniumTestCommand() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_WEB_TEST_SUITE;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -133,7 +133,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildTestCommandWithFilter() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_TEST;
         List<String> bazelArgs =
                 Collections.singletonList(BazelCommandArgs.TEST_FILTER.getName() + "=someBazelTestFilter");
@@ -157,7 +157,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildTestCommandWithDebugEnabled() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//a/b/c");
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0");
         TargetKind targetKind = TargetKind.JAVA_TEST;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockBuildCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockBuildCommand.java
@@ -17,50 +17,82 @@ import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 public class MockBuildCommand extends MockCommand {
 
     public MockBuildCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         if (commandTokens.size() < 3) {
             // this is just 'bazel build' without a target, which is not valid, blow up here as there is something wrong in the calling code
             throw new IllegalArgumentException("The plugin issued the command 'bazel build' without a third arg. This is not a valid bazel command.");
         }
-
-        List<MockCommandSimulatedOutput> simulatedOutputLines = new ArrayList<>();
         
-        // stdout is used to print diagnostics, and stderr is a line per path to an aspect json file
+        // check that the target (e.g. projects/libs/javalib0) is valid relative to our test workspace
+        String target = findBazelTargetInArgs();
+        if (!isValidBazelTarget(target)) {
+            errorLines = Arrays.asList(new String[] { "ERROR: no such package '"+target+"': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.", 
+                    "- /fake/path/"+target });
+            return;
+        }
+        
+        // We have two major types of builds:
+        //  - generating the aspect json files
+        //  - code builds
+        // We will fork based on build type...
+        if (commandTokens.get(2).contains("local_eclipse_aspect")) {
+            createAspectBuildCommand();
+        } else {
+            createCodeBuildCommand();
+        }
+    }
+    
+    /**
+     * When the aspect build is run, the output lists the paths to all of the aspect files written
+     * to disk. To simulate the aspect command output, the MockBuildCommand needs to know the list of aspect file paths
+     * that are in the workspace. 
+     * <p>
+     * We need to use a Set of paths because the same aspect (ex. slf4j-api) will be used by multiple
+     * mock bazel packages, so we need to make sure we only list each once
+     */
+    void createAspectBuildCommand() {
+        List<MockCommandSimulatedOutput> simulatedOutputLines = new ArrayList<>();
+        // TODO this aspect code here is indirect, it should just populate out/err lines directly
+        // TODO clean up "Problem adding jar to project" errors seen when running tests from Eclipse, seems to be during aspect phase
+        // stderr is a line per path to an aspect json file
+        
+        // build command looks like: bazel build --override_repository=local_eclipse_aspect=/tmp/bef/bazelws/bazel-workspace/tools/aspect ...
+        MockCommandSimulatedOutputMatcher aspectCommandMatcher1 = new MockCommandSimulatedOutputMatcher(1, "build");
+        MockCommandSimulatedOutputMatcher aspectCommandMatcher2 = new MockCommandSimulatedOutputMatcher(2, ".*local_eclipse_aspect.*");
+        
+        for (String packagePath : testWorkspaceFactory.workspaceDescriptor.aspectFileSets.keySet()) {
+            // the last arg is the package path with the wildcard target (//projects/libs/javalib0:*)
+            String wildcardTarget = "//"+packagePath+":.*"; // TODO this is returning the same set of aspects for each target in a package
+            MockCommandSimulatedOutputMatcher aspectCommandMatcher3 = new MockCommandSimulatedOutputMatcher(7, wildcardTarget);
+
+            List<MockCommandSimulatedOutputMatcher> matchers = new ArrayList<>();
+            Collections.addAll(matchers, aspectCommandMatcher1, aspectCommandMatcher2, aspectCommandMatcher3);
+    
+            List<String> aspectFilePathsList = new ArrayList<>();
+            aspectFilePathsList.addAll(testWorkspaceFactory.workspaceDescriptor.aspectFileSets.get(packagePath));
+            String nameForLog = "Aspect file set for target: "+wildcardTarget;
+            MockCommandSimulatedOutput aspectOutput = new MockCommandSimulatedOutput(nameForLog, outputLines, aspectFilePathsList, matchers);
+            simulatedOutputLines.add(aspectOutput);
+        }
+        for (MockCommandSimulatedOutput candidateOutput: simulatedOutputLines) {
+            if (candidateOutput.doesMatch(commandTokens)) {
+                // the output is targeted to this command
+                outputLines = candidateOutput.outputLines;
+                errorLines = candidateOutput.errorLines;
+                break;
+            }
+        }
+    }
+    
+    void createCodeBuildCommand() {
+        List<MockCommandSimulatedOutput> simulatedOutputLines = new ArrayList<>();
+
+        // stdout is used to print diagnostics
+        // assume the build will succeed and pre-set the stdout message (something further down may set this differently though)
+        // note the time, target count, and action count are all static; if you want to write tests that inspect those values you have a lot of work to do here
         outputLines = Arrays.asList(new String[] { "INFO: Analyzed 19 targets (0 packages loaded, 1 target configured).", "INFO: Found 19 targets...",
                 "INFO: Elapsed time: 0.146s, Critical Path: 0.00s", "INFO: Build completed successfully, 1 total action" });
-        
-        /**
-         * When the aspect build is run, the output lists the paths to all of the aspect files written
-         * to disk. To simulate the aspect command output, the MockBuildCommand needs to know the list of aspect file paths
-         * that are in the workspace. 
-         * <p>
-         * We need to use a Set of paths because the same aspect (ex. slf4j-api) will be used by multiple
-         * mock bazel packages, so we need to make sure we only list each once
-         */
-        // add Aspect build lines
-        if (commandTokens.get(2).contains("local_eclipse_aspect")) {
-            // build command looks like: bazel build --override_repository=local_eclipse_aspect=/tmp/bef/bazelws/bazel-workspace/tools/aspect ...
-            MockCommandSimulatedOutputMatcher aspectCommandMatcher1 = new MockCommandSimulatedOutputMatcher(1, "build");
-            MockCommandSimulatedOutputMatcher aspectCommandMatcher2 = new MockCommandSimulatedOutputMatcher(2, ".*local_eclipse_aspect.*");
-            
-            for (String packagePath : testWorkspaceFactory.workspaceDescriptor.aspectFileSets.keySet()) {
-                // the last arg is the package path with the wildcard target (//projects/libs/javalib0:*)
-                String wildcardTarget = "//"+packagePath+":.*"; // TODO this is returning the same set of aspects for each target in a package
-                MockCommandSimulatedOutputMatcher aspectCommandMatcher3 = new MockCommandSimulatedOutputMatcher(7, wildcardTarget);
-    
-                List<MockCommandSimulatedOutputMatcher> matchers = new ArrayList<>();
-                Collections.addAll(matchers, aspectCommandMatcher1, aspectCommandMatcher2, aspectCommandMatcher3);
-        
-                List<String> aspectFilePathsList = new ArrayList<>();
-                aspectFilePathsList.addAll(testWorkspaceFactory.workspaceDescriptor.aspectFileSets.get(packagePath));
-                String nameForLog = "Aspect file set for target: "+wildcardTarget;
-                MockCommandSimulatedOutput aspectOutput = new MockCommandSimulatedOutput(nameForLog, outputLines, aspectFilePathsList, matchers);
-                simulatedOutputLines.add(aspectOutput);
-            }
-            // TODO this aspect code here is indirect, it should just populate out/err lines directly
-            // TODO clean up "Problem adding jar to project" errors seen when running tests from Eclipse, seems to be during aspect phase
-        } 
         
         // TODO derive build output from test workspace structure
         // TODO allow testOptions to determine that a package build should fail
@@ -74,5 +106,4 @@ public class MockBuildCommand extends MockCommand {
             }
         }
     }
-    
 }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockCleanCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockCleanCommand.java
@@ -12,7 +12,7 @@ import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 public class MockCleanCommand extends MockCommand {
 
     public MockCleanCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         addSimulatedOutputToCommandStdOut("INFO: Starting clean.");
     }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockCustomCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockCustomCommand.java
@@ -18,7 +18,7 @@ public class MockCustomCommand extends MockCommand {
      */
     public MockCustomCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory,
             List<MockCommandSimulatedOutput> simulatedOutputLinesProvidedByTest) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         boolean handled = false;
         for (MockCommandSimulatedOutput candidateOutput: simulatedOutputLinesProvidedByTest) {

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockInfoCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockInfoCommand.java
@@ -12,7 +12,7 @@ import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 public class MockInfoCommand extends MockCommand {
 
     public MockInfoCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         if (commandTokens.size() < 3) {
             // this is just the generic 'bazel info', which is a legal bazel command but it provides a many line response

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockLauncherCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockLauncherCommand.java
@@ -19,7 +19,7 @@ public class MockLauncherCommand extends MockCommand {
      */
     public MockLauncherCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory,
             List<MockCommandSimulatedOutput> simulatedOutputLinesProvidedByTest) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
 
         boolean handled = false;
         for (MockCommandSimulatedOutput candidateOutput: simulatedOutputLinesProvidedByTest) {
@@ -40,7 +40,5 @@ public class MockLauncherCommand extends MockCommand {
             throw new IllegalStateException("The MockLauncherCommand does not have enough output to provide to simulate the launcher commands. There are "+
                     simulatedOutputLinesProvidedByTest.size()+" outputs configured. Command as received:\n" + commandPretty);
         }
-        
-        // TODO add launcher tests
     }
 }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockQueryCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockQueryCommand.java
@@ -1,5 +1,6 @@
 package com.salesforce.bazel.eclipse.command.mock.type;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -12,20 +13,39 @@ import com.salesforce.bazel.eclipse.test.TestBazelWorkspaceFactory;
 public class MockQueryCommand extends MockCommand {
 
     public MockQueryCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         if (commandTokens.size() < 3) {
             // this is just 'bazel build' without a target, which is not valid, blow up here as there is something wrong in the calling code
-            throw new IllegalArgumentException("The plugin issued the command 'bazel build' without a third arg. This is not a valid bazel command.");
+            throw new IllegalArgumentException("The plugin issued the command 'bazel query' without a third arg. This is not a valid bazel command.");
+        }
+
+        // determine the type of query
+        String queryArg = commandTokens.get(2);
+        if (queryArg.startsWith("kind(rule, //")) {
+            // the only bazel query command we currently invoke has this idiom in the third arg:
+            // kind(rule, //projects/libs/javalib0:*)
+            // strip target to be just '//projects/libs/javalib0:*'
+            String target = queryArg.substring(13, queryArg.length()-1);
+            
+            if (!isValidBazelTarget(target)) {
+                errorLines = Arrays.asList(new String[] { "ERROR: no such package '"+target+"': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.", 
+                        "- /fake/abs/path/"+target });
+                return;
+            }
+            // TODO create simulated query results in a more dynamic way using the test workspace structure
+            if (commandTokens.get(2).contains("javalib0")) {
+                addSimulatedOutputToCommandStdOut("java_test rule //projects/libs/javalib0:javalib0Test");
+                addSimulatedOutputToCommandStdOut("java_library rule //projects/libs/javalib0:javalib0");
+            } else if (commandTokens.get(2).contains("javalib1")) {
+                addSimulatedOutputToCommandStdOut("java_test rule //projects/libs/javalib1:javalib1Test");
+                addSimulatedOutputToCommandStdOut("java_library rule //projects/libs/javalib1:javalib1");
+            }
+            
+        } else {
+            throw new IllegalArgumentException("The plugin issued the command 'bazel query' with an unknown type of query. "+
+                    "The mocking layer (MockQueryCommand) does not know how to simulate a response.");
         }
         
-        // TODO create simulated query results in a more dynamic way using the test workspace structure
-        if (commandTokens.get(2).contains("javalib0")) {
-            addSimulatedOutputToCommandStdOut("java_test rule //projects/libs/javalib0:javalib0Test");
-            addSimulatedOutputToCommandStdOut("java_library rule //projects/libs/javalib0:javalib0");
-        } else if (commandTokens.get(2).contains("javalib1")) {
-            addSimulatedOutputToCommandStdOut("java_test rule //projects/libs/javalib1:javalib1Test");
-            addSimulatedOutputToCommandStdOut("java_library rule //projects/libs/javalib1:javalib1");
-        }
     }
 }

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockTestCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockTestCommand.java
@@ -1,5 +1,6 @@
 package com.salesforce.bazel.eclipse.command.mock.type;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +19,7 @@ public class MockTestCommand extends MockCommand {
     }
 
     public MockTestCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         if (commandTokens.size() < 3) {
             // this is just 'bazel test' without a target, which is not valid, blow up here as there is something wrong in the calling code
@@ -35,6 +36,16 @@ public class MockTestCommand extends MockCommand {
             } else {
                 addSimulatedOutputToCommandStdErr("   'test' options: --explicit_java_test_deps=false");
             }
+            return;
+        } 
+
+        // proceed with an actual test invocation
+        // check that the target (e.g. projects/libs/javalib0) is valid relative to our test workspace
+        String target = findBazelTargetInArgs();
+        if (!isValidBazelTarget(target)) {
+            errorLines = Arrays.asList(new String[] { "ERROR: no such package '"+target+"': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.", 
+                    "- /fake/path/"+target });
+            return;
         }
         
         // TODO pull more bazelrc options from testOptions

--- a/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockVersionCommand.java
+++ b/plugin-libs/plugin-command/src/test/java/com/salesforce/bazel/eclipse/command/mock/type/MockVersionCommand.java
@@ -18,7 +18,7 @@ public class MockVersionCommand extends MockCommand {
     }
 
     public MockVersionCommand(List<String> commandTokens, Map<String, String> testOptions, TestBazelWorkspaceFactory testWorkspaceFactory) {
-        super(commandTokens);
+        super(commandTokens, testOptions, testWorkspaceFactory);
         
         // 1.0.0 is the minimum supported Bazel version currently, tests can tell this mock to return a different value
         String bazelVersion = testOptions.getOrDefault(TESTOPTION_BAZELVERSION, "1.0.0");

--- a/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/OperatingEnvironmentDetectionStrategy.java
+++ b/plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/model/OperatingEnvironmentDetectionStrategy.java
@@ -29,4 +29,17 @@ public interface OperatingEnvironmentDetectionStrategy {
         return operatingSystemFoldername;
     }
     
+    
+    /**
+     * When running inside a tool (like an IDE) we sometimes want to handle errors and try to soldier on
+     * even if something went awry. In particular, situations where timing issues impact an operation, 
+     * the operation may get rerun a little later and succeed. 
+     * <p>
+     * But when we are running tests we want to be strict and fail on failures. This boolean should be set to
+     * true when we are running tests.
+     */
+    default boolean isTestRuntime() {
+        return false;
+    }
+
 }

--- a/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/mock/MockOperatingEnvironmentDetectionStrategy.java
+++ b/plugin-libs/plugin-model/src/test/java/com/salesforce/bazel/eclipse/model/mock/MockOperatingEnvironmentDetectionStrategy.java
@@ -22,4 +22,16 @@ public class MockOperatingEnvironmentDetectionStrategy implements OperatingEnvir
         return osName;
     }
 
+    /**
+     * When running inside a tool (like an IDE) we sometimes want to handle errors and try to soldier on
+     * even if something went awry. In particular, situations where timing issues impact an operation, 
+     * the operation may get rerun a little later and succeed. 
+     * <p>
+     * But when we are running tests we want to be strict and fail on failures. This boolean should be set to
+     * true when we are running tests.
+     */
+    public boolean isTestRuntime() {
+        return true;
+    }
+
 }

--- a/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelPackageDescriptor.java
+++ b/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelPackageDescriptor.java
@@ -1,0 +1,32 @@
+package com.salesforce.bazel.eclipse.test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class TestBazelPackageDescriptor {
+    
+    public TestBazelWorkspaceDescriptor parentWorkspaceDescriptor;
+    
+    // Ex: projects/libs/javalib0  (no leading //, no trailing rule name)
+    public String packagePath;
+    
+    // Ex: javalib0
+    public String packageName;
+    
+    // Ex: /tmp/workspaces/test_workspace1/projects/libs/javalib0
+    public File diskLocation;
+    
+    // Associated targets
+    public Map<String, TestBazelTargetDescriptor> targets = new TreeMap<>();
+    
+    
+    public TestBazelPackageDescriptor(TestBazelWorkspaceDescriptor parentWorkspace, String packagePath, String packageName, File diskLocation) {
+        this.parentWorkspaceDescriptor = parentWorkspace;
+        this.packagePath = packagePath;
+        this.packageName = packageName;
+        this.diskLocation = diskLocation;
+        
+        this.parentWorkspaceDescriptor.createdPackages.put(packagePath, this);
+    }
+}

--- a/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelTargetDescriptor.java
+++ b/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelTargetDescriptor.java
@@ -1,0 +1,26 @@
+package com.salesforce.bazel.eclipse.test;
+
+public class TestBazelTargetDescriptor {
+
+    public TestBazelPackageDescriptor parentPackage;
+    
+    // Ex: projects/libs/javalib0:javalib0
+    public String targetPath;
+    
+    // Ex: javalib0
+    public String targetName;
+    
+    // Ex: java_library
+    public String targetType;
+
+    public TestBazelTargetDescriptor(TestBazelPackageDescriptor parentPackage, String targetName,
+            String targetType) {
+        this.parentPackage = parentPackage;
+        this.targetPath = parentPackage.packagePath + ":" + targetName;
+        this.targetName = targetName;
+        this.targetType = targetType;
+        
+        this.parentPackage.parentWorkspaceDescriptor.createdTargets.put(targetPath, this);
+    }
+    
+}

--- a/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelWorkspaceDescriptor.java
+++ b/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestBazelWorkspaceDescriptor.java
@@ -41,8 +41,22 @@ public class TestBazelWorkspaceDescriptor {
     public File dirBazelBin;            // [outputbase]/execroot/test_workspace/bazel-out/darwin-fastbuild/bin
     public File dirBazelTestLogs;       // [outputbase]/execroot/test_workspace/bazel-out/darwin-fastbuild/testlogs
 
+    
+    // WORKSPACE CATALOGS
+    
     // map of package path (projects/libs/javalib0) to the directory containing the package on the file system
-    public Map<String, File> createdPackages = new TreeMap<>();
+    public Map<String, TestBazelPackageDescriptor> createdPackages = new TreeMap<>();
+    
+    public TestBazelPackageDescriptor getCreatedPackageByName(String packageName) {
+        TestBazelPackageDescriptor desc = createdPackages.get(packageName);
+        if (desc == null) {
+            System.out.println("Test caused a package to be requested that does not exist: "+packageName);
+        }
+        return desc;
+    }
+    
+    // map of target (projects/libs/javalib0:javalib0) to the package (projects/libs/javalib0)
+    public Map<String, TestBazelTargetDescriptor> createdTargets = new TreeMap<>();
     
     // map of package path (projects/libs/javalib0) to the set of absolute paths for the aspect files for the package and deps
     public Map<String, Set<String>> aspectFileSets= new TreeMap<>();

--- a/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestJavaRuleCreator.java
+++ b/plugin-libs/plugin-testdeps/src/main/java/com/salesforce/bazel/eclipse/test/TestJavaRuleCreator.java
@@ -6,35 +6,37 @@ import java.io.PrintStream;
 import java.util.Map;
 
 public class TestJavaRuleCreator {
-    public static void createJavaBuildFile(Map<String, String> commandOptions, File buildFile, String projectName, int projectIndex) 
-            throws Exception {
+    public static void createJavaBuildFile(TestBazelWorkspaceDescriptor workspaceDescriptor, File buildFile, TestBazelPackageDescriptor packageDescriptor) throws Exception {
         try (PrintStream out = new PrintStream(new FileOutputStream(buildFile))) {
             
-            String build_java_library =  createJavaLibraryRule(projectName);
-            String build_java_test = createJavaTestRule(projectName, commandOptions);
+            String build_java_library =  createJavaLibraryRule(packageDescriptor.packageName);
+            new TestBazelTargetDescriptor(packageDescriptor, packageDescriptor.packageName, "java_library");
+            
+            String build_java_test = createJavaTestRule(packageDescriptor.packageName, workspaceDescriptor.testOptions);
+            new TestBazelTargetDescriptor(packageDescriptor, packageDescriptor.packageName+"Test", "java_test");
                         
             out.print(build_java_library+"\n\n"+build_java_test);
         } 
     }
     
     @SuppressWarnings("unused")
-    private static String createJavaBinaryRule(String projectName, int projectIndex) {
+    private static String createJavaBinaryRule(String packageName, int packageIndex) {
         StringBuffer sb = new StringBuffer();
         sb.append("java_binary(\n   name=\"");
-        sb.append(projectName);
+        sb.append(packageName);
         sb.append("\",\n");
         sb.append("   srcs = glob([\"src/main/java/**/*.java\"]),\n");
         sb.append("   resources = [\"src/main/resources/main.properties\"],\n"); // don't glob, to make sure the file exists in the right location
         sb.append("   create_executable = True,\n");
-        sb.append("   main_class = \"com.salesforce.fruit"+projectIndex+".Apple\",\n");
+        sb.append("   main_class = \"com.salesforce.fruit"+packageIndex+".Apple\",\n");
         sb.append(")");
         return sb.toString();
     }
 
-    private static String createJavaLibraryRule(String projectName) {
+    private static String createJavaLibraryRule(String packageName) {
         StringBuffer sb = new StringBuffer();
         sb.append("java_library(\n   name=\"");
-        sb.append(projectName);
+        sb.append(packageName);
         sb.append("\",\n");
         sb.append("   srcs = glob([\"src/main/java/**/*.java\"]),\n");
         sb.append("   visibility = [\"//visibility:public\"],\n");
@@ -42,12 +44,12 @@ public class TestJavaRuleCreator {
         return sb.toString();
     }
     
-    private static String createJavaTestRule(String projectName, Map<String, String> commandOptions) {
+    private static String createJavaTestRule(String packageName, Map<String, String> commandOptions) {
         boolean explicitJavaTestDeps = "true".equals(commandOptions.get("explicit_java_test_deps"));
         
         StringBuffer sb = new StringBuffer();
         sb.append("java_test(\n   name=\"");
-        sb.append(projectName);
+        sb.append(packageName);
         sb.append("Test\",\n");
         sb.append("   srcs = glob([\"src/test/java/**/*.java\"]),\n");
         sb.append("   resources = [\"src/test/resources/test.properties\"],\n"); // don't glob, to make sure the file exists in the right location
@@ -61,10 +63,10 @@ public class TestJavaRuleCreator {
     }
 
     @SuppressWarnings("unused")
-    private static String createSpringBootRule(String projectName, int projectIndex) {
+    private static String createSpringBootRule(String packageName, int projectIndex) {
         StringBuffer sb = new StringBuffer();
         sb.append("springboot(\n   name=\"");
-        sb.append(projectName);
+        sb.append(packageName);
         sb.append("\",\n");
         sb.append("   java_library = \":base_lib\",\n");
         sb.append("   boot_app_class = \"com.salesforce.fruit"+projectIndex+".Apple\",\n");
@@ -73,10 +75,10 @@ public class TestJavaRuleCreator {
     }
 
     @SuppressWarnings("unused")
-    private static String createSpringBootTestRule(String projectName) {
+    private static String createSpringBootTestRule(String packageName) {
         StringBuffer sb = new StringBuffer();
         sb.append("springboot_test(\n   name=\"");
-        sb.append(projectName);
+        sb.append(packageName);
         sb.append("\",\n");
         sb.append("   deps = [],\n");
         sb.append("   srcs = glob([\"src/**/*.java\"]),\n");


### PR DESCRIPTION
- bazel build/test/query mock commands now verify passed package is actually found in the test workspace, which required fixing some tests too
- reworked exception handling in BazelClasspathContainer, we wrap exceptions when running in the IDE to smooth out timing issues and random failures, but now we run in strict mode for tests so critical problems aren't swallowed
- and more