### PR TITLE
initial impl for resource files in Package/Project Explorer

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
@@ -43,22 +43,23 @@ public interface BazelConstants {
     /**
      * The Bazel BUILD files BEF looks for.
      */
+    Collection<String> WORKSPACE_FILE_NAMES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("WORKSPACE", "WORKSPACE.bazel")));
+
+    /**
+     * The Bazel BUILD files BEF looks for.
+     */
     Collection<String> BUILD_FILE_NAMES =
-        Collections.unmodifiableSet(
-            new HashSet<>(
-                Arrays.asList(
-                    new String[]{"BUILD", "BUILD.bazel"})));
+            Collections.unmodifiableSet(
+                new HashSet<>(
+                        Arrays.asList("BUILD", "BUILD.bazel")));
 
     /**
      * The targets configured by default for each imported Bazel package.
      */
     Collection<String> DEFAULT_PACKAGE_TARGETS =
-        Collections.unmodifiableSet(
-            new HashSet<>(
-                Arrays.asList(
-                    // "*" includes test _deploy jars, which we currently need for our Eclipse JUnit
-                    // integration to work - unfortunately building those jars can be slow if there
-                    // are many test targets
-                    new String[]{"*"})));
+            Collections.unmodifiableSet(
+                new HashSet<>(
+                        Arrays.asList("*")));
 
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelDirectoryStructureUtil.java
@@ -63,11 +63,22 @@ public final class BazelDirectoryStructureUtil {
         return false;
     }
 
+    public static boolean isWorkspaceRoot(File repositoryRoot) {
+        Path rootPath = repositoryRoot.toPath();
+        for (String buildFileName : BazelConstants.WORKSPACE_FILE_NAMES) {
+            Path buildFilePath = rootPath.resolve(buildFileName);
+            if (Files.isRegularFile(buildFilePath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static List<String> findBazelPackages(File repositoryRoot, String relativeRepositoryPath) {
         Path rootPath = repositoryRoot.toPath();
         try {
             return
-                Files.walk(rootPath.resolve(relativeRepositoryPath))
+                    Files.walk(rootPath.resolve(relativeRepositoryPath))
                     .filter(Files::isRegularFile)
                     .filter(p -> BazelConstants.BUILD_FILE_NAMES.contains(p.getFileName().toString()))
                     .map(Path::getParent)

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseFileLinker.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseFileLinker.java
@@ -53,20 +53,6 @@ class EclipseFileLinker {
         File f = new File(new File(bazelWorkspaceRootDirectory, packageFSPath), fileName);
         if (f.exists()) {
             IFile projectFile = resourceHelper.getProjectFile(eclipseProject, fileName);
-            if (projectFile.exists()) {
-                // What has happened is the user imported the Bazel workspace into Eclipse, but then deleted it from their Eclipse workspace at some point.
-                // Now they are trying to import it again. Like the IntelliJ plugin we are refusing to do so, but perhaps we will
-                // support this once we are convinced that we are safe to import over an old imported version of the Bazel workspace. TODO
-                // For now, just bail, with a good message.
-                String logMsg =
-                        "You have imported this Bazel workspace into Eclipse previously, but then deleted it from your Eclipse workspace. "
-                                + "This left files on the filesystem in your Eclipse workspace directory and the feature currently does not support overwriting an old imported Bazel workspace. "
-                                + "\nTo import this Bazel workspace, use file system tools to delete the associated Bazel Eclipse project files from the "
-                                + "Eclipse workspace directory, and then try to import again. \nFile: "
-                                + projectFile.getFullPath();
-                // TODO throwing this exception just writes a log message, we need a modal error popup for this error
-                throw new IllegalStateException(logMsg);
-            }
             try {
                 resourceHelper.createFileLink(projectFile, Path.fromOSString(f.getCanonicalPath()), IResource.NONE,
                     null);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectCreator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/EclipseProjectCreator.java
@@ -88,6 +88,26 @@ class EclipseProjectCreator {
         return eclipseProject;
     }
 
+    /**
+     * Links files in the root of package into the Eclipse project.
+     */
+    void linkFilesInPackageDirectory(EclipseFileLinker fileLinker, IProject project, String packageFSPath,
+            File packageDirFile, String fileExtension) {
+        File[] pkgFiles = packageDirFile.listFiles();
+
+        for (File pkgFile : pkgFiles) {
+            if (pkgFile.isFile()) {
+                String name = pkgFile.getName();
+                if (fileExtension != null) {
+                    if (!name.endsWith(fileExtension)) {
+                        continue;
+                    }
+                }
+                fileLinker.link(packageFSPath, project, name);
+            }
+        }
+    }
+
     private static IProject createBaseEclipseProject(String eclipseProjectName, URI location) {
         ResourceHelper resourceHelper = BazelPluginActivator.getResourceHelper();
         IProgressMonitor progressMonitor = null;


### PR DESCRIPTION
The easy part of #180. This only links files that exist when each project is imported. We will need a ResourceChangeListener to link new files as they are created.