### PR TITLE
allow two bazel packages to have same name in same bazel workspace

### DIFF
--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/ResourceHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/api/ResourceHelper.java
@@ -43,6 +43,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.osgi.service.prefs.Preferences;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
 
 /**
  * Interface for looking up Eclipse Workspace and Project resources, and subcomponents of each.
@@ -64,6 +65,16 @@ public interface ResourceHelper {
      */
     IProject getProjectByName(String projectName);
 
+    /**
+     * Returns the IProject reference for the Bazel Workspace project.
+     */
+    IProject getBazelWorkspaceProject(BazelWorkspace bazelWorkspace);
+
+    /**
+     * Returns the IProjects for the Bazel Workspace project.
+     */
+    IProject[] getProjectsForBazelWorkspace(BazelWorkspace bazelWorkspace);
+    
     /**
      * Creates a new project resource in the workspace using the given project description. Upon successful completion,
      * the project will exist but be closed.

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
@@ -49,6 +49,7 @@ import org.osgi.service.prefs.Preferences;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.config.BazelProjectConstants;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
 
 /**
  * Resource helper implementation used when running in a live Eclipse runtime.
@@ -66,6 +67,28 @@ public class EclipseResourceHelper implements ResourceHelper {
         return getEclipseWorkspaceRoot().getProject(projectName);
     }
 
+    /**
+     * Returns the IProject reference for the Bazel Workspace project.
+     */
+    @Override
+    public IProject getBazelWorkspaceProject(BazelWorkspace bazelWorkspace) {
+        for (IProject candidate : getEclipseWorkspaceRoot().getProjects()) {
+            if (isBazelRootProject(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Returns the IProjects for the Bazel Workspace project.
+     */
+    @Override
+    public IProject[] getProjectsForBazelWorkspace(BazelWorkspace bazelWorkspace) {
+        // todo once we support multiple Bazel workspaces, this will need to figure that out
+        return  getEclipseWorkspaceRoot().getProjects(); 
+    }
+    
     /**
      * Creates the project described by newProject, with the passed description.
      */
@@ -124,7 +147,7 @@ public class EclipseResourceHelper implements ResourceHelper {
     public IWorkspaceRoot getEclipseWorkspaceRoot() {
         return ResourcesPlugin.getWorkspace().getRoot();
     }
-
+    
     @Override
     public String getResourceAbsolutePath(IResource resource) {
         if (resource == null) {

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockResourceHelper.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/MockResourceHelper.java
@@ -47,6 +47,7 @@ import org.osgi.service.prefs.Preferences;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
 
 public class MockResourceHelper implements ResourceHelper {
 
@@ -97,6 +98,22 @@ public class MockResourceHelper implements ResourceHelper {
 
         return project;
     }
+    
+    @Override
+    public IProject getBazelWorkspaceProject(BazelWorkspace bazelWorkspace) {
+        for (IProject candidate : getEclipseWorkspaceRoot().getProjects()) {
+            if (isBazelRootProject(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public IProject[] getProjectsForBazelWorkspace(BazelWorkspace bazelWorkspace) {
+        return mockProjects.values().toArray(new IProject[] {});
+    }
+    
 
     @Override
     public boolean isBazelRootProject(IProject project) {


### PR DESCRIPTION
Fixes Issue #40 . Supports a Bazel workspace with package names that are not unique, like:

- //projects/path1/apple-api/BUILD (java_library target here)
- //projects/path2/apple-api/BUILD (java_library target here)

this would import into Eclipse with Eclipse projects named:
- apple-api
- apple-api2

I also made some small improvements to how we handle incremental imports (import projects into an existing Eclipse workspace).