### PR TITLE
fixes found during testing of BUILD refresh

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
@@ -527,12 +527,14 @@ public class BazelClasspathContainer implements IClasspathContainer {
             // to get into an incorrect state that it can't recover from unless eclipse is restarted.
             // The error is thrown by at org.eclipse.jface.viewers.ColumnViewer.checkBusy(ColumnViewer.java:764)
             // asyncExec might help here, but need a display widget to call on
-            // Ignoring the error allows the classpath container to recover and the use does not know
+            // Ignoring the error allows the classpath container to recover and the user does not know
             // there ever was a problem.
             try {
                 projectDescription.setReferencedProjects(updatedRefList.toArray(new IProject[] {}));
                 resourceHelper.setProjectDescription(thisProject, projectDescription);
             } catch(RuntimeException ex) {
+                // potential cause: org.eclipse.core.internal.resources.ResourceException: The resource tree is locked for modifications.
+                // if that is happening in your code path, see ResourceHelper.applyDeferredProjectDescriptionUpdates()
                 System.err.println("Caught RuntimeException updating project: " + thisProject.toString());
                 ex.printStackTrace();
                 continueOrThrow(ex);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/ResourceHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/ResourceHelper.java
@@ -215,9 +215,17 @@ public interface ResourceHelper {
     
     /**
      * Sets the project description object for the passed project.
+     * Returns true if the description is queued for later application using applyDeferredProjectDescriptionUpdates().
      */
-    void setProjectDescription(IProject project, IProjectDescription description);
-    
+    boolean setProjectDescription(IProject project, IProjectDescription description);
+
+    /**
+     * When setProjectDescription() fails, it is likely because the resource tree is locked.
+     * Call this method outside of a locked code path if setProjectDescription() returned true.
+     * It is harmless to call this method if there are no queued updates.
+     */
+    void applyDeferredProjectDescriptionUpdates();
+
     /**
      * Retrieves the scope context for the project.
      */

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
@@ -24,6 +24,8 @@
 package com.salesforce.bazel.eclipse.runtime.impl;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -157,14 +159,47 @@ public class EclipseResourceHelper implements ResourceHelper {
         }
     }
     
-    @Override
-    public void setProjectDescription(IProject project, IProjectDescription description) {
-        try {
-            project.setDescription(description, null);
-        } catch (CoreException ce) {
-            throw new IllegalStateException(ce);
+    private static class DeferredProjectDescriptionUpdate {
+        public IProject project;
+        public IProjectDescription description;
+        public DeferredProjectDescriptionUpdate(IProject project, IProjectDescription description) {
+            this.project = project;
+            this.description = description;
         }
     }
+    private List<DeferredProjectDescriptionUpdate> deferredProjectDescriptionUpdates = new ArrayList<>();
+    
+    @Override
+    public boolean setProjectDescription(IProject project, IProjectDescription description) {
+        boolean needsDeferredApplication = false;
+        try {
+            project.setDescription(description, null);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            // this is likely an issue with the resource tree being locked, so we have to defer this update
+            // but it works for any type of issue
+            deferredProjectDescriptionUpdates.add(new DeferredProjectDescriptionUpdate(project, description));
+            needsDeferredApplication = true;
+        }
+        return needsDeferredApplication;
+    }
+    
+    /**
+     * When setProjectDescription() fails, it is likely because the resource tree is locked.
+     * Call this method outside of a locked code path if setProjectDescription() returned true.
+     */
+    public void applyDeferredProjectDescriptionUpdates() {
+        if (this.deferredProjectDescriptionUpdates.size() == 0) {
+            return;
+        }
+        List<DeferredProjectDescriptionUpdate> updates =  this.deferredProjectDescriptionUpdates;
+        this.deferredProjectDescriptionUpdates = new ArrayList<>();
+        for (DeferredProjectDescriptionUpdate update : updates) {
+            // this could theoretically still fail, but we don't want an infinite retry so let this go if it fails
+            setProjectDescription(update.project, update.description);
+        }
+    }
+    
     
     @Override
     public IScopeContext getProjectScopeContext(IProject project) {

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockResourceHelper.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockResourceHelper.java
@@ -194,7 +194,7 @@ public class MockResourceHelper implements ResourceHelper {
     }
 
     @Override
-    public void setProjectDescription(IProject project, IProjectDescription description) {
+    public boolean setProjectDescription(IProject project, IProjectDescription description) {
         mockDescriptions.put(project.getName(), description);
         
         if (description.getReferencedProjects().length > 0) {
@@ -204,6 +204,16 @@ public class MockResourceHelper implements ResourceHelper {
                 throw new IllegalStateException(anyE);
             }
         }
+        return false;
+    }
+    
+    /**
+     * When setProjectDescription() fails, it is likely because the resource tree is locked.
+     * Call this method outside of a locked code path if setProjectDescription() returned true.
+     */
+    @Override
+    public void applyDeferredProjectDescriptionUpdates() {
+        // the mocking layer does not model locking behaviors of Eclipse
     }
 
     @Override

--- a/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
+++ b/plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelWorkspaceAspectHelper.java
@@ -181,11 +181,10 @@ public class BazelWorkspaceAspectHelper {
     }
 
     /**
-     * Clear the AspectPackageInfo cache for the passed project name. This flushes the dependency graph for any
-     * target that contains the project name. This is a little sloppy, but over time we plan to revisit all of this
-     * in https://github.com/salesforce/bazel-eclipse/issues/131
+     * Clear the AspectPackageInfo cache for the passed package. This flushes the dependency graph for any
+     * target that contains the package name. 
      */
-    public synchronized Set<String> flushAspectInfoCacheForProject(String projectName) {
+    public synchronized Set<String> flushAspectInfoCacheForPackage(String packageName) {
         Set<String> flushedTargets = new LinkedHashSet<>();
         
         // the target may not even be in cache, that is ok, just try to remove it from both current and wildcard caches
@@ -193,7 +192,7 @@ public class BazelWorkspaceAspectHelper {
         Iterator<String> iter = this.aspectInfoCache_current.keySet().iterator();
         while(iter.hasNext()) {
             String key = iter.next();
-            if (key.contains(projectName)) {
+            if (key.contains(packageName)) {
                 flushedTargets.add(key);
                 iter.remove();
             }
@@ -201,7 +200,7 @@ public class BazelWorkspaceAspectHelper {
         iter = this.aspectInfoCache_wildcards.keySet().iterator();
         while(iter.hasNext()) {
             String key = iter.next();
-            if (key.contains(projectName)) {
+            if (key.contains(packageName)) {
                 flushedTargets.add(key);
                 iter.remove();
             }


### PR DESCRIPTION
1. if a change to a BUILD file results in adding a dep from one Eclipse project to another, the Project references are updated in the BazelClasspathContainer. But sometimes the resource tree is locked (not always though), and that change needs to be deferred.
2. our Build error parsing logic could not handle build errors from BUILD file issues. I put in a quick workaround, will file a bug to do it right
3. I moved our BUILD query cache down a layer to be closer to the code that actually runs the bazel queries.