### PR TITLE
add support for softlinked workspace files

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceInitializer.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceInitializer.java
@@ -55,6 +55,11 @@ public class BazelPreferenceInitializer extends AbstractPreferenceInitializer {
         IPreferenceStore store = BazelPluginActivator.getInstance().getPreferenceStore();
         Properties globalPrefs = loadGlobalPreferences();
         
+        // TODO Instead of doing this manual mapping of global prefs into prefs, which requires an entry
+        // for each new pref, all users of prefs in BEF should not use the prefs store directly but a 
+        // wrapper class that will do this global pref lookup in real time
+        
+        
         // USER FACING PREFS (visible on Prefs page)
         
         String bazelExecLocationFromEnv = BazelExecutableUtil.which("bazel", "/usr/local/bin/bazel");
@@ -65,6 +70,11 @@ public class BazelPreferenceInitializer extends AbstractPreferenceInitializer {
         value = globalPrefs.getProperty(BazelPreferenceKeys.GLOBALCLASSPATH_SEARCH_PREF_NAME, "false");
         store.setDefault(BazelPreferenceKeys.GLOBALCLASSPATH_SEARCH_PREF_NAME, "true".equals(value));
 
+        // FEATURE FLAGS
+        value = globalPrefs.getProperty(BazelPreferenceKeys.DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK, "false");
+        store.setDefault(BazelPreferenceKeys.DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK, "true".equals(value));
+        
+        
         // BEF DEVELOPER PREFS (for efficient repetitive testing of BEF)
         value = globalPrefs.getProperty(BazelPreferenceKeys.BAZEL_DEFAULT_WORKSPACE_PATH_PREF_NAME);
         if (value != null) {

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceKeys.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceKeys.java
@@ -5,6 +5,7 @@ package com.salesforce.bazel.eclipse.preferences;
  */
 public class BazelPreferenceKeys {
     
+    // *********************************************************************
     // USER FACING PREFS (visible on Prefs page)
     
     // path the the bazel executable
@@ -17,6 +18,18 @@ public class BazelPreferenceKeys {
     public static final String EXTERNAL_JAR_CACHE_PATH_PREF_NAME = "EXTERNAL_JAR_CACHE_PATH";
 
     
+    // *********************************************************************
+    // BREAK GLASS PREFS (emergency feature flags to disable certain features in case of issues)
+    // Naming convention: these should all started with the token DISABLE_
+
+    // We support Bazel workspaces in which the WORKSPACE file in the root is actually a soft link to the actual
+    // file in a subdirectory. Due to the way the system Open dialog works, we have to do some sad logic to figure
+    // out this is the case. This flag disables this feature, in case that logic causes problems for some users. 
+    // https://github.com/salesforce/bazel-eclipse/issues/164
+    public static final String DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK = "DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK";
+    
+    
+    // *********************************************************************
     // BEF DEVELOPER PREFS (for efficient repetitive testing of BEF)
     
     // The import wizard will be populated by this path if set, which saves time during repetitive testing of imports

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
@@ -97,7 +98,8 @@ public class BazelImportWizardPage extends WizardPage {
         composite.setLayout(new GridLayout(3, false));
         setControl(composite);
 
-        locationControl = new BazelImportWizardLocationControl(this);
+        IPreferenceStore prefs = BazelPluginActivator.getInstance().getPreferenceStore();
+        locationControl = new BazelImportWizardLocationControl(this, prefs);
         locationControl.addLocationControl(composite);
 
         labelProvider = new BazelImportWizardLabelProvider(this);


### PR DESCRIPTION
This is a worrisome solution for #164. I am not totally comfortable with the solution, but the system Open dialog's behavior does not seem to be configurable. If the WORKSPACE file is a softlink, the Open dialog resolves the soft link to the canonical path. So to support this use case we need to detect that we are in a non-root directory of the Bazel workspace. This could get nasty as Bazel supports nested workspaces, but the solution seems to be ok since it makes sure the found WORKSPACE soft link is pointing to the canonical file identified by the user.

I also added a pref to disable this feature, just in case there is trouble with it. A follow on PR will clean up the prefs stuff, it is a little rough.

