### PR TITLE
update-site fixes

### DIFF
--- a/.github/create-update-site.sh
+++ b/.github/create-update-site.sh
@@ -1,0 +1,4 @@
+mkdir update-site
+cp releng/p2repository/target/*.zip update-site
+cp -R releng/p2repository/target/repository update-site/update-site
+cp .github/update-site-index.html update-site/index.html

--- a/.github/update-site-index.html
+++ b/.github/update-site-index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Bazel Eclipse Update Site</title>
+</head>
+<body>
+  <h2>Bazel Eclipse Update Site</h2>
+  This is the update site for installing Bazel Eclipse.
+  Follow these instructions:
+
+  <ul>
+    <li>In Eclipse, select the menu Eclipse -> Help -> Install New Software...</li>
+    <li>Click the Add button.</li>
+    <li>Enter a name, 'Bazel Eclipse' for example.</li>
+    <li>For location, enter https://opensource.salesforce.com/bazel-eclipse/update-site</li>
+    <li>Click the Add button.</li>
+    <li>Click the Bazel Eclipse Feature check box</li>
+    <li>Click on Next until the feature is installed.</li>
+  </ul>
+
+  Welcome to Bazel Eclipse!
+
+  <footer>Salesforce.com</footer>
+</body>
+</html>

--- a/.github/workflows/build-release-deploy.yml
+++ b/.github/workflows/build-release-deploy.yml
@@ -45,14 +45,10 @@ jobs:
           BUILD_LABEL: "CI ${{ steps.time.outputs.time }} (${{ steps.branch_name.outputs.branch }})"
         run: mvn --batch-mode clean verify
 
-      - name: Copy built BEF zip file into the update site location
+      - name: Create the update-site layout on the filesystem
         id: create_layout
         shell: bash
-        run:
-          mkdir update-site
-          echo "This is the Bazel Eclipse update site." > update-site/index.html
-          cp releng/p2repository/target/*.zip update-site
-          cp -R releng/p2repository/target/repository update-site/update-site
+        run: .github/create-update-site.sh
 
       - name: Deploy Update Site 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.1
@@ -61,4 +57,3 @@ jobs:
           folder: update-site
           single-commit: true
           ssh-key: ${{ secrets.DEPLOY_KEY }}
-          target-folder: update-site

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,3 @@ pom.tycho
 
 # other
 *.patch
-
-# GitHub Action Workflows
-update-site


### PR DESCRIPTION
GitHub pages is now a toplevel index.html with the update-site in a subdir.

https://opensource.salesforce.com/bazel-eclipse/