### PR TITLE
doc updates for bazel-java-sdk refactor

### DIFF
--- a/bazel-java-sdk/README.md
+++ b/bazel-java-sdk/README.md
@@ -1,12 +1,8 @@
-## Bazel Eclipse Feature: Model Plugin
+## Bazel Java SDK
 
-In the [architecture](../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across 4 Eclipse plugins.
+In the [architecture](../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across a few Eclipse plugins.
 
 - **plugin-core**: this plugin is the one that is integrated with Eclipse APIs, and contains classes such as the activator
-- **plugin-model**: model objects for the various concepts within the feature
-- **plugin-abstractions**: has plain interfaces to stand in the place of Eclipse APIs
-- **plugin-command**: provides the Bazel command line integration
+- **bazel-java-sdk**: handles model abstractions and command execution for Bazel
 
-### Models
-
-This package contains the simple Java model objects for important concepts in the Bazel Eclipse Feature
+This package contains the SDK.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -95,15 +95,11 @@ It makes sense to look over the fence at the Maven plugins to see how they have 
 
 - [M2Eclipse plugins](https://github.com/eclipse/m2e-core)
 
-### The 4 plugins that compose the Bazel Eclipse Feature
+### The plugins that compose the Bazel Eclipse Feature
 
-Internally, the Bazel Eclipse Feature is implemented using 4 Eclipse plugins.
+Internally, the Bazel Eclipse Feature is implemented using several Eclipse plugins.
 Not only does this separate concerns, but it makes unit testing simpler.
 Only one plugin (the *plugin-core*) has access to Eclipse APIs.
 
 - **plugin-core**: this plugin is the one that is integrated with Eclipse APIs, and contains classes such as the activator
-- **plugin-model**: model objects for the various concepts within the feature
-- **plugin-abstractions**: has plain interfaces to stand in the place of Eclipse APIs
-- **plugin-command**: provides the Bazel command line integration
-
-You can find more documentation of each in the [plugin-core](../../plugin-core) and [plugin-libs](../../plugin-libs) directories.
+- **bazel-java-sdk**: handles model abstractions and command execution for Bazel

--- a/docs/dev/dev_guide.md
+++ b/docs/dev/dev_guide.md
@@ -67,7 +67,7 @@ Follow these steps to begin development of the Bazel Eclipse Feature in the Ecli
 - Launch the Eclipse SDK
 - *File* -> *Import* -> *Existing Project*
 - Select the *bazel-eclipse* folder as the root directory
-- Eclipse should detect that the projects are there, and offer to import projects *Bazel Eclipse Feature*, *plugin-model* and others.
+- Eclipse should detect that the projects are there, and offer to import projects *Bazel Eclipse Feature*, *bazel-java-sdk* and others.
 - Click Finish
 
 :fire: if you see errors or warnings at this point, see the [dev issues page](dev_issues.md)  for help.

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -32,7 +32,7 @@ public void warn(String message, Object... args);
 public void info(String message, Object... args);
 public void debug(String message, Object... args);
 ```
-These methods can be found [here](../../plugin-libs/plugin-model/src/main/java/com/salesforce/bazel/eclipse/logging/LogHelper.java).
+These methods can be found [here](../../bazel-java-sdk/src/main/java/com/salesforce/bazel/eclipse/logging/LogHelper.java).
 
 These methods should be familiar to SLF4j users.
 The ```message```and ```args``` work just like SLF4J where ```{}``` is used to substitute values in the ```args```.

--- a/plugin-core/README.md
+++ b/plugin-core/README.md
@@ -1,11 +1,11 @@
 ## Bazel Eclipse Feature: Core Plugin
 
-In the [architecture](../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across 4 Eclipse plugins.
+In the [architecture](../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across a few Eclipse plugins.
 
 - **plugin-core**: this plugin is the one that is integrated with Eclipse APIs, and contains classes such as the activator
-- **plugin-model**: model objects for the various concepts within the feature
-- **plugin-abstractions**: has plain interfaces to stand in the place of Eclipse APIs
-- **plugin-command**: provides the Bazel command line integration
+- **bazel-java-sdk**: handles model abstractions and command execution for Bazel
+
+This package contains the core plugin.
 
 ### Eclipse API Integration
 


### PR DESCRIPTION
I sent a handful of big refactor commits directly to master outside of PRs, since the diffs would have been unreadable anyway. This is the resulting doc changes from all of that work.

- collapsed model, abstractions and command plugins into a single bazel-java-sdk plugin

If you are developing BEF (ie. not just using it), and have an Eclipse workspace for it, you will need to re-import your workspace since the structure of BEF is now significantly different.