### PR TITLE
temp solution for PULLER_TIMEOUT, disconnect bazel clean

### DIFF
--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelProcessBuilder.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelProcessBuilder.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.ProcessBuilder.Redirect;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A lightweight wrapper around java.lang.ProcessBuilder. To make functional testing possible where ProcessBuilder
@@ -39,6 +40,16 @@ public class BazelProcessBuilder {
 
     public BazelProcessBuilder(List<String> args) {
         this.innerProcessBuilder = new ProcessBuilder(args);
+    }
+
+    public BazelProcessBuilder(List<String> args, Map<String, String> bazelEnvironmentVariables) {
+        this.innerProcessBuilder = new ProcessBuilder(args);
+        if (bazelEnvironmentVariables != null) {
+            Map<String, String> liveEnvironmentVariables = this.innerProcessBuilder.environment();
+            if (liveEnvironmentVariables != null) {
+                liveEnvironmentVariables.putAll(bazelEnvironmentVariables);
+            }
+        }
     }
 
     /**

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
@@ -178,7 +178,10 @@ public class BazelBuilder extends IncrementalProjectBuilder {
             super.clean(monitor);
         } else {
             bazelWorkspaceCmdRunner.flushAspectInfoCache();
-            bazelWorkspaceCmdRunner.runBazelClean(null);
+            
+            // TODO make a pref to enable a bazel clean, but in almost any circumstance 'bazel clean' is not correct
+            // https://github.com/salesforce/bazel-eclipse/issues/185
+            // bazelWorkspaceCmdRunner.runBazelClean(null);
         }
 
         BazelClasspathContainer.clean();

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
@@ -94,6 +94,10 @@ public class BazelLaunchConfigurationDelegate implements ILaunchConfigurationDel
         String projectName = BazelLaunchConfigAttributes.PROJECT.getStringValue(configuration);
         BazelLabel label = new BazelLabel(BazelLaunchConfigAttributes.LABEL.getStringValue(configuration));
         String targetKindStr = BazelLaunchConfigAttributes.TARGET_KIND.getStringValue(configuration);
+        if (targetKindStr == null) {
+            LOG.error("Target is of unknown type. Cannot create a launcher.");
+            return;
+        }
         BazelTargetKind targetKind = BazelTargetKind.valueOfIgnoresCaseRequiresMatch(targetKindStr);
         IProject project = BazelPluginActivator.getResourceHelper().getProjectByName(projectName);
 


### PR DESCRIPTION
There are a few things going on in this PR, I should have made them separate but each is fairly small.

- Temporary solution for rules_docker download timeouts (PULLER_TIMEOUT env var), with #190 filed to implement a better solution.
- More logging during command execution, which I used to narrow in on the problem for this case, but also some incremental work towards #191 
- Implemented solution for #185 which disconnects Bazel clean from Eclipse clean. I didn't implement the pref yet.
- Fixed an untracked bug for the Launcher UI for projects that have no launchable targets, found during the course of doing other business.