### PR TITLE
incremental improvement of path support

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
@@ -1,5 +1,7 @@
 package com.salesforce.bazel.sdk.command.test;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Filter that enables Bazel command output to be associated with a particular command. By providing a list of these,
  * you can make sure that the output lines are only returned to the caller if all matchers return true.
@@ -12,8 +14,9 @@ public class MockCommandSimulatedOutputMatcher {
         matchArgIndex = index;
         matchArgRegex = regex;
 
-        if (matchArgRegex.contains("\\")) {
-            matchArgRegex = matchArgRegex.replace("\\", "\\\\");
+        if (matchArgRegex.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
+            matchArgRegex =
+                    matchArgRegex.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX);
         }
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Writes json files to the Bazel output file system that mimic what is written by the Bazel aspects. Each json file
@@ -51,7 +51,7 @@ public class TestAspectFileCreator {
      * @return the absolute File path to the file
      */
     static String createJavaAspectFileForMavenJar(File outputBase, String mavenJarName, String actualJarNameNoSuffix) {
-        String externalName = "external" + "/" + mavenJarName; // $SLASH_OK
+        String externalName = "external" + BazelPathHelper.UNIX_SLASH + mavenJarName;
         String dependencies = null;
         List<String> sources = null;
         String mainClass = null;
@@ -218,7 +218,7 @@ public class TestAspectFileCreator {
         if (sources != null) {
             for (String source : sources) {
                 sb.append("    \""); // $SLASH_OK: escape char
-                source = source.replace("\\", "\\\\"); // hack because Windows paths need to be json escaped
+                source = source.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX); // hack because Windows paths need to be json escaped
                 sb.append(source);
                 sb.append("\",\n"); // $SLASH_OK: line continue
             }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Descriptor for a manufactured bazel package in a test workspace.
  */
@@ -26,7 +28,7 @@ public class TestBazelPackageDescriptor {
     public TestBazelPackageDescriptor(TestBazelWorkspaceDescriptor parentWorkspace, String packagePath,
             String packageName, File diskLocation) {
 
-        if (packagePath.contains("\\")) {
+        if (packagePath.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
             // Windows bug, someone passed in a Windows path
             throw new IllegalArgumentException(
                     "Windows filesystem path passed to TestBazelPackageDescriptor instead of the Bazel package path: "

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Utility class to generate a Bazel workspace and other artifacts on the filesystem. As of this writing, the workspace

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Map;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class TestJavaRuleCreator {
     public static void createJavaBuildFile(TestBazelWorkspaceDescriptor workspaceDescriptor, File buildFile,

--- a/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Export-Package: com.salesforce.bazel.sdk.aspect,
  com.salesforce.bazel.sdk.lang.jvm.external,
  com.salesforce.bazel.sdk.logging,
  com.salesforce.bazel.sdk.model,
+ com.salesforce.bazel.sdk.path,
  com.salesforce.bazel.sdk.project,
  com.salesforce.bazel.sdk.util,
  com.salesforce.bazel.sdk.workspace

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsPollingFileStream.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/BazelBuildEventsPollingFileStream.java
@@ -7,8 +7,8 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
 
 /**
  * Bazel build event protocol stream (BEP) for a Bazel workspace. A BEP stream allows you to monitor and react to build
- * events emitted from Bazel. This implementation spawns a thread and actively polls one or more BEP files for new events.
- * It is intelligent and will only reparse a file if the file modification time has changed.
+ * events emitted from Bazel. This implementation spawns a thread and actively polls one or more BEP files for new
+ * events. It is intelligent and will only reparse a file if the file modification time has changed.
  * <p>
  * Because this stream integrates with your builds with Bazel using BEP, this stream will work with command line builds
  * but also with IDE builds.
@@ -46,7 +46,7 @@ public class BazelBuildEventsPollingFileStream extends BazelBuildEventsFileStrea
      */
     public void addFileToMonitor(File bepFile, boolean parseOnStart) {
         BEPMonitoredFile monitoredFile = addFileToMonitor_Internal(bepFile);
-        
+
         // if caller does not want the initial state parsed, capture the current last mod
         if (!parseOnStart && monitoredFile.file.exists()) {
             monitoredFile.fileLastModifiedMS = monitoredFile.file.lastModified();
@@ -101,7 +101,8 @@ public class BazelBuildEventsPollingFileStream extends BazelBuildEventsFileStrea
                     long currentLastMod = monitoredFile.file.lastModified();
                     if (currentLastMod == monitoredFile.fileLastModifiedMS) {
                         // the file hasn't changed since we last parsed it, bail
-                        LOG.info("FilePoller will not parse [{}] because it hasn't changed.", monitoredFile.file.getName());
+                        LOG.info("FilePoller will not parse [{}] because it hasn't changed.",
+                            monitoredFile.file.getName());
                         continue;
                     }
                     monitoredFile.fileLastModifiedMS = currentLastMod;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/event/BEPNamedSetEvent.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/event/BEPNamedSetEvent.java
@@ -34,22 +34,13 @@ public class BEPNamedSetEvent extends BEPEvent {
     // PARSER
 
     /**
-     * "namedSetOfFiles":{
-     *  "files":[
-     *    {
-     *       "name":"foo/bar/mylib2.jar",
-     *       "uri":"file:///private/var/tmp/_bazel_mbenioff/8fc74f66fda297c82a847368ee50d6a4/execroot/myrepo/bazel-out/darwin-fastbuild/bin/foo/bar/mylib.jar",
-     *       "pathPrefix":[ "bazel-out", "darwin-fastbuild", "bin" ]
-     *    },
-     *    {
-     *      "name":"foo/bar/mylib2.jar",
-     *      "uri":"file:///private/var/tmp/_bazel_mbenioff/8fc74f66fda297c82a847368ee50d6a4/execroot/myrepo/bazel-out/darwin-fastbuild/bin/foo/bar/mylib2.jar",
-     *      "pathPrefix":[ "bazel-out", "darwin-fastbuild", "bin" ]
-     *    }
-     * ]
-     * }
+     * "namedSetOfFiles":{ "files":[ { "name":"foo/bar/mylib2.jar",
+     * "uri":"file:///private/var/tmp/_bazel_mbenioff/8fc74f66fda297c82a847368ee50d6a4/execroot/myrepo/bazel-out/darwin-fastbuild/bin/foo/bar/mylib.jar",
+     * "pathPrefix":[ "bazel-out", "darwin-fastbuild", "bin" ] }, { "name":"foo/bar/mylib2.jar",
+     * "uri":"file:///private/var/tmp/_bazel_mbenioff/8fc74f66fda297c82a847368ee50d6a4/execroot/myrepo/bazel-out/darwin-fastbuild/bin/foo/bar/mylib2.jar",
+     * "pathPrefix":[ "bazel-out", "darwin-fastbuild", "bin" ] } ] }
      */
-    
+
     private void parseDetails(JSONObject setDetail) {
         JSONArray filesArray = (JSONArray) setDetail.get("files");
         if (filesArray != null && filesArray.size() > 0) {
@@ -66,8 +57,7 @@ public class BEPNamedSetEvent extends BEPEvent {
 
     @Override
     public String toString() {
-        return "BEPNamedSetOfFilesEvent [files=" + files + ", index=" + index + ", eventType="
-                + eventType + ", isProcessed=" + isProcessed + ", isLastMessage=" + isLastMessage + ", isError="
-                + isError + "]";
+        return "BEPNamedSetOfFilesEvent [files=" + files + ", index=" + index + ", eventType=" + eventType
+                + ", isProcessed=" + isProcessed + ", isLastMessage=" + isLastMessage + ", isError=" + isError + "]";
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileParser.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/bep/file/BEPFileParser.java
@@ -58,7 +58,7 @@ public class BEPFileParser {
             // if there are less than 100 bytes in the file, it means there isn't anything interesting to look at yet
             // so just cut off our processing early
             LOG.debug(callerForLog + ": Halting processing of BEP file " + bepFile.getAbsolutePath()
-            + " because it has a short length of [" + bepFile.length() + "] bytes.");
+                    + " because it has a short length of [" + bepFile.length() + "] bytes.");
             return result;
         }
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
@@ -34,14 +34,10 @@
 package com.salesforce.bazel.sdk.command;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Knows how to build paths to various files under bazel output directories (bazel-bin etc)
- *
- * @author stoens
- * @since summer 2019
- *
  */
 public class BazelOutputDirectoryBuilder {
 
@@ -52,10 +48,15 @@ public class BazelOutputDirectoryBuilder {
      */
     public String getRunScriptPath(BazelLabel label) {
         StringBuilder sb = new StringBuilder();
-        sb.append("bazel-bin/");
+        sb.append("bazel-bin");
+        sb.append(BazelPathHelper.UNIX_SLASH);
         sb.append(label.getPackagePath());
-        sb.append("/");
+        sb.append(BazelPathHelper.UNIX_SLASH);
         sb.append(label.getTargetName());
-        return BazelPathHelper.osSeps(sb.toString());
+
+        // generate the String, converting to Windows style path if necessary
+        String path = BazelPathHelper.osSeps(sb.toString());
+
+        return path;
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
@@ -33,6 +33,7 @@ import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
 import com.salesforce.bazel.sdk.index.model.ClassIdentifier;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Crawler that descends into nested directories of jar files and adds found files to the index.
@@ -144,7 +145,7 @@ public class JavaJarCrawler {
                 continue;
             }
             // convert path / into . to form the legal package name, and trim the .class off the end
-            fqClassname = fqClassname.replace("/", ".");
+            fqClassname = fqClassname.replace(BazelPathHelper.JAR_SLASH, ".");
             fqClassname = fqClassname.substring(0, fqClassname.length() - 6);
             LOG.debug("Indexer found classname: {} in jar {}", fqClassname, jarId.locationIdentifier);
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
@@ -32,7 +32,7 @@ import com.salesforce.bazel.sdk.index.CodeIndex;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.index.model.CodeLocationIdentifier;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Crawler that descends into nested directories of source files and adds found files to the index.
@@ -105,8 +105,10 @@ public class SourceFileCrawler {
                         }
                         String childRelative = candidateFile.getName();
                         if (!relativePathToClosestArtifact.isEmpty()) {
-                            childRelative = BazelPathHelper
-                                    .osSeps(relativePathToClosestArtifact + "/" + candidateFile.getName()); // $SLASH_OK
+                            childRelative = relativePathToClosestArtifact + BazelPathHelper.UNIX_SLASH
+                                    + candidateFile.getName();
+                            // convert to Windows path if necessary
+                            childRelative = BazelPathHelper.osSeps(childRelative);
                         }
                         indexRecur(candidateFile, childRelative, closestArtifactLocationDescriptor, false);
                     } else if (candidateFile.canRead()) {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
@@ -33,6 +33,8 @@
  */
 package com.salesforce.bazel.sdk.model;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Answers to everything you've always wanted to ask a Bazel Label.
  * </p>
@@ -63,7 +65,7 @@ public class BazelLabel {
         if (label == null) {
             throw new IllegalArgumentException("label cannot be null");
         }
-        if (label.contains("\\")) {
+        if (label.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
             // the caller is passing us a label with \ as separators, probably a bug due to Windows paths
             throw new IllegalArgumentException(
                     "Label [" + label + "] has Windows style path delimeters. Bazel paths always have / delimiters");
@@ -144,7 +146,7 @@ public class BazelLabel {
         int i = packagePath.lastIndexOf("...");
         if (i != -1) {
             packagePath = packagePath.substring(0, i);
-            if (packagePath.endsWith("/")) { // $SLASH_OK: bazel path
+            if (packagePath.endsWith(BazelPathHelper.BAZEL_SLASH)) {
                 packagePath = packagePath.substring(0, packagePath.length() - 1);
             }
         } else {
@@ -179,7 +181,7 @@ public class BazelLabel {
      */
     public String getPackageName() {
         String packagePath = getPackagePath();
-        int i = packagePath.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int i = packagePath.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         return i == -1 ? packagePath : packagePath.substring(i + 1);
     }
 
@@ -215,7 +217,7 @@ public class BazelLabel {
         if (targetName == null) {
             return null;
         }
-        int i = targetName.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int i = targetName.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         if (i != -1) {
             return targetName.substring(i + 1); // ok because target name cannot end with slash
         }
@@ -270,7 +272,7 @@ public class BazelLabel {
             throw new IllegalAccessError(path);
         }
         path = path.trim();
-        if (path.endsWith("/")) { // $SLASH_OK: bazel path
+        if (path.endsWith(BazelPathHelper.BAZEL_SLASH)) {
             path = path.substring(0, path.length() - 1);
         }
         return path;
@@ -298,7 +300,7 @@ public class BazelLabel {
         if (label.endsWith(":")) {
             throw new IllegalArgumentException(label);
         }
-        if (label.endsWith("/")) { // $SLASH_OK: bazel path
+        if (label.endsWith(BazelPathHelper.BAZEL_SLASH)) {
             throw new IllegalArgumentException(label);
         }
         if (label.equals("//")) {
@@ -307,7 +309,7 @@ public class BazelLabel {
         if (label.startsWith("//")) {
             label = label.substring(2);
         }
-        if (label.startsWith("/")) { // $SLASH_OK: bazel path
+        if (label.startsWith(BazelPathHelper.BAZEL_SLASH)) {
             label = label.substring(1);
         }
         return label;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
@@ -40,6 +40,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 /**
  * Model class for a Bazel Java package. It is a node in a tree of the hierarchy of packages. The root node in this tree
  * is the directory which contains the WORKSPACE file, and is a special case in that it does not typically represent
@@ -315,19 +317,19 @@ public class BazelPackageInfo implements BazelPackageLocation {
         }
 
         // split the file system path by OS path separator
-        String regex = "/";
-        if (File.separator.equals("\\")) {
-            regex = "\\\\";
+        String regex = BazelPathHelper.UNIX_SLASH;
+        if (File.separator.equals(BazelPathHelper.WINDOWS_BACKSLASH)) {
+            regex = BazelPathHelper.WINDOWS_BACKSLASH_REGEX;
         }
         String[] pathElements = relativeWorkspacePath.split(regex);
 
         // assemble the path elements into a proper Bazel package name
-        String name = "/"; // $SLASH_OK: bazel path
+        String name = BazelPathHelper.BAZEL_SLASH;
         for (String e : pathElements) {
             if (e.isEmpty()) {
                 continue;
             }
-            name = name + "/" + e; // $SLASH_OK: bazel path
+            name = name + BazelPathHelper.BAZEL_SLASH + e;
         }
 
         // set computedPackageName only when done computing it, to avoid threading issues
@@ -348,7 +350,7 @@ public class BazelPackageInfo implements BazelPackageLocation {
         if (computedPackageNameLastSegment != null) {
             return computedPackageNameLastSegment;
         }
-        int lastSlash = computedPackageName.lastIndexOf("/"); // $SLASH_OK: bazel path
+        int lastSlash = computedPackageName.lastIndexOf(BazelPathHelper.BAZEL_SLASH);
         if (lastSlash == -1) {
             computedPackageNameLastSegment = "";
             return computedPackageNameLastSegment;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * A wrapper for a Bazel logical "problem" (error/warning).
@@ -147,7 +147,7 @@ public class BazelProblem {
 
     private String getRelativeResourcePath(BazelLabel label) {
         String bazelPackagePath = label.getPackagePath();
-        String relativeFilePath = BazelPathHelper.osSeps(bazelPackagePath + "/");
+        String relativeFilePath = BazelPathHelper.osSeps(bazelPackagePath + BazelPathHelper.UNIX_SLASH);
         if (resourcePath.startsWith(relativeFilePath) && (resourcePath.length() > (relativeFilePath.length()))) {
             return File.separator + resourcePath.substring(relativeFilePath.length());
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/InMemoryBazelPackageLocation.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/InMemoryBazelPackageLocation.java
@@ -26,7 +26,7 @@ public class InMemoryBazelPackageLocation implements BazelPackageLocation {
             this.path = path;
         }
         this.lastSegment = "";
-        int lastSlash = path.indexOf("/");
+        int lastSlash = path.indexOf(File.separator);
         if (lastSlash > 0) {
             this.lastSegment = path.substring(lastSlash + 1);
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/BazelPathHelper.java
@@ -1,0 +1,138 @@
+package com.salesforce.bazel.sdk.path;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.salesforce.bazel.sdk.logging.LogHelper;
+
+/**
+ * Static utilities to help with file system paths, especially cross platform.
+ */
+public class BazelPathHelper {
+    private static final LogHelper LOG = LogHelper.log(BazelPathHelper.class);
+
+    // Slash character for Bazel paths; this is provided as a constant to help code searches
+    // for Bazel specific code. 
+    public static final String BAZEL_SLASH = "/";
+
+    // Slash character for unix file paths; this is provided as a constant to help code searches
+    // for Unix specific code. 
+    public static final String UNIX_SLASH = "/";
+
+    // Backslash character; this is provided as a constant to help code searches
+    // for Windows specific code. There are two backslash characters because Java 
+    // requires a leading backslash to encode a backslash
+    public static final String WINDOWS_BACKSLASH = "\\";
+
+    // Regex pattern to use to look for a single backslash character in a path
+    // why 4? 
+    // Regex needs a double \ to escape backslash in the matcher (1+1=2)
+    // Java requires a backslash to encode a backslash in the String (2x2=4)
+    public static final String WINDOWS_BACKSLASH_REGEX = "\\\\";
+
+    // Slash character for file paths in jar files; this is provided as a constant to help code searches
+    // for Jar specific code. 
+    public static final String JAR_SLASH = "/";
+
+    /**
+     * Primary feature toggle. isUnix is true for all platforms except Windows.
+     */
+    public static boolean isUnix = true;
+
+    static {
+        if (System.getProperty("os.name").contains("Windows")) {
+            isUnix = false;
+        }
+    }
+
+    /**
+     * Resolve softlinks and other abstractions in the workspace paths.
+     */
+    public static File getCanonicalFileSafely(File directory) {
+        if (directory == null) {
+            return null;
+        }
+        try {
+            directory = directory.getCanonicalFile();
+        } catch (IOException ioe) {
+            LOG.error("error locating path [{}] on the file system", ioe, directory.getAbsolutePath());
+        }
+        return directory;
+    }
+
+    /**
+     * Resolve softlinks and other abstractions in the workspace paths.
+     */
+    public static String getCanonicalPathStringSafely(File directory) {
+        String path = null;
+        if (directory == null) {
+            return null;
+        }
+        try {
+            path = directory.getCanonicalPath();
+        } catch (IOException ioe) {
+            LOG.error("error locating path [{}] on the file system", ioe, directory.getAbsolutePath());
+        }
+        if (path == null) {
+            // fallback to absolute path in case canonical path fails
+            path = directory.getAbsolutePath();
+        }
+        return path;
+    }
+
+    /**
+     * Resolve softlinks and other abstractions in the workspace paths.
+     */
+    public static String getCanonicalPathStringSafely(String path) {
+        if (path == null) {
+            return null;
+        }
+        try {
+            path = new File(path).getCanonicalPath();
+        } catch (IOException ioe) {
+            LOG.error("error locating path [{}] on the file system", ioe, path);
+        }
+        return path;
+    }
+
+    public static String osSepRegex() {
+        if (isUnix) {
+            return UNIX_SLASH;
+        }
+        return WINDOWS_BACKSLASH_REGEX;
+    }
+
+    /**
+     * Convert a slash style relative path to Windows backslash, if running on Windows
+     */
+    public static String osSeps(String unixStylePath) {
+        String path = unixStylePath;
+        if (!isUnix) {
+            path = unixStylePath.replace(UNIX_SLASH, WINDOWS_BACKSLASH);
+        }
+        return path;
+    }
+
+    /**
+     * Convert a slash style relative path to Windows backslash, if running on Windows. Replace with two back slashes if
+     * so, as the consumer needs escaped backslashes.
+     */
+    public static String osSepsEscaped(String unixStylePath) {
+        String path = unixStylePath;
+        if (!isUnix) {
+            path = unixStylePath.replace(UNIX_SLASH, WINDOWS_BACKSLASH);
+        }
+        return path;
+    }
+
+    /**
+     * Convert a slash style relative path to Windows backslash, if running on Windows
+     */
+    public static String bazelLabelSeps(String fsPath) {
+        String path = fsPath;
+        if (!isUnix) {
+            path = fsPath.replace(WINDOWS_BACKSLASH, UNIX_SLASH);
+        }
+        return path;
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
@@ -4,8 +4,8 @@ import java.io.File;
 import java.util.Set;
 
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.util.BazelConstants;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
 import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
 
 /**

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
@@ -7,7 +7,7 @@ import org.json.simple.JSONObject;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectOutputJarSet;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class AspectOutputJarsTest {
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class AspectTargetInfosTest {
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
@@ -42,7 +42,7 @@ import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelOutputDirectoryBuilderTest {
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelTest.java
@@ -43,6 +43,8 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
+
 public class BazelLabelTest {
 
     @Test
@@ -209,7 +211,7 @@ public class BazelLabelTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidLabel_trailingSlash() {
-        new BazelLabel("/"); // $SLASH_OK bazel path
+        new BazelLabel(BazelPathHelper.BAZEL_SLASH);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProblemTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProblemTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelProblemTest {
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.model.test.MockBazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.model.test.MockOperatingEnvironmentDetectionStrategy;
-import com.salesforce.bazel.sdk.util.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 public class BazelWorkspaceTest {
 


### PR DESCRIPTION
Work towards better modelling in the SDK to use classes to explicitly model paths such that we don't introduce windows bugs by mistake. This PR mostly adds constants so that "/" and "\" patterns are searchable in the code base.

Lots of diffs because I moved BazelPathHelper into a new package.