### PR TITLE
add instructions to install from marketplace

### DIFF
--- a/.github/update-site-index.html
+++ b/.github/update-site-index.html
@@ -5,8 +5,18 @@
   <title>Bazel Eclipse Update Site</title>
 </head>
 <body>
-  <h2>Bazel Eclipse Update Site</h2>
-  This is the update site for installing Bazel Eclipse.
+  <h2>Bazel Eclipse Installation</h2>
+
+  This is the installation site for Bazel Eclipse.
+  You can read up on Bazel Eclipse <a href="https://github.com/salesforce/bazel-eclipse/blob/master/README.md">in the documentation</a>
+  <p/>
+  The easiest way to install Bazel Eclipse is to drag the install button below onto your
+  running Eclipse IDE and search for <i>Bazel</i>. Try it!
+  <p/>
+  <a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5403450" class="drag" title="Drag to your running Eclipse* workspace."><img style="width:80px;" typeof="foaf:Image" class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.svg" alt="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client" /></a>
+
+  <p/>
+  There is also an update site for installing Bazel Eclipse.
   Follow these instructions:
 
   <ul>
@@ -20,7 +30,8 @@
   </ul>
 
   Welcome to Bazel Eclipse!
-
+  <p/>
+  &nbsp
   <footer>Salesforce.com</footer>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ The **2.x** release line will work towards adding Bazel specific features to Ecl
 
 ## Using the Feature
 
-For detailed installation and setup instructions, see this page:
+**Quick Installation**
+
+Drag the _Install_ button and drop on your running Eclipse IDE and search for _Bazel_.
+It is that easy!
+
+<a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5403450" class="drag" title="Drag to your running Eclipse workspace.">
+  <img style="width:80px;" typeof="foaf:Image" class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.svg" alt="Drag to your running Eclipse workspace." />
+</a>
+
+**Detailed Installation and User's Guides**
+
+For detailed manual installation and setup instructions, and the User's Guide, see these pages:
 
 - [Installing Eclipse and the Bazel Eclipse Feature](docs/install.md)
 - [Bazel Eclipse Feature User's Guide](docs/using_the_feature.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,10 +48,20 @@ Choose a version of Bazel that is at least as high as that check.
 
 ### Installing the Bazel Eclipse feature into Eclipse
 
-First, understand what releases of BEF are available, which is [covered on this page](releases.md).
-Next, follow these steps to install it in your Eclipse IDE.
+**Quick Installation**
 
-**Install the Bazel Eclipse feature into Eclipse:**
+Drag the _Install_ button and drop on your running Eclipse IDE, and search for _Bazel_.
+It is that easy!
+
+<a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=5403450" class="drag" title="Drag to your running Eclipse workspace.">
+  <img style="width:80px;" typeof="foaf:Image" class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.svg" alt="Drag to your running Eclipse workspace." />
+</a>
+
+**Manually Install the Bazel Eclipse feature into Eclipse:**
+
+First, understand what releases of BEF are available, which is [covered on the Releases page](releases.md).
+If you want to install the latest version of BEF, follow these steps to install it in your Eclipse IDE using the update site:
+
 - Start Eclipse.
 - In Eclipse, go to *Help* -> *Install New Software*
 - Click the *Add* button
@@ -60,6 +70,8 @@ Next, follow these steps to install it in your Eclipse IDE.
 - Check the box next to the *Bazel Eclipse* item, then hit *Next*
 - Click *Next/Agree/Finish* until it completes.
 - Restart Eclipse
+
+Otherwise, you can install older versions of BEF using the archive zip files that are listed [on the Releases page](releases.md).
 
 **To verify that it is installed:**
 - Start Eclipse


### PR DESCRIPTION
Marketplace has a really cool **Install** button feature. Adding it to our site and our docs.

It is already live here:
https://opensource.salesforce.com/bazel-eclipse/index.html