### PR TITLE
Centralize default target definition, eager bazel query #131

### DIFF
--- a/bzl-java-sdk/BUILD
+++ b/bzl-java-sdk/BUILD
@@ -63,6 +63,15 @@ java_test(
 )
 
 java_test(
+    name = "BazelLabelUtilTest",
+    srcs = [
+        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
+        "src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java",
+        "src/test/java/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java",
+    ],
+)
+
+java_test(
     name = "BazelProblemTest",
     srcs = [
         "src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java",
@@ -149,6 +158,7 @@ java_test(
         "src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java",
         "src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java",
         "src/test/java/com/salesforce/bazel/sdk/project/ProjectViewTest.java",
+        "src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java",
     ],
 )
 

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelper.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelper.java
@@ -243,7 +243,7 @@ public class BazelWorkspaceAspectHelper {
                 // this could be done in the loop above, but this is good sanity
                 Set<AspectTargetInfo> atis = aspectInfoCache_current.get(label);
                 if (atis == null) {
-                    LOG.warn("ASPECT CACHE BUG target: " + label + getLogStr(label, caller));
+                    LOG.error("ASPECT CACHE BUG target: " + label + getLogStr(label, caller));
                     atis = Collections.emptySet();
                 }
                 resultMap.put(label, atis);

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
@@ -26,12 +26,14 @@ package com.salesforce.bazel.sdk.lang.jvm;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import com.salesforce.bazel.sdk.aspect.AspectOutputJarSet;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfo;
@@ -138,8 +140,19 @@ public class BazelJvmClasspath {
             // of all targets if configured with the wildcard target
             BazelBuildFile bazelBuildFileModel = null;
             try {
-                bazelBuildFileModel = bazelWorkspaceCmdRunner.queryBazelTargetsInBuildFile(progressMonitor,
-                    this.bazelProjectManager.getBazelLabelForProject(bazelProject));
+                // we pass the targets that are configured for the current project to bazel query
+                // typically, this is a single wildcard target, but the user may
+                // also have specified explicit targets to use
+                List<BazelLabel> labels = configuredTargetsForProject.getConfiguredTargets().stream().map(BazelLabel::new).collect(Collectors.toList());
+                Collection<BazelBuildFile> buildFiles = bazelWorkspaceCmdRunner.queryBazelTargetsInBuildFile(progressMonitor, labels);
+                // since we only call query with labels for the same package, we expect to get a single BazelBuildFile instance back
+                if (buildFiles.isEmpty()) {
+                    throw new IllegalStateException("Unexpected empty BazelBuildFile collection, this is a bug");
+                } else if (buildFiles.size() > 1) {
+                    throw new IllegalStateException("Expected a single BazelBuildFile instance, this is a bug");
+                } else {
+                    bazelBuildFileModel = buildFiles.iterator().next();
+                }
             } catch (Exception anyE) {
                 logger.error("Unable to compute classpath containers entries for project " + bazelProject.name, anyE);
                 return returnEmptyClasspathOrThrow(anyE);

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
@@ -1,0 +1,34 @@
+package com.salesforce.bazel.sdk.model;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public final class BazelLabelUtil {
+
+    /**
+     * Given a Collection of labels, groups the labels by their owning Bazel package.
+     *
+     * @return a mapping of package -> labels belonging to that package
+     */
+    public static Map<BazelLabel, Collection<BazelLabel>> groupByPackage(Collection<BazelLabel> labels) {
+        Map<BazelLabel, Collection<BazelLabel>> packageToLabels = new HashMap<>();
+        for (BazelLabel label : labels) {
+            BazelLabel pack = label.toDefaultPackageLabel();
+            Collection<BazelLabel> group = packageToLabels.get(pack);
+            if (group == null) {
+                group = new HashSet<>();
+                packageToLabels.put(pack, group);
+            }
+            group.add(label);
+        }
+        return packageToLabels;
+    }
+
+    private BazelLabelUtil() {
+        throw new IllegalArgumentException("Not meant to be instantiated");
+    }
+
+
+}

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
@@ -72,9 +72,9 @@ public class BazelProjectTargets {
 
     // TODO weave these into the constructor
 
-    public void activateWildcardTarget() {
+    public void activateWildcardTarget(String wildcardTarget) {
         this.isActivatedWildcardTarget = true;
-        this.configuredTargets.add(projectBazelLabel + ":*");
+        this.configuredTargets.add(projectBazelLabel + ":" + wildcardTarget);
     }
 
     public void activateSpecificTargets(Set<String> activatedTargets) {
@@ -107,6 +107,11 @@ public class BazelProjectTargets {
 
     public boolean isAllTargetsDeactivated() {
         return this.configuredTargets.size() == 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(getConfiguredTargets());
     }
 
 }

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.util.BazelConstants;
 
 /**
  * The <a href="http://ij.bazel.build/docs/project-views.html">project view</a> file.
@@ -127,7 +128,7 @@ public class ProjectView {
     }
 
     /**
-     * Adds a default target for each directory that does not have one (or more) entries
+     * Adds the default targets for each directory that does not have one (or more) entries
      * in the "targets:" section.
      */
     public void addDefaultTargets() {
@@ -142,12 +143,14 @@ public class ProjectView {
                 }
             }
             if (!foundLabel) {
-                defaultLabels.add(bazelPackage.toPackageWildcardLabel());
+                for (String target : BazelConstants.DEFAULT_PACKAGE_TARGETS) {
+                    defaultLabels.add(new BazelLabel(bazelPackage.getPackagePath(), target));
+                }
             }
         }
         for (BazelLabel dflt : defaultLabels) {
-            // this method is used to adjust internal state, it is ok for the line number is
-            // to be incorrect
+            // since this method is used to adjust internal state, it is ok for the
+            // line number to not be correct.
             targetToLineNumber.put(dflt, 0);
         }
     }
@@ -198,11 +201,13 @@ public class ProjectView {
         int lineNumber = 3;
         for (BazelPackageLocation pack : packages) {
             packageToLineNumber.put(pack, lineNumber);
+            lineNumber += 1;
         }
         // newline
         lineNumber += 1;
         for (BazelLabel target : targets) {
             targetToLineNumber.put(target, lineNumber);
+            lineNumber += 1;
         }
     }
 

--- a/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
+++ b/bzl-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
@@ -1,3 +1,36 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 package com.salesforce.bazel.sdk.util;
 
 import java.io.File;

--- a/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/test/type/MockQueryCommand.java
+++ b/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/command/test/type/MockQueryCommand.java
@@ -27,15 +27,15 @@ public class MockQueryCommand extends MockCommand {
         // determine the type of query
         String queryArg = commandTokens.get(2);
 
-        if (queryArg.startsWith("kind(rule, //")) {
-            // QUERY: 
-            //    kind(rule, //projects/libs/javalib0:*)
+        if (queryArg.startsWith("kind(rule, set(//")) {
+            // QUERY:
+            //    kind(rule, set(//projects/libs/javalib0:*))
             // RESPONSE: for each target in the package, a line is written to stdout such as:
             //    java_library rule //projects/libs/javalib0:javalib0
             //    java_test rule //projects/libs/javalib0:javalib0Test
 
             // strip target to be just '//projects/libs/javalib0'
-            String queryPackage = queryArg.substring(13, queryArg.length() - 3);
+            String queryPackage = queryArg.substring(17, queryArg.length() - 4);
 
             if (!isValidBazelTarget(queryPackage)) {
                 // by default, isValidBazelTarget() will throw an exception if the package is missing, but the test may configure it to return false instead

--- a/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
+++ b/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelTest.java
@@ -68,9 +68,11 @@ public class BazelLabelTest {
         assertTrue(new BazelLabel("//foo/blah:t1").isConcrete());
         assertFalse(new BazelLabel("blah/...").isConcrete());
         assertFalse(new BazelLabel("blah:*").isConcrete());
+        assertFalse(new BazelLabel("blah:all").isConcrete());
         assertTrue(new BazelLabel("//:query").isConcrete());
         assertFalse(new BazelLabel("//...").isConcrete());
         assertFalse(new BazelLabel("//:*").isConcrete());
+        assertFalse(new BazelLabel("//:all").isConcrete());
         assertTrue(new BazelLabel("@foo//query:t2").isConcrete());
     }
 
@@ -84,22 +86,32 @@ public class BazelLabelTest {
         assertEquals("", new BazelLabel("//:query").getPackagePath());
         assertEquals("", new BazelLabel("//...").getPackagePath());
         assertEquals("", new BazelLabel("//:*").getPackagePath());
+        assertEquals("", new BazelLabel("//:all").getPackagePath());
         assertEquals("a/b/c", new BazelLabel("@foo//a/b/c").getPackagePath());
     }
 
     @Test
-    public void testGetDefaultPackageLabel() {
-        assertEquals("//foo", new BazelLabel("foo").getDefaultPackageLabel().getLabel());
-        assertEquals("//foo/blah", new BazelLabel("//foo/blah").getDefaultPackageLabel().getLabel());
-        assertEquals("//foo/blah", new BazelLabel("foo/blah:t1").getDefaultPackageLabel().getLabel());
-        assertEquals("//blah", new BazelLabel("blah/...").getDefaultPackageLabel().getLabel());
-        assertEquals("//blah", new BazelLabel("blah:*").getDefaultPackageLabel().getLabel());
-        assertEquals("@foo//blah/goo", new BazelLabel("@foo//blah/goo:t1").getDefaultPackageLabel().getLabel());
+    public void testToDefaultPackageLabel() {
+        assertEquals("//foo", new BazelLabel("foo").toDefaultPackageLabel().getLabel());
+        assertEquals("//foo/blah", new BazelLabel("//foo/blah").toDefaultPackageLabel().getLabel());
+        assertEquals("//foo/blah", new BazelLabel("foo/blah:t1").toDefaultPackageLabel().getLabel());
+        assertEquals("//blah", new BazelLabel("blah/...").toDefaultPackageLabel().getLabel());
+        assertEquals("//blah", new BazelLabel("blah:*").toDefaultPackageLabel().getLabel());
+        assertEquals("@foo//blah/goo", new BazelLabel("@foo//blah/goo:t1").toDefaultPackageLabel().getLabel());
+    }
+
+    @Test
+    public void testInvalidButAcceptableInput() {
+        // we fixup the input for these cases
+        assertEquals("//foo:t1", new BazelLabel("/foo:t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("foo", ":t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("foo/", "t1").getLabel());
+        assertEquals("//foo:t1", new BazelLabel("/foo/", "t1").getLabel());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testGetDefaultPackageLabel_invalidRootLabel() {
-        new BazelLabel("//...").getDefaultPackageLabel();
+    public void testToDefaultPackageLabel_invalidRootLabel() {
+        new BazelLabel("//...").toDefaultPackageLabel();
     }
 
     @Test
@@ -122,9 +134,11 @@ public class BazelLabelTest {
         assertEquals("t1", new BazelLabel("foo/blah:t1").getTargetName());
         assertEquals(null, new BazelLabel("blah/...").getTargetName());
         assertEquals("*", new BazelLabel("blah:*").getTargetName());
+        assertEquals("all", new BazelLabel("blah:all").getTargetName());
         assertEquals("query", new BazelLabel("//:query").getTargetName());
         assertEquals(null, new BazelLabel("//...").getTargetName());
         assertEquals("*", new BazelLabel("//:*").getTargetName());
+        assertEquals("all", new BazelLabel("//:all").getTargetName());
         assertEquals("t1", new BazelLabel("@foo//blah/goo:t1").getTargetName());
     }
 
@@ -153,6 +167,12 @@ public class BazelLabelTest {
         assertEquals("query", new BazelLabel("//:query").getLastComponentOfTargetName());
         assertEquals(null, new BazelLabel("//...").getLastComponentOfTargetName());
         assertEquals("blah", new BazelLabel("@repo//foo:src/foo/blah").getLastComponentOfTargetName());
+    }
+
+    @Test
+    public void testPackageAndTargetCtor() {
+        assertEquals("//a/b/c:foo", new BazelLabel("a/b/c", "foo").getLabel());
+        assertEquals("//a/b/c:foo", new BazelLabel("//a/b/c", "foo").getLabel());
     }
 
     @Test

--- a/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java
+++ b/bzl-java-sdk/src/test/java/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java
@@ -1,0 +1,29 @@
+package com.salesforce.bazel.sdk.model;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class BazelLabelUtilTest {
+
+    @Test
+    public void testGroupByPackage() {
+        BazelLabel l1 = new BazelLabel("a/b/c:t1");
+        BazelLabel l2 = new BazelLabel("d/e/f:t2");
+        BazelLabel l3 = new BazelLabel("a/b/c:t2");
+
+        Map<BazelLabel, Collection<BazelLabel>> m = BazelLabelUtil.groupByPackage(Arrays.asList(new BazelLabel[]{l1, l2, l3}));
+
+        assertEquals(2, m.size());
+        assertThat(m.get(new BazelLabel("a/b/c")), hasItem(l1));
+        assertThat(m.get(new BazelLabel("a/b/c")), hasItem(l3));
+        assertThat(m.get(new BazelLabel("d/e/f")), hasItem(l2));
+    }
+
+}

--- a/plugin-core/BUILD
+++ b/plugin-core/BUILD
@@ -119,8 +119,8 @@ java_test(
 )
 
 java_test(
-    name = "BazelBuilderTest",
-    srcs = ["src/test/java/com/salesforce/bazel/eclipse/builder/BazelBuilderTest.java"] + mock_src,
+    name = "EclipseClasspathUtilTest",
+    srcs = ["src/test/java/com/salesforce/bazel/eclipse/builder/EclipseClasspathUtilTest.java"] + mock_src,
     deps = [
         ":com.salesforce.bazel.eclipse.core-bin",
         "//bzl-java-sdk",

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/EclipseImplicitClasspathHelper.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/classpath/EclipseImplicitClasspathHelper.java
@@ -1,3 +1,38 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 package com.salesforce.bazel.eclipse.classpath;
 
 import java.io.IOException;

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
@@ -228,14 +228,15 @@ public class EclipseBazelProjectManager extends BazelProjectManager {
             if (propertyName.startsWith(TARGET_PROPERTY_PREFIX)) {
                 String target = eclipseProjectBazelPrefs.get(propertyName, "");
                 if (!target.isEmpty()) {
-                    if (!target.startsWith(projectLabel)) {
+                    BazelLabel label = new BazelLabel(target);
+                    if (!label.getLabel().startsWith(projectLabel)) {
                         // the user jammed in a label not associated with this project, ignore
                         //continue;
                     }
-                    if (target.endsWith(":*")) {
+                    if (!label.isConcrete()) {
                         // we have a wildcard target, so discard any existing targets we gathered (if the user messed up their prefs)
                         // and just go with that.
-                        activatedTargets.activateWildcardTarget();
+                        activatedTargets.activateWildcardTarget(label.getTargetName());
                         return activatedTargets;
                     }
                     activeTargets.add(target);

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
@@ -50,6 +50,7 @@ import com.salesforce.bazel.eclipse.projectimport.flow.ImportFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.InitImportFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.InitJREFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.LoadAspectsFlow;
+import com.salesforce.bazel.eclipse.projectimport.flow.LoadTargetsFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.OrderProjectsFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.SetupClasspathContainersFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.SetupProjectBuildersFlow;
@@ -93,6 +94,11 @@ public class ProjectImporterFactory {
         flows.removeIf(flow -> flow.getClass() == InitJREFlow.class);
     }
 
+    @VisibleForTesting
+    public void skipQueryCacheWarmup() {
+        flows.removeIf(flow -> flow.getClass() == LoadTargetsFlow.class);
+    }
+
     public ProjectImporter build() {
         return new FlowProjectImporter(flows.toArray(new ImportFlow[flows.size()]), bazelWorkspaceRootPackageInfo, selectedBazelPackages, projectOrderResolver);
     }
@@ -107,6 +113,7 @@ public class ProjectImporterFactory {
                     new InitImportFlow(),
                     new DetermineTargetsFlow(),
                     new LoadAspectsFlow(),
+                    new LoadTargetsFlow(),
                     new CreateRootProjectFlow(),
                     new OrderProjectsFlow(),
                     new CreateProjectsFlow(),

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectStructureInspector.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectStructureInspector.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.util.BazelConstants;
 import com.salesforce.bazel.sdk.util.BazelPathHelper;
 
 /**
@@ -105,13 +106,10 @@ class EclipseProjectStructureInspector {
         }
 
         if (foundSourceCodePaths) {
-            BazelLabel packageTarget = new BazelLabel(packageNode.getBazelPackageFSRelativePath());
-            if (packageTarget.isPackageDefault()) {
-                // if the label is //foo, we want foo:* so that we pick up all targets in the
-                // BUILD file, instead of only the default package target
-                packageTarget = packageTarget.toPackageWildcardLabel();
+            String packagePath = packageNode.getBazelPackageFSRelativePath();
+            for (String target : BazelConstants.DEFAULT_PACKAGE_TARGETS) {
+                this.bazelTargets.add(new BazelLabel(packagePath, target));
             }
-            this.bazelTargets.add(packageTarget);
         }
     }
 

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportFlow.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportFlow.java
@@ -23,8 +23,6 @@
  */
 package com.salesforce.bazel.eclipse.projectimport.flow;
 
-import org.eclipse.core.runtime.CoreException;
-
 /**
  * A single project import step.
  *
@@ -36,7 +34,7 @@ public interface ImportFlow {
     /**
      * Run the import step.
      */
-    void run(ImportContext ctx) throws CoreException;
+    void run(ImportContext ctx) throws Exception;
 
     /**
      * Asserts invariants about the state of the specified ctx.

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewEditor.java
@@ -82,11 +82,12 @@ public class ProjectViewEditor extends AbstractDecoratedTextEditor {
         super.editorSaved();
         String projectViewContent = getSourceViewer().getTextWidget().getText();
         ProjectView proposedProjectView = new ProjectView(this.rootDirectory, projectViewContent);
-        proposedProjectView = ProjectViewProcessor.resolvePackages(proposedProjectView);
-        List<BazelPackageLocation> invalidPackages = ProjectViewProcessor.getInvalidDirectories(proposedProjectView);
+        List<BazelPackageLocation> invalidPackages = new ArrayList<>();
+        proposedProjectView = ProjectViewProcessor.resolvePackages(proposedProjectView, invalidPackages);
         List<BazelProblem> problems = new ArrayList<>();
         for (BazelPackageLocation invalidPackage : invalidPackages) {
-            problems.add(BazelProblem.createError(PROJECT_VIEW_RESOURCE, proposedProjectView.getLineNumber(invalidPackage),
+            int lineNumber = proposedProjectView.getLineNumber(invalidPackage);
+            problems.add(BazelProblem.createError(PROJECT_VIEW_RESOURCE, lineNumber,
                 "Bad Bazel Package: " + invalidPackage.getBazelPackageFSRelativePath()));
         }
         markerManager.clearAndPublish(problems, this.rootProject, getProgressMonitor());

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewProcessor.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/projectview/ProjectViewProcessor.java
@@ -11,47 +11,79 @@ import com.salesforce.bazel.sdk.project.ProjectView;
 import com.salesforce.bazel.sdk.project.ProjectViewPackageLocation;
 import com.salesforce.bazel.sdk.util.BazelDirectoryStructureUtil;
 
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
 final class ProjectViewProcessor {
 
     private static final LogHelper LOG = LogHelper.log(ProjectViewProcessor.class);
 
-    static List<BazelPackageLocation> getInvalidDirectories(ProjectView projectView) {
-        List<BazelPackageLocation> invalidDirectories = new ArrayList<>();
+    /**
+     * Expands parent directories in the specified ProjectView to concrete Bazel Packages.
+     *
+     * Populates the given invalidDirectories list with...invalid directories.
+     *
+     * @return Expanded ProjectView, if there are no errors.
+     */
+    static ProjectView resolvePackages(ProjectView projectView, List<BazelPackageLocation> invalidDirectories) {
         File rootDir = projectView.getWorkspaceRootDirectory();
-        for (BazelPackageLocation packageLocation : projectView.getDirectories()) {
-            String packageDir = packageLocation.getBazelPackageFSRelativePath();
-            if (!BazelDirectoryStructureUtil.isBazelPackage(rootDir, packageDir)) {
-                invalidDirectories.add(packageLocation);
-            }
-        }
-        return invalidDirectories;
-    }
-
-    static ProjectView resolvePackages(ProjectView projectView) {
-        File rootDir = projectView.getWorkspaceRootDirectory();
-        List<BazelPackageLocation> updatedDirectories = new ArrayList<>();
+        List<BazelPackageLocation> directories = new ArrayList<>();
+        List<BazelPackageLocation> additionalDirectories = new ArrayList<>();
         for (BazelPackageLocation packageLocation : projectView.getDirectories()) {
 
             String directory = packageLocation.getBazelPackageFSRelativePath();
             if (BazelDirectoryStructureUtil.isBazelPackage(rootDir, directory)) {
                 // no change, just add the same package
-                updatedDirectories.add(packageLocation);
+                directories.add(packageLocation);
             } else {
                 // look for BUILD files below this location
                 List<String> additionalPackages = BazelDirectoryStructureUtil.findBazelPackages(rootDir, directory);
                 LOG.info("Found " + additionalPackages.size() + " packages under " + directory);
                 if (additionalPackages.isEmpty()) {
-                    // add the original directory back, it will get flagged as invalid
-                    updatedDirectories.add(packageLocation);
+                    invalidDirectories.add(packageLocation);
                 } else {
-                    updatedDirectories.addAll(
+                    additionalDirectories.addAll(
                         additionalPackages.stream()
                             .map(p -> new ProjectViewPackageLocation(rootDir, p))
                             .collect(Collectors.toList()));
                 }
             }
         }
-        return new ProjectView(rootDir, updatedDirectories, projectView.getTargets());
+        directories.addAll(additionalDirectories);
+
+        return invalidDirectories.isEmpty() ?
+            new ProjectView(rootDir, directories, projectView.getTargets()) :
+            projectView;
     }
 
 }

--- a/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/plugin-core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -33,7 +33,7 @@
  */
 /*******************************************************************************
  * Copyright (c) 2008-2013 Sonatype, Inc. and others. Copyright 2018-2019 Salesforce
- * 
+ *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
@@ -197,7 +197,7 @@ public class BazelImportWizardPage extends WizardPage {
             String target = bazelProjectManager.getConfiguredBazelTargets(bazelProject, false).getConfiguredTargets()
                     .iterator().next();
             BazelLabel label = new BazelLabel(target);
-            String pack = label.getDefaultPackageLabel().getLabel();
+            String pack = label.toDefaultPackageLabel().getLabel();
             BazelPackageInfo bpi = rootPackage.findByPackage(pack);
             if (bpi != null) {
                 importedPackages.add(bpi);

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/EclipseClasspathUtilTest.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/builder/EclipseClasspathUtilTest.java
@@ -13,7 +13,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaProject;
 import org.junit.Test;
 
-public class BazelBuilderTest {
+import com.salesforce.bazel.eclipse.classpath.EclipseClasspathUtil;
+
+public class EclipseClasspathUtilTest {
 
     @Test
     public void testGetDownstreamProjectsOf() throws Exception {
@@ -28,7 +30,7 @@ public class BazelBuilderTest {
         IJavaProject unrelated = getMockedProject("unrelated", new String[] { "Z" });
 
         Set<IProject> downstreams =
-                BazelBuilder.getDownstreamProjectsOf(D.getProject(), new IJavaProject[] { A, B, C, D, unrelated });
+                EclipseClasspathUtil.getDownstreamProjectsOf(D.getProject(), new IJavaProject[] { A, B, C, D, unrelated });
 
         assertEquals(3, downstreams.size());
         assertTrue(downstreams.contains(A.getProject()));
@@ -42,7 +44,7 @@ public class BazelBuilderTest {
     public void testDownstreamSetImpl() throws Exception {
         IJavaProject A = getMockedProject("A", new String[] {});
 
-        Set<IProject> downstreams = BazelBuilder.getDownstreamProjectsOf(A.getProject(), new IJavaProject[] {});
+        Set<IProject> downstreams = EclipseClasspathUtil.getDownstreamProjectsOf(A.getProject(), new IJavaProject[] {});
 
         assertFalse("Do not use a TreeSet", downstreams instanceof TreeSet);
     }

--- a/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
+++ b/plugin-core/src/test/java/com/salesforce/bazel/eclipse/mock/EclipseFunctionalTestEnvironmentFactory.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 package com.salesforce.bazel.eclipse.mock;
 
@@ -46,7 +46,7 @@ import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 /**
  * Factory for creating test environments for Eclipse functional tests. Produces a Mock Eclipse workspace from
  * templates.
- * 
+ *
  * @author plaird
  */
 public class EclipseFunctionalTestEnvironmentFactory {
@@ -114,6 +114,7 @@ public class EclipseFunctionalTestEnvironmentFactory {
         ProjectImporterFactory projectImporterFactory = new ProjectImporterFactory(workspaceRootProject, bazelPackagesToImport);
         projectImporterFactory.setImportOrderResolver(new MockImportOrderResolver());
         projectImporterFactory.skipJREWarmup();
+        projectImporterFactory.skipQueryCacheWarmup();
         ProjectImporter projectImporter = projectImporterFactory.build();
         // run the import process (this is actually done in BazelImportWizard.performFinish() when a user is running the show)
         List<IProject> importedProjectsList = projectImporter.run(new EclipseWorkProgressMonitor(), new MockProgressMonitor());


### PR DESCRIPTION
Sorry this PR is a bit large.  There are 2 mains changes:
- I wanted to experiment with different wildcard targets ("all" vs "\*").  We had multiple places in code where we assumed "*", I tried to get rid of those assumptions.
- Import was running one bazel query for imported bazel package. This was a source of slowness - we now run a single bazel query for all configured labels early during import, to populate the query cache.