### PR TITLE
Centralize default target definition

### DIFF
--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelWorkspaceCommandRunner.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelWorkspaceCommandRunner.java
@@ -204,6 +204,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     /**
      * Returns the execution root of the current Bazel workspace.
      */
+    @Override
     public File computeBazelWorkspaceExecRoot() {
 
         if (bazelExecRootDirectory == null) {
@@ -257,6 +258,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     /**
      * Returns the output base of the current Bazel workspace.
      */
+    @Override
     public File computeBazelWorkspaceOutputBase() {
         if (bazelOutputBaseDirectory == null) {
             try {
@@ -278,6 +280,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     /**
      * Returns the bazel-bin of the current Bazel workspace.
      */
+    @Override
     public File computeBazelWorkspaceBin() {
         if (bazelBinDirectory == null) {
             try {
@@ -299,6 +302,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
     /**
      * Returns the explicitly set options in the workspace config files (.bazelrc et al)
      */
+    @Override
     public void populateBazelWorkspaceCommandOptions(BazelWorkspaceCommandOptions commandOptions) {
         try {
             ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
@@ -352,14 +356,13 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
      * operation is cached internally, so repeated calls in the same label are cheap.
      * <p>
      *
-     * @param bazelPackageName
-     *            the label path that identifies the package where the BUILD file lives (//projects/libs/foo)
+     * @param labels
+     *            the labels to query
      */
     public synchronized BazelBuildFile queryBazelTargetsInBuildFile(WorkProgressMonitor progressMonitor,
-            String bazelPackageName)
+            Collection<BazelLabel> labels)
             throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
-        return this.bazelQueryHelper.queryBazelTargetsInBuildFile(bazelWorkspaceRootDirectory, progressMonitor,
-            bazelPackageName);
+        return this.bazelQueryHelper.queryBazelTargetsInBuildFile(bazelWorkspaceRootDirectory, progressMonitor, labels);
     }
 
     /**
@@ -518,6 +521,7 @@ public class BazelWorkspaceCommandRunner implements BazelWorkspaceMetadataStrate
      */
     public synchronized Set<String> flushAspectInfoCacheForPackage(String packageName) {
         Set<BazelLabel> flushedPackages = this.aspectHelper.flushAspectInfoCacheForPackage(new BazelLabel(packageName));
+        LOG.info("Flushed aspect cache for packages: " + flushedPackages);
         return flushedPackages.stream().map(BazelLabel::getPackagePath).collect(Collectors.toSet());
     }
 

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelper.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelper.java
@@ -243,7 +243,7 @@ public class BazelWorkspaceAspectHelper {
                 // this could be done in the loop above, but this is good sanity
                 Set<AspectTargetInfo> atis = aspectInfoCache_current.get(label);
                 if (atis == null) {
-                    LOG.warn("ASPECT CACHE BUG target: " + label + getLogStr(label, caller));
+                    LOG.error("ASPECT CACHE BUG target: " + label + getLogStr(label, caller));
                     atis = Collections.emptySet();
                 }
                 resultMap.put(label, atis);

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import com.salesforce.bazel.sdk.aspect.AspectOutputJarSet;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfo;
@@ -138,8 +139,11 @@ public class BazelJvmClasspath {
             // of all targets if configured with the wildcard target
             BazelBuildFile bazelBuildFileModel = null;
             try {
-                bazelBuildFileModel = bazelWorkspaceCmdRunner.queryBazelTargetsInBuildFile(progressMonitor,
-                    this.bazelProjectManager.getBazelLabelForProject(bazelProject));
+                // we pass the targets that are configured for the current project to bazel query
+                // typically, this is a single wildcard target, but the user may
+                // also have specified explicit targets to use
+                List<BazelLabel> labels = configuredTargetsForProject.getConfiguredTargets().stream().map(BazelLabel::new).collect(Collectors.toList());
+                bazelBuildFileModel = bazelWorkspaceCmdRunner.queryBazelTargetsInBuildFile(progressMonitor, labels);
             } catch (Exception anyE) {
                 logger.error("Unable to compute classpath containers entries for project " + bazelProject.name, anyE);
                 return returnEmptyClasspathOrThrow(anyE);

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
@@ -70,9 +70,17 @@ public class BazelLabel {
         } else {
             this.repositoryName = null;
         }
-        label = sanitize(label);
+        label = sanitizeLabel(label);
         this.localLabelPart = label;
         this.fullLabel = getFullLabel(this.repositoryName, this.localLabelPart);
+    }
+
+    /**
+     * Instantiates a BazelLabel instance with the Bazel package path and the label
+     * name specified separately. For example: "a/b/c" and "my-target-name".
+     */
+    public BazelLabel(String packagePath, String targetName) {
+        this(sanitizePackagePath(packagePath) + ":" + sanitizeTargetName(targetName));
     }
 
     /**
@@ -114,7 +122,9 @@ public class BazelLabel {
      * @return true if this instance represents a concrete label, false otherwise
      */
     public boolean isConcrete() {
-        return !this.localLabelPart.endsWith("*") && !this.localLabelPart.endsWith("...");
+        return !(this.localLabelPart.endsWith("*") ||
+               this.localLabelPart.endsWith("...") ||
+               this.localLabelPart.endsWith("all"));
     }
 
     /**
@@ -252,7 +262,29 @@ public class BazelLabel {
             new BazelLabel("@" + repositoryName + "//" + localLabelPart);
     }
 
-    private static String sanitize(String label) {
+    private static String sanitizePackagePath(String path) {
+        if (path == null) {
+            throw new IllegalAccessError(path);
+        }
+        path = path.trim();
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private static String sanitizeTargetName(String target) {
+        if (target == null) {
+            throw new IllegalArgumentException(target);
+        }
+        target = target.strip();
+        if (target.startsWith(":")) {
+            target = target.substring(1);
+        }
+        return target;
+    }
+
+    private static String sanitizeLabel(String label) {
         if (label == null) {
             throw new IllegalArgumentException(label);
         }
@@ -271,6 +303,9 @@ public class BazelLabel {
         }
         if (label.startsWith("//")) {
             label = label.substring(2);
+        }
+        if (label.startsWith("/")) {
+            label = label.substring(1);
         }
         return label;
     }

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
@@ -72,9 +72,9 @@ public class BazelProjectTargets {
 
     // TODO weave these into the constructor
 
-    public void activateWildcardTarget() {
+    public void activateWildcardTarget(String wildcardTarget) {
         this.isActivatedWildcardTarget = true;
-        this.configuredTargets.add(projectBazelLabel + ":*");
+        this.configuredTargets.add(projectBazelLabel + ":" + wildcardTarget);
     }
 
     public void activateSpecificTargets(Set<String> activatedTargets) {
@@ -107,6 +107,11 @@ public class BazelProjectTargets {
 
     public boolean isAllTargetsDeactivated() {
         return this.configuredTargets.size() == 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(getConfiguredTargets());
     }
 
 }

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.util.BazelConstants;
 
 /**
  * The <a href="http://ij.bazel.build/docs/project-views.html">project view</a> file.
@@ -127,7 +128,7 @@ public class ProjectView {
     }
 
     /**
-     * Adds a default target for each directory that does not have one (or more) entries
+     * Adds the default targets for each directory that does not have one (or more) entries
      * in the "targets:" section.
      */
     public void addDefaultTargets() {
@@ -142,12 +143,14 @@ public class ProjectView {
                 }
             }
             if (!foundLabel) {
-                defaultLabels.add(bazelPackage.toPackageWildcardLabel());
+                for (String target : BazelConstants.DEFAULT_PACKAGE_TARGETS) {
+                    defaultLabels.add(new BazelLabel(bazelPackage.getPackagePath(), target));
+                }
             }
         }
         for (BazelLabel dflt : defaultLabels) {
-            // this method is used to adjust internal state, it is ok for the line number is
-            // to be incorrect
+            // since this method is used to adjust internal state, it is ok for the
+            // line number to not be correct.
             targetToLineNumber.put(dflt, 0);
         }
     }
@@ -198,11 +201,13 @@ public class ProjectView {
         int lineNumber = 3;
         for (BazelPackageLocation pack : packages) {
             packageToLineNumber.put(pack, lineNumber);
+            lineNumber += 1;
         }
         // newline
         lineNumber += 1;
         for (BazelLabel target : targets) {
             targetToLineNumber.put(target, lineNumber);
+            lineNumber += 1;
         }
     }
 

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
@@ -1,3 +1,36 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 package com.salesforce.bazel.sdk.util;
 
 import java.util.Arrays;
@@ -7,10 +40,25 @@ import java.util.HashSet;
 
 public interface BazelConstants {
 
+    /**
+     * The Bazel BUILD files BEF looks for.
+     */
     Collection<String> BUILD_FILE_NAMES =
         Collections.unmodifiableSet(
             new HashSet<>(
                 Arrays.asList(
                     new String[]{"BUILD", "BUILD.bazel"})));
+
+    /**
+     * The targets configured by default for each imported Bazel package.
+     */
+    Collection<String> DEFAULT_PACKAGE_TARGETS =
+        Collections.unmodifiableSet(
+            new HashSet<>(
+                Arrays.asList(
+                    // we use "all" instead of "*" because "*" includes implicit
+                    // targets, such as test _deploy jars, which are slow(er) to build
+                    // and not needed by BEF
+                    new String[]{"all"})));
 
 }

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
@@ -1,3 +1,36 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 package com.salesforce.bazel.sdk.util;
 
 import java.io.File;

--- a/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
+++ b/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
@@ -68,9 +68,11 @@ public class BazelLabelTest {
         assertTrue(new BazelLabel("//foo/blah:t1").isConcrete());
         assertFalse(new BazelLabel("blah/...").isConcrete());
         assertFalse(new BazelLabel("blah:*").isConcrete());
+        assertFalse(new BazelLabel("blah:all").isConcrete());
         assertTrue(new BazelLabel("//:query").isConcrete());
         assertFalse(new BazelLabel("//...").isConcrete());
         assertFalse(new BazelLabel("//:*").isConcrete());
+        assertFalse(new BazelLabel("//:all").isConcrete());
         assertTrue(new BazelLabel("@foo//query:t2").isConcrete());
     }
 
@@ -84,6 +86,7 @@ public class BazelLabelTest {
         assertEquals("", new BazelLabel("//:query").getPackagePath());
         assertEquals("", new BazelLabel("//...").getPackagePath());
         assertEquals("", new BazelLabel("//:*").getPackagePath());
+        assertEquals("", new BazelLabel("//:all").getPackagePath());
         assertEquals("a/b/c", new BazelLabel("@foo//a/b/c").getPackagePath());
     }
 
@@ -95,6 +98,15 @@ public class BazelLabelTest {
         assertEquals("//blah", new BazelLabel("blah/...").getDefaultPackageLabel().getLabel());
         assertEquals("//blah", new BazelLabel("blah:*").getDefaultPackageLabel().getLabel());
         assertEquals("@foo//blah/goo", new BazelLabel("@foo//blah/goo:t1").getDefaultPackageLabel().getLabel());
+    }
+
+    @Test
+    public void testInvalidButAcceptableInput() {
+        // we fixup the input for these cases
+        assertEquals("//foo:t1", new BazelLabel("/foo:t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("foo", ":t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("foo/", "t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("/foo/", "t1").getLabel());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -122,9 +134,11 @@ public class BazelLabelTest {
         assertEquals("t1", new BazelLabel("foo/blah:t1").getTargetName());
         assertEquals(null, new BazelLabel("blah/...").getTargetName());
         assertEquals("*", new BazelLabel("blah:*").getTargetName());
+        assertEquals("all", new BazelLabel("blah:all").getTargetName());
         assertEquals("query", new BazelLabel("//:query").getTargetName());
         assertEquals(null, new BazelLabel("//...").getTargetName());
         assertEquals("*", new BazelLabel("//:*").getTargetName());
+        assertEquals("all", new BazelLabel("//:all").getTargetName());
         assertEquals("t1", new BazelLabel("@foo//blah/goo:t1").getTargetName());
     }
 
@@ -153,6 +167,12 @@ public class BazelLabelTest {
         assertEquals("query", new BazelLabel("//:query").getLastComponentOfTargetName());
         assertEquals(null, new BazelLabel("//...").getLastComponentOfTargetName());
         assertEquals("blah", new BazelLabel("@repo//foo:src/foo/blah").getLastComponentOfTargetName());
+    }
+
+    @Test
+    public void testPackageAndTargetCtor() {
+        assertEquals("//a/b/c:foo", new BazelLabel("a/b/c", "foo").getLabel());
+        assertEquals("//a/b/c:foo", new BazelLabel("//a/b/c", "foo").getLabel());
     }
 
     @Test

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
@@ -228,14 +228,15 @@ public class EclipseBazelProjectManager extends BazelProjectManager {
             if (propertyName.startsWith(TARGET_PROPERTY_PREFIX)) {
                 String target = eclipseProjectBazelPrefs.get(propertyName, "");
                 if (!target.isEmpty()) {
-                    if (!target.startsWith(projectLabel)) {
+                    BazelLabel label = new BazelLabel(target);
+                    if (!label.getLabel().startsWith(projectLabel)) {
                         // the user jammed in a label not associated with this project, ignore
                         //continue;
                     }
-                    if (target.endsWith(":*")) {
+                    if (!label.isConcrete()) {
                         // we have a wildcard target, so discard any existing targets we gathered (if the user messed up their prefs)
                         // and just go with that.
-                        activatedTargets.activateWildcardTarget();
+                        activatedTargets.activateWildcardTarget(label.getTargetName());
                         return activatedTargets;
                     }
                     activeTargets.add(target);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectStructureInspector.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectStructureInspector.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.util.BazelConstants;
 import com.salesforce.bazel.sdk.util.BazelPathHelper;
 
 /**
@@ -105,13 +106,10 @@ class EclipseProjectStructureInspector {
         }
 
         if (foundSourceCodePaths) {
-            BazelLabel packageTarget = new BazelLabel(packageNode.getBazelPackageFSRelativePath());
-            if (packageTarget.isPackageDefault()) {
-                // if the label is //foo, we want foo:* so that we pick up all targets in the
-                // BUILD file, instead of only the default package target
-                packageTarget = packageTarget.toPackageWildcardLabel();
+            String packagePath = packageNode.getBazelPackageFSRelativePath();
+            for (String target : BazelConstants.DEFAULT_PACKAGE_TARGETS) {
+                this.bazelTargets.add(new BazelLabel(packagePath, target));
             }
-            this.bazelTargets.add(packageTarget);
         }
     }
 

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -82,11 +82,12 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
         super.editorSaved();
         String projectViewContent = getSourceViewer().getTextWidget().getText();
         ProjectView proposedProjectView = new ProjectView(this.rootDirectory, projectViewContent);
-        proposedProjectView = ProjectViewProcessor.resolvePackages(proposedProjectView);
-        List<BazelPackageLocation> invalidPackages = ProjectViewProcessor.getInvalidDirectories(proposedProjectView);
+        List<BazelPackageLocation> invalidPackages = new ArrayList<>();
+        proposedProjectView = ProjectViewProcessor.resolvePackages(proposedProjectView, invalidPackages);
         List<BazelProblem> problems = new ArrayList<>();
         for (BazelPackageLocation invalidPackage : invalidPackages) {
-            problems.add(BazelProblem.createError(PROJECT_VIEW_RESOURCE, proposedProjectView.getLineNumber(invalidPackage),
+            int lineNumber = proposedProjectView.getLineNumber(invalidPackage);
+            problems.add(BazelProblem.createError(PROJECT_VIEW_RESOURCE, lineNumber,
                 "Bad Bazel Package: " + invalidPackage.getBazelPackageFSRelativePath()));
         }
         markerManager.clearAndPublish(problems, this.rootProject, getProgressMonitor());

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewProcessor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewProcessor.java
@@ -11,47 +11,79 @@ import com.salesforce.bazel.sdk.project.ProjectView;
 import com.salesforce.bazel.sdk.project.ProjectViewPackageLocation;
 import com.salesforce.bazel.sdk.util.BazelDirectoryStructureUtil;
 
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 final class ProjectViewProcessor {
 
     private static final LogHelper LOG = LogHelper.log(ProjectViewProcessor.class);
 
-    static List<BazelPackageLocation> getInvalidDirectories(ProjectView projectView) {
-        List<BazelPackageLocation> invalidDirectories = new ArrayList<>();
+    /**
+     * Expands parent directories in the specified ProjectView to concrete Bazel Packages.
+     *
+     * Populates the given invalidDirectories list with...invalid directories.
+     *
+     * @return Expanded ProjectView, if there are no errors.
+     */
+    static ProjectView resolvePackages(ProjectView projectView, List<BazelPackageLocation> invalidDirectories) {
         File rootDir = projectView.getWorkspaceRootDirectory();
-        for (BazelPackageLocation packageLocation : projectView.getDirectories()) {
-            String packageDir = packageLocation.getBazelPackageFSRelativePath();
-            if (!BazelDirectoryStructureUtil.isBazelPackage(rootDir, packageDir)) {
-                invalidDirectories.add(packageLocation);
-            }
-        }
-        return invalidDirectories;
-    }
-
-    static ProjectView resolvePackages(ProjectView projectView) {
-        File rootDir = projectView.getWorkspaceRootDirectory();
-        List<BazelPackageLocation> updatedDirectories = new ArrayList<>();
+        List<BazelPackageLocation> directories = new ArrayList<>();
+        List<BazelPackageLocation> additionalDirectories = new ArrayList<>();
         for (BazelPackageLocation packageLocation : projectView.getDirectories()) {
 
             String directory = packageLocation.getBazelPackageFSRelativePath();
             if (BazelDirectoryStructureUtil.isBazelPackage(rootDir, directory)) {
                 // no change, just add the same package
-                updatedDirectories.add(packageLocation);
+                directories.add(packageLocation);
             } else {
                 // look for BUILD files below this location
                 List<String> additionalPackages = BazelDirectoryStructureUtil.findBazelPackages(rootDir, directory);
                 LOG.info("Found " + additionalPackages.size() + " packages under " + directory);
                 if (additionalPackages.isEmpty()) {
-                    // add the original directory back, it will get flagged as invalid
-                    updatedDirectories.add(packageLocation);
+                    invalidDirectories.add(packageLocation);
                 } else {
-                    updatedDirectories.addAll(
+                    additionalDirectories.addAll(
                         additionalPackages.stream()
                             .map(p -> new ProjectViewPackageLocation(rootDir, p))
                             .collect(Collectors.toList()));
                 }
             }
         }
-        return new ProjectView(rootDir, updatedDirectories, projectView.getTargets());
+        directories.addAll(additionalDirectories);
+
+        return invalidDirectories.isEmpty() ?
+            new ProjectView(rootDir, directories, projectView.getTargets()) :
+            projectView;
     }
 
 }


### PR DESCRIPTION
I tried to remove hardcoding of the "\*" target.  Also, I switched "\*" to "all", which doesn't include implicit targets (such as _deploy jars). 