### PR TITLE
delay updating project def outside of sync block to avoid deadlocks

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
@@ -175,9 +175,9 @@ public class EclipseResourceHelper implements ResourceHelper {
         try {
             project.setDescription(description, null);
         } catch (Exception ex) {
-            ex.printStackTrace();
             // this is likely an issue with the resource tree being locked, so we have to defer this update
             // but it works for any type of issue
+        	BazelPluginActivator.info("Deferring updates to project "+project.getName()+" because workspace is locked.");
             deferredProjectDescriptionUpdates.add(new DeferredProjectDescriptionUpdate(project, description));
             needsDeferredApplication = true;
         }


### PR DESCRIPTION
I saw a classpath deadlock today (not related to the problem marker deadlock). I believe it was caused by updating the project def in the Eclipse workspace inside of a Java synchronized block.

This PR moves the workspace modifying operation outside of the Java synch block. This is not the last word though, I will file an issue to better integrate with Eclipse's WorkManager to avoid these problems.