### PR TITLE
fix core plugin so it is unpacked

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Eclipse-BundleShape: dir
 Bundle-ManifestVersion: 2
 Bundle-Name: Bazel Eclipse Core Plugin
 Automatic-Module-Name: com.salesforce.bazel.eclipse.core

--- a/features/com.salesforce.bazel.eclipse.feature/feature.xml
+++ b/features/com.salesforce.bazel.eclipse.feature/feature.xml
@@ -230,7 +230,8 @@
          id="com.salesforce.bazel.eclipse.core"
          download-size="0"
          install-size="0"
-         version="0.0.0"/>
+         version="0.0.0"
+         unpack="true"/>
 
    <plugin
          id="com.salesforce.bazel.eclipse.deps"


### PR DESCRIPTION
After the Tycho transition, BEF worked fine when launched from the Eclipse SDK. But when the updatesite was built, and the feature was installed in a regular Eclipse, the Bazel Aspect was broken. The Bazel Aspect is a file in a Bazel workspace that is embedded in the BEF Core plugin. We need for the BEF Core plugin to be laid out in extracted form, not a jar, after installation.

The feature we were missing from the Tycho build was that unpacking. Eclipse is an odd duck and it takes a few settings to make that happen:
- unpack=true
- tell it to use the 'dir' shape in the manifest

https://stackoverflow.com/questions/922230/how-do-i-force-an-eclipse-plug-in-to-be-unpacked