### PR TITLE
reload flushed aspects

### DIFF
--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelBuilderTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/BazelBuilderTest.java
@@ -57,7 +57,7 @@ public class BazelBuilderTest {
     	IProject project = mock(IProject.class);
     	BazelWorkspaceCommandRunner runner = mock(BazelWorkspaceCommandRunner.class);
     	
-    	subject.refreshClasspath(project, null, runner);
+    	subject.refreshProjectClasspath(project, null, null, runner);
     	
     	// Verify the methods we can are called. Each one allows the classpath container
     	// to be refreshed from the current state of the build

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/BazelWorkspaceCommandRunner.java
@@ -506,14 +506,24 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     public synchronized void flushAspectInfoCache(String target) {
         this.aspectHelper.flushAspectInfoCache(target);
     }
-    
+
     /**
      * Clear the AspectPackageInfo cache for the passed targets. This flushes the dependency graph for those targets.
      */
     public synchronized void flushAspectInfoCache(Set<String> targets) {
         this.aspectHelper.flushAspectInfoCache(targets);
     }
-    
+
+    /**
+     * Clear the AspectPackageInfo cache for the passed project name. This flushes the dependency graph for any
+     * target that contains the project name. This is a little sloppy, but over time we plan to revisit all of this
+     * in https://github.com/salesforce/bazel-eclipse/issues/131
+     */
+    public synchronized Set<String>  flushAspectInfoCacheForProject(String projectName) {
+        return this.aspectHelper.flushAspectInfoCacheForProject(projectName);
+    }
+
+
     /**
      * Access to the low level aspect collaborator. Visible for tests.
      */

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/shell/ShellCommand.java
@@ -120,7 +120,7 @@ public final class ShellCommand implements Command {
         for (String arg : args) {
             command = command + arg + " ";
         }
-        System.out.println("Executing command: "+command);
+        System.out.println("Executing command (timeout = "+timeoutMS+"): "+command);
         long startTimeMS = System.currentTimeMillis();
 
         try {


### PR DESCRIPTION
This resolves an issue I would see sometimes after a BUILD file change or expanding a project node in the project explorer. There is some Eclipse project locking going on, and trying to regenerate the aspect cache can get stuck. So immediately after flushing the targets for a changed BUILD, we regenerate the aspect info before telling Eclipse to refresh the classpath container.