### PR TITLE
remove guava

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/META-INF/MANIFEST.MF
@@ -10,9 +10,7 @@ Require-Bundle: org.hamcrest.library;bundle-version="1.3.0",
  org.junit;bundle-version="4.13.0",
  org.mockito;bundle-version="2.23.0",
  com.salesforce.bazel-java-sdk;bundle-version="1.2.3"
-Import-Package: com.google.common.base;version="30.1.0",
- com.google.common.collect;version="30.1.0",
- org.json
+Import-Package: org.json;version="20160212"
 Export-Package: com.salesforce.bazel.sdk.command.test,
  com.salesforce.bazel.sdk.command.test.type,
  com.salesforce.bazel.sdk.model.test,

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommand.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import org.mockito.Mockito;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.command.BazelProcessBuilder;
 import com.salesforce.bazel.sdk.command.Command;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
@@ -62,19 +61,19 @@ public class MockCommand implements Command {
     }
 
     public void addSimulatedOutputToCommandStdOut(String... someStrings) {
-        this.outputLines = new ArrayList<>();
+        outputLines = new ArrayList<>();
         for (String someString : someStrings) {
-            this.outputLines.add(someString);
+            outputLines.add(someString);
         }
-        this.errorLines = new ArrayList<>();
+        errorLines = new ArrayList<>();
     }
 
     public void addSimulatedOutputToCommandStdErr(String... someStrings) {
-        this.errorLines = new ArrayList<>();
+        errorLines = new ArrayList<>();
         for (String someString : someStrings) {
-            this.errorLines.add(someString);
+            errorLines.add(someString);
         }
-        this.outputLines = new ArrayList<>();
+        outputLines = new ArrayList<>();
     }
 
     @Override
@@ -83,11 +82,11 @@ public class MockCommand implements Command {
     }
 
     @Override
-    public ImmutableList<String> getSelectedErrorLines() {
+    public List<String> getSelectedErrorLines() {
         if (errorLines != null) {
-            return ImmutableList.copyOf(errorLines);
+            return errorLines;
         }
-        return ImmutableList.of();
+        return new ArrayList<>();
     }
 
     @Override
@@ -101,11 +100,11 @@ public class MockCommand implements Command {
     }
 
     @Override
-    public ImmutableList<String> getSelectedOutputLines() {
+    public List<String> getSelectedOutputLines() {
         if (outputLines != null) {
-            return ImmutableList.copyOf(outputLines);
+            return outputLines;
         }
-        return ImmutableList.of();
+        return new ArrayList<>();
     }
 
     // HELPERS

--- a/bundles/com.salesforce.bazel-java-sdk/BUILD
+++ b/bundles/com.salesforce.bazel-java-sdk/BUILD
@@ -5,7 +5,6 @@ java_library(
     srcs = glob(["src/main/java/**/*.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "//plugin-libs/plugin-deps:com_google_guava",
         "//plugin-libs/plugin-deps:org_json_json",
     ],
 )
@@ -24,7 +23,6 @@ java_library(
 
         "//plugin-libs/plugin-testdeps:org_junit_junit",
         "//plugin-libs/plugin-testdeps:org_mockito_mockito_core",
-        "//plugin-libs/plugin-deps:com_google_guava",
     ],
 )
 
@@ -50,7 +48,6 @@ java_test(
     srcs = ["src/test/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java",],
     deps = [
         ":bzl-java-sdk",
-        "//plugin-libs/plugin-deps:com_google_guava",
     ],
 )
 
@@ -98,7 +95,7 @@ java_test(
         "src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java",
         "src/test/java/com/salesforce/bazel/sdk/command/BazelOutputParserTest.java",
     ],
-    deps = ["//plugin-libs/plugin-deps:com_google_guava",],
+    deps = [],
 )
 
 java_test(
@@ -107,7 +104,6 @@ java_test(
     deps = [
         ":bzl-java-sdk",
 
-        "//plugin-libs/plugin-deps:com_google_guava",
         "//plugin-libs/plugin-testdeps:com_google_truth",
         "//plugin-libs/plugin-testdeps:org_hamcrest_core",
         "//plugin-libs/plugin-testdeps:org_junit_junit",
@@ -170,7 +166,6 @@ java_test(
     deps = [
         ":bzl-java-sdk",
 
-        "//plugin-libs/plugin-deps:com_google_guava",
         "//plugin-libs/plugin-deps:org_json_json",
         "//plugin-libs/plugin-testdeps:org_hamcrest_core",
         "//plugin-libs/plugin-testdeps:org_junit_junit",

--- a/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
@@ -23,10 +23,7 @@ Export-Package: com.salesforce.bazel.app.analyzy,
  com.salesforce.bazel.sdk.project,
  com.salesforce.bazel.sdk.util,
  com.salesforce.bazel.sdk.workspace
-Import-Package: com.google.common.annotations;version="30.1.0",
- com.google.common.base;version="30.1.0",
- com.google.common.collect;version="30.1.0",
- org.json;version=20160212
+Import-Package: org.json;version=20160212
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/Command.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/Command.java
@@ -24,9 +24,8 @@
 package com.salesforce.bazel.sdk.command;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Function;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * A built command that can be run via the run() method.
@@ -47,7 +46,7 @@ public interface Command {
      *
      * @see {@link CommandBuilder#setStderrLineSelector(Function)}
      */
-    ImmutableList<String> getSelectedErrorLines();
+    List<String> getSelectedErrorLines();
 
     /**
      * Returns the list of lines selected from the standard output stream. Lines printed to the standard output stream
@@ -55,7 +54,7 @@ public interface Command {
      *
      * @see {@link CommandBuilder#setStdoutLineSelector(Function)}
      */
-    ImmutableList<String> getSelectedOutputLines();
+    List<String> getSelectedOutputLines();
 
     /**
      * Returns a BazelProcessBuilder configured to run this Command instance.

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelCommandExecutor.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelCommandExecutor.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Copyright 2016 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.sdk.command.Command;
 import com.salesforce.bazel.sdk.command.CommandBuilder;
@@ -65,7 +64,7 @@ public class BazelCommandExecutor {
 
     public synchronized List<String> runBazelAndGetOutputLines(File workingDirectory,
             WorkProgressMonitor progressMonitor, List<String> args, Function<String, String> selector, long timeoutMS)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
 
         CommandBuilder builder =
                 getConfiguredCommandBuilder(ConsoleType.WORKSPACE, workingDirectory, progressMonitor, args, timeoutMS);
@@ -77,7 +76,7 @@ public class BazelCommandExecutor {
 
     public synchronized List<String> runBazelAndGetOuputLines(ConsoleType consoleType, File workingDirectory,
             WorkProgressMonitor progressMonitor, List<String> args, Function<String, String> selector, long timeoutMS)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
 
         CommandBuilder builder =
                 getConfiguredCommandBuilder(consoleType, workingDirectory, progressMonitor, args, timeoutMS);
@@ -86,14 +85,14 @@ public class BazelCommandExecutor {
         if (command.run() == 0) {
             return command.getSelectedOutputLines();
         }
-        return ImmutableList.of();
+        return new ArrayList<>();
     }
 
     // WHEN INTERESTING OUTPUT IS ON STDERR...
 
     public synchronized List<String> runBazelAndGetErrorLines(File directory, WorkProgressMonitor progressMonitor,
             List<String> args, Function<String, String> selector, long timeoutMS)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
 
         CommandBuilder builder =
                 getConfiguredCommandBuilder(ConsoleType.WORKSPACE, directory, progressMonitor, args, timeoutMS);
@@ -105,7 +104,7 @@ public class BazelCommandExecutor {
 
     public synchronized List<String> runBazelAndGetErrorLines(ConsoleType consoleType, File directory,
             WorkProgressMonitor progressMonitor, List<String> args, Function<String, String> selector, long timeoutMS)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
 
         CommandBuilder builder = getConfiguredCommandBuilder(consoleType, directory, progressMonitor, args, timeoutMS);
         Command command = builder.setStderrLineSelector(selector).build();
@@ -113,7 +112,7 @@ public class BazelCommandExecutor {
             return command.getSelectedErrorLines();
         }
 
-        return ImmutableList.of();
+        return new ArrayList<>();
     }
 
     // HELPERS
@@ -136,12 +135,12 @@ public class BazelCommandExecutor {
 
     private CommandBuilder getConfiguredCommandBuilder(ConsoleType type, File directory,
             WorkProgressMonitor progressMonitor, List<String> args, long timeoutMS)
-            throws BazelCommandLineToolConfigurationException {
+                    throws BazelCommandLineToolConfigurationException {
 
         String consoleName = type.getConsoleName(directory);
 
         return commandBuilder.setConsoleName(consoleName).setDirectory(directory).setTimeout(timeoutMS)
-                .addArguments(this.bazelExecutable.getAbsolutePath()).addArguments(args)
+                .addArguments(bazelExecutable.getAbsolutePath()).addArguments(args)
                 .setProgressMonitor(progressMonitor);
     }
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelQueryHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelQueryHelper.java
@@ -25,6 +25,7 @@ package com.salesforce.bazel.sdk.command.internal;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,7 +36,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelBuildFile;
@@ -72,15 +72,15 @@ public class BazelQueryHelper {
     @Deprecated
     public synchronized List<String> listBazelTargetsInBuildFiles(File bazelWorkspaceRootDirectory,
             WorkProgressMonitor progressMonitor, File... directories)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
-        ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+        List<String> argBuilder = new ArrayList<>();
         argBuilder.add("query");
         for (File f : directories) {
             String directoryPath = f.toURI().relativize(bazelWorkspaceRootDirectory.toURI()).getPath();
             argBuilder.add(directoryPath + "/...");
         }
         return bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory, progressMonitor,
-            argBuilder.build(), (t) -> t, BazelCommandExecutor.TIMEOUT_INFINITE);
+            argBuilder, t -> t, BazelCommandExecutor.TIMEOUT_INFINITE);
     }
 
     /**
@@ -125,13 +125,13 @@ public class BazelQueryHelper {
 
         // bazel query 'kind(rule, [label]:*)' --output label_kind
 
-        ImmutableList.Builder<String> argBuilder = ImmutableList.builder();
+        List<String> argBuilder = new ArrayList<>();
         argBuilder.add("query");
         argBuilder.add("kind(rule, set(" + labels + "))");
         argBuilder.add("--output");
         argBuilder.add("label_kind");
         List<String> resultLines = bazelCommandExecutor.runBazelAndGetOutputLines(bazelWorkspaceRootDirectory,
-            null, argBuilder.build(), (t) -> t, BazelCommandExecutor.TIMEOUT_INFINITE);
+            null, argBuilder, t -> t, BazelCommandExecutor.TIMEOUT_INFINITE);
 
         // Sample Output:  (format: rule_type 'rule' label)
         // java_binary rule //projects/libs/apple/apple-api:apple-main

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/shell/SelectOutputStream.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/shell/SelectOutputStream.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Copyright 2016 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -45,21 +45,18 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-
 /**
  * A wrapper output stream to output part of the result to a given output and extracting the other part with a selector
  * function. The other part is return as a list of string.
  */
 public class SelectOutputStream extends OutputStream {
 
-    private OutputStream output;
-    private Function<String, String> selector;
+    private final OutputStream output;
+    private final Function<String, String> selector;
     private boolean closed = false;
-    private List<String> lines = new LinkedList<>();
-    private List<String> outputLines = new LinkedList<>();
-    private ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    private final List<String> lines = new LinkedList<>();
+    private final List<String> outputLines = new LinkedList<>();
+    private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
     /**
      * Create a SelectOutputStream. <code>output<code> is the output stream where non-selected lines
@@ -80,7 +77,9 @@ public class SelectOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        Preconditions.checkState(!closed, "Attempted to write on a closed stream");
+        if (closed) {
+            throw new IllegalStateException("Attempted to write on a closed stream");
+        }
         byte b0 = (byte) b;
         if (b0 == '\n') {
             select(true);
@@ -91,7 +90,7 @@ public class SelectOutputStream extends OutputStream {
 
     private void select(boolean appendNewLine) throws UnsupportedEncodingException, IOException {
         String line = null;
-        if (this.selector != null) {
+        if (selector != null) {
             line = selector.apply(stream.toString(StandardCharsets.UTF_8.name()));
         }
 
@@ -109,7 +108,9 @@ public class SelectOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        Preconditions.checkState(!closed);
+        if (closed) {
+            throw new IllegalStateException("Attempted to close a closed stream");
+        }
         super.close();
         select(false);
         closed = true;
@@ -118,14 +119,14 @@ public class SelectOutputStream extends OutputStream {
     /**
      * Returns the list of selected lines.
      */
-    ImmutableList<String> getLines() {
-        return ImmutableList.copyOf(lines);
+    List<String> getLines() {
+        return lines;
     }
 
     /**
      * Returns the list of output lines.
      */
-    ImmutableList<String> getOutputLines() {
-        return ImmutableList.copyOf(outputLines);
+    List<String> getOutputLines() {
+        return outputLines;
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/shell/ShellCommandBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/shell/ShellCommandBuilder.java
@@ -25,8 +25,6 @@ package com.salesforce.bazel.sdk.command.shell;
 
 import java.io.IOException;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.command.CommandBuilder;
 import com.salesforce.bazel.sdk.console.CommandConsole;
 import com.salesforce.bazel.sdk.console.CommandConsoleFactory;
@@ -46,14 +44,16 @@ public class ShellCommandBuilder extends CommandBuilder {
     /**
      * Build a Command object.
      */
+    @Override
     public ShellCommand build_impl() throws IOException {
-        Preconditions.checkNotNull(directory);
-        ImmutableList<String> iargs = ImmutableList.copyOf(this.args);
+        if (directory == null) {
+            throw new IllegalStateException("Parameter directory is null");
+        }
         CommandConsole console = consoleName == null ? null : consoleFactory.get(consoleName,
             "Running " + String.join(" ", args) + " from " + directory.toString());
 
-        ShellCommand command = new ShellCommand(console, directory, iargs, stdoutSelector, stderrSelector, stdout,
-                stderr, progressMonitor, timeoutMS);
+        ShellCommand command = new ShellCommand(console, directory, args, stdoutSelector, stderrSelector, stdout,
+            stderr, progressMonitor, timeoutMS);
 
         return command;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelBuildFileHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelBuildFileHelper.java
@@ -41,7 +41,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 
 public class BazelBuildFileHelper {
@@ -102,7 +101,6 @@ public class BazelBuildFileHelper {
         return false;
     }
 
-    @VisibleForTesting
     static boolean hasJavaRulesInLine(String buildFileLine) {
         buildFileLine = buildFileLine.trim();
         if (Arrays.stream(JAVA_PROJECT_INDICATORS).parallel().anyMatch(buildFileLine::startsWith)) {

--- a/bundles/com.salesforce.bazel.eclipse.core/BUILD
+++ b/bundles/com.salesforce.bazel.eclipse.core/BUILD
@@ -18,8 +18,6 @@ eclipse_plugin(
     classpath_resources = ['plugin.xml'],
     deps = [
         "//bzl-java-sdk",
-
-        "//plugin-libs/plugin-deps:com_google_guava",
     ],
 )
 
@@ -37,7 +35,6 @@ mock_deps = [
         "//bzl-java-sdk:test-workspace-support",
         "//bzl-java-sdk:test-command-mocks",
 
-        "//plugin-libs/plugin-deps:com_google_guava",
         "//plugin-libs/plugin-testdeps:org_mockito_mockito_core",
 
         "//tools/eclipse_jars:org_eclipse_core_contenttype",

--- a/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
@@ -30,7 +30,3 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: bin/,
  .
-Import-Package: com.google.common.annotations;version="30.1.0",
- com.google.common.base;version="30.1.0",
- com.google.common.collect;version="30.1.0",
- com.google.common.graph;version="30.1.0"

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/builder/BazelBuilder.java
@@ -35,8 +35,6 @@
  */
 package com.salesforce.bazel.eclipse.builder;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +56,6 @@ import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
-import com.google.common.collect.Lists;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.classpath.BazelClasspathContainer;
 import com.salesforce.bazel.eclipse.classpath.BazelGlobalSearchClasspathContainer;
@@ -132,8 +129,7 @@ public class BazelBuilder extends IncrementalProjectBuilder {
             if (buildSuccessful) {
                 IJavaProject[] allImportedProjects = javaCoreHelper.getAllBazelJavaProjects(true);
                 IProject rootWorkspaceProject = Arrays.stream(allImportedProjects)
-                        .filter(p -> resourceHelper.isBazelRootProject(p.getProject())).collect(onlyElement())
-                        .getProject();
+                        .filter(p -> resourceHelper.isBazelRootProject(p.getProject())).findFirst().get().getProject();
                 Set<IProject> downstreamProjects = EclipseClasspathUtil.getDownstreamProjectsOf(project, allImportedProjects);
                 buildProjects(bazelWorkspaceCmdRunner, downstreamProjects, progressMonitor, rootWorkspaceProject,
                     monitor);
@@ -193,7 +189,7 @@ public class BazelBuilder extends IncrementalProjectBuilder {
 
     private boolean buildProjects(BazelWorkspaceCommandRunner cmdRunner, Collection<IProject> projects,
             WorkProgressMonitor progressMonitor, IProject rootProject, IProgressMonitor monitor)
-            throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
+                    throws IOException, InterruptedException, BazelCommandLineToolConfigurationException {
         Set<String> bazelTargets = new TreeSet<>();
         BazelProjectManager bazelProjectManager = BazelPluginActivator.getBazelProjectManager();
         List<BazelProject> bazelProjects = new ArrayList<>();
@@ -223,7 +219,7 @@ public class BazelBuilder extends IncrementalProjectBuilder {
     }
 
     private static List<String> getAllBazelBuildFlags(Collection<IProject> projects) {
-        List<String> buildFlags = Lists.newArrayList();
+        List<String> buildFlags = new ArrayList<>();
         BazelProjectManager bazelProjectManager = BazelPluginActivator.getBazelProjectManager();
 
         for (IProject project : projects) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/builder/ResourceDeltaInspector.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/builder/ResourceDeltaInspector.java
@@ -43,7 +43,6 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
 
-import com.google.common.base.Preconditions;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.util.BazelConstants;
 
@@ -62,7 +61,9 @@ class ResourceDeltaInspector {
     }
 
     private static boolean hasChangedFiles(IResourceDelta delta, Collection<String> filenameNeedles) {
-        Preconditions.checkNotNull(delta);
+        if (delta == null) {
+            throw new IllegalArgumentException("Field delta cannot be null.");
+        }
         try {
             Collection<IResource> matchingResources = new ArrayList<>();
             delta.accept(new ChangedResourceVisitor(filenameNeedles, matchingResources));

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -59,7 +60,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.launching.IVMConnector;
 import org.eclipse.jdt.launching.JavaRuntime;
 
-import com.google.common.collect.ImmutableMap;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.launch.BazelLaunchConfigurationSupport.BazelLaunchConfigAttributes;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
@@ -157,7 +157,10 @@ public class BazelLaunchConfigurationDelegate implements ILaunchConfigurationDel
     // INTERNAL
 
     private static Map<String, String> getConnectorDebugArgs() {
-        return ImmutableMap.of("hostname", DEBUG_HOST, "port", String.valueOf(DEBUG_PORT));
+        Map<String, String> map = new HashMap<>();
+        map.put("hostname", DEBUG_HOST);
+        map.put("port", String.valueOf(DEBUG_PORT));
+        return map;
     }
 
     private static void connectDebugger(ILaunchConfiguration configuration, IProject project, IProgressMonitor monitor,

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.salesforce.bazel.eclipse.projectimport.flow.CreateProjectsFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.CreateRootProjectFlow;
 import com.salesforce.bazel.eclipse.projectimport.flow.DetermineTargetsFlow;
@@ -89,12 +88,10 @@ public class ProjectImporterFactory {
         this.projectOrderResolver = projectOrderResolver;
     }
 
-    @VisibleForTesting
     public void skipJREWarmup() {
         flows.removeIf(flow -> flow.getClass() == InitJREFlow.class);
     }
 
-    @VisibleForTesting
     public void skipQueryCacheWarmup() {
         flows.removeIf(flow -> flow.getClass() == LoadTargetsFlow.class);
     }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectCreator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectCreator.java
@@ -25,6 +25,7 @@ package com.salesforce.bazel.eclipse.projectimport.flow;
 
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -36,7 +37,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.eclipse.BazelNature;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.projectimport.ProjectImporterUtils;
@@ -81,7 +81,7 @@ class EclipseProjectCreator {
             ProjectImporterUtils.addNatureToEclipseProject(eclipseProject, JavaCore.NATURE_ID);
             BazelProjectManager projMgr = BazelPluginActivator.getBazelProjectManager();
             projMgr.addSettingsToProject(bazelProject, bazelWorkspaceRootDirectory.getAbsolutePath(), packageFSPath,
-                bazelTargets, ImmutableList.of()); // TODO pass buildFlags
+                bazelTargets, new ArrayList<>()); // TODO pass buildFlags
         } catch (CoreException e) {
             LOG.error(e.getMessage(), e);
         }
@@ -106,7 +106,7 @@ class EclipseProjectCreator {
             // 1. the given project name 2. no references to other projects 3. an empty build spec 4. an empty comment
             // to which we add the location uri
             IProjectDescription eclipseProjectDescription = resourceHelper.createProjectDescription(newEclipseProject);
-            if (location != null && workspaceRoot.getLocationURI().equals(location)) {
+            if ((location != null) && workspaceRoot.getLocationURI().equals(location)) {
                 eclipseProjectLocation = null;
             }
             eclipseProjectDescription.setLocationURI(eclipseProjectLocation);
@@ -123,7 +123,7 @@ class EclipseProjectCreator {
             }
         } else {
             BazelPluginActivator.error("Project [" + eclipseProjectName
-                    + "] already exists, which is unexpected. Project initialization will not occur.");
+                + "] already exists, which is unexpected. Project initialization will not occur.");
             createdEclipseProject = newEclipseProject;
         }
         BazelPluginActivator.getBazelProjectManager().addProject(new BazelProject(eclipseProjectName, createdEclipseProject));

--- a/bundles/com.salesforce.bazel.eclipse.deps/BUILD
+++ b/bundles/com.salesforce.bazel.eclipse.deps/BUILD
@@ -5,15 +5,6 @@ load(
 load("//tools:feature_version_def.bzl", "VERSION")
 
 
-java_import(
-    name = "com_google_guava",
-    jars = [
-        "lib/guava-28.2.jar",
-    ],
-    visibility = [
-        "//visibility:public",
-    ],
-)
 
 java_import(
     name = "org_json_json",
@@ -64,7 +55,6 @@ eclipse_plugin(
     exports = "org.json,org.slf4j,com.google.common.base,com.google.common.collect",
     visibility = ["//visibility:public"],
     deps = [
-      ":com_google_guava",
       ":org_json_json",
     ],
 )

--- a/bundles/com.salesforce.bazel.eclipse.deps/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel.eclipse.deps/META-INF/MANIFEST.MF
@@ -7,9 +7,5 @@ Bundle-Version: 1.4.0.qualifier
 Bundle-Vendor: Salesforce
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: lib/guava-28.2.jar,
- lib/json-20160212.jar
-Export-Package: com.google.common.base;version="28.2",
- com.google.common.collect;version="28.2",
- com.google.common.graph;version="28.2",
- org.json;version="20160212"
+Bundle-ClassPath: lib/json-20160212.jar
+Export-Package: org.json;version="20160212"

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
@@ -39,12 +39,14 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.List;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
 
 public class AspectTargetInfosTest {
@@ -183,8 +185,10 @@ public class AspectTargetInfosTest {
 
     private static AspectTargetInfo getAspectTargetInfo(String label, BazelTargetKind targetKind,
             String... sourcePaths) {
-        return new AspectTargetInfo(new File(""), ImmutableList.of(), ImmutableList.of(), "some/path",
-                targetKind.toString().toLowerCase(), label, ImmutableList.of(), ImmutableList.copyOf(sourcePaths),
+        List<String> sourcePathList = Arrays.asList(sourcePaths);
+
+        return new AspectTargetInfo(new File(""), new ArrayList<>(), new ArrayList<>(), "some/path",
+                targetKind.toString().toLowerCase(), label, new ArrayList<>(), sourcePathList,
                 "main-class");
     }
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputParserTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputParserTest.java
@@ -35,11 +35,11 @@ package com.salesforce.bazel.sdk.command;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.salesforce.bazel.sdk.model.BazelProblem;
 
 public class BazelOutputParserTest {
@@ -47,10 +47,10 @@ public class BazelOutputParserTest {
     @Test
     public void testSingleJavaError() {
         BazelOutputParser p = new BazelOutputParser();
-        List<String> lines = ImmutableList.of(
+        List<String> lines = Arrays.asList(
             "ERROR: /Users/stoens/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building libbanana-api.jar (2 source files) failed (Exit 1)",
             "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:50: error: cannot find symbol",
-            "    this.numSeeds = numSeeds;");
+                "    this.numSeeds = numSeeds;");
 
         List<BazelProblem> errors = p.getErrors(lines);
 
@@ -64,13 +64,13 @@ public class BazelOutputParserTest {
     @Test
     public void testMultipleJavaErrors() {
         BazelOutputParser p = new BazelOutputParser();
-        List<String> lines = ImmutableList.of(
+        List<String> lines = Arrays.asList(
             "ERROR: /Users/stoens/bazel-build-example-for-eclipse/sayhello/BUILD:1:1: Building sayhello/libsayhello.jar (2 source files) failed (Exit 1)",
             "sayhello/src/main/java/com/blah/foo/hello/Main.java:16: error: cannot find symbol", "    blah 1 2 3",
             "             ^",
             "ERROR: /Users/stoens/bazel-build-example-for-eclipse/sayhello/BUILD:1:1: Building sayhello/libsayhello.jar (2 source files) failed (Exit 1)",
             "sayhello/src/main/java/com/blah/foo/hello/Main.java:17: error: cannot find symbols",
-            "INFO: Elapsed time: 0.196s, Critical Path: 0.03s");
+                "INFO: Elapsed time: 0.196s, Critical Path: 0.03s");
 
         List<BazelProblem> errors = p.getErrors(lines);
 
@@ -87,7 +87,7 @@ public class BazelOutputParserTest {
     @Test
     public void testMultipleJavaErrorsWithSameStatus() {
         BazelOutputParser p = new BazelOutputParser();
-        List<String> lines = ImmutableList.of(
+        List<String> lines = Arrays.asList(
             "ERROR: /Users/d.sang/workplace/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building projects/libs/banana/banana-api/libbanana-api.jar (2 source files) failed (Exit 1)\n",
             "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:41: error: ';' expected\n",
             "  public int numSeeds\n", "                     ^\n",
@@ -111,7 +111,7 @@ public class BazelOutputParserTest {
     @Test
     public void testMultipleErrorSourceLines() {
         BazelOutputParser p = new BazelOutputParser();
-        List<String> lines = ImmutableList.of(
+        List<String> lines = Arrays.asList(
             "ERROR: /Users/d.sang/workplace/bazel-demo/main_usecases/java/simplejava-mvnimport/projects/libs/banana/banana-api/BUILD:1:1: Building projects/libs/banana/banana-api/libbanana-api.jar (2 source files) failed (Exit 1)\n",
             "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:41: error: ';' expected\n",
             "projects/libs/banana/banana-api/src/main/java/demo/banana/api/Banana.java:42: error: ';' expected\n",
@@ -139,7 +139,7 @@ public class BazelOutputParserTest {
     public void testUnformattedError() {
         BazelOutputParser p = new BazelOutputParser();
         List<String> lines =
-                ImmutableList.of("ERROR: this is just a string that we should probably handle but we don't right now");
+                Arrays.asList("ERROR: this is just a string that we should probably handle but we don't right now");
 
         List<BazelProblem> errors = p.getErrors(lines);
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelUtilTest.java
@@ -1,8 +1,7 @@
 package com.salesforce.bazel.sdk.model;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,12 +17,12 @@ public class BazelLabelUtilTest {
         BazelLabel l2 = new BazelLabel("d/e/f:t2");
         BazelLabel l3 = new BazelLabel("a/b/c:t2");
 
-        Map<BazelLabel, Collection<BazelLabel>> m = BazelLabelUtil.groupByPackage(Arrays.asList(new BazelLabel[]{l1, l2, l3}));
+        Map<BazelLabel, Collection<BazelLabel>> m = BazelLabelUtil.groupByPackage(Arrays.asList(l1, l2, l3));
 
         assertEquals(2, m.size());
-        assertThat(m.get(new BazelLabel("a/b/c")), hasItem(l1));
-        assertThat(m.get(new BazelLabel("a/b/c")), hasItem(l3));
-        assertThat(m.get(new BazelLabel("d/e/f")), hasItem(l2));
+        assertTrue(m.get(new BazelLabel("a/b/c")).contains(l1));
+        assertTrue(m.get(new BazelLabel("a/b/c")).contains(l3));
+        assertTrue(m.get(new BazelLabel("d/e/f")).contains(l2));
     }
 
 }

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Copyright 2017 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -49,7 +49,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.stubbing.OngoingStubbing;
+
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.mock.EclipseFunctionalTestEnvironmentFactory;
 import com.salesforce.bazel.eclipse.mock.MockEclipse;
@@ -67,11 +67,11 @@ public class BazelClasspathContainerFTest {
     private IJavaProject javalib1_IJavaProject;
 
     /*
-     * CLASSPATH README 
+     * CLASSPATH README
      * - the "raw" classpath is the one set at the project level, and includes the Bazel Classpath Container as a single entry, the JRE as a single entry, etc
      * - the "resolved" classpath is the one where each raw entry contributes back the actual elements; for the Bazel classpath container it will contain
      *     an entry PER dependency for the project (e.g. slf4j-api, log4j, other Bazel workspace packages). Each resolved entry is known as a 'simple' entry.
-     * - referenced entries are the ones written into the .classpath file, which seem to be the raw classpath at least for our use cases 
+     * - referenced entries are the ones written into the .classpath file, which seem to be the raw classpath at least for our use cases
      */
 
     /**


### PR DESCRIPTION
Having guava in BEF wasn't hurting anything, but we don't want it in bazel-java-sdk as that should be as light as possible. We were only using Guava for a few easily replaceable use cases, so just remove it from BEF entirely.