### PR TITLE
final refactor of path related code in BEF/SDK (copybara)

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommand.java
@@ -32,7 +32,7 @@ import org.mockito.Mockito;
 
 import com.salesforce.bazel.sdk.command.BazelProcessBuilder;
 import com.salesforce.bazel.sdk.command.Command;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
@@ -143,13 +143,13 @@ public class MockCommand implements Command {
             return true;
         }
 
-        if (target.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
+        if (target.startsWith(BazelLabel.BAZEL_ROOT_SLASHES)) {
             target = target.substring(2);
         }
         String packageLabel = target;
         // TODO also need to check for ... and :all
-        String ruleName = BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR;
-        int colonIndex = target.indexOf(BazelPathHelper.BAZEL_COLON);
+        String ruleName = BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR;
+        int colonIndex = target.indexOf(BazelLabel.BAZEL_COLON);
         if (colonIndex >= 0) {
             packageLabel = target.substring(0, colonIndex);
             ruleName = target.substring(colonIndex + 1);
@@ -158,7 +158,7 @@ public class MockCommand implements Command {
         if (testWorkspaceFactory.workspaceDescriptor.getCreatedPackageByName(packageLabel) == null) {
             returnFalseOrThrow(target);
         }
-        if (!ruleName.equals(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR)) {
+        if (!ruleName.equals(BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR)) {
             // * ruleName is always valid, but if there is a specific rule we need to check
             if (testWorkspaceFactory.workspaceDescriptor.createdTargets.get(target) == null) {
                 returnFalseOrThrow(target);

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandSimulatedOutputMatcher.java
@@ -1,6 +1,6 @@
 package com.salesforce.bazel.sdk.command.test;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Filter that enables Bazel command output to be associated with a particular command. By providing a list of these,
@@ -14,9 +14,9 @@ public class MockCommandSimulatedOutputMatcher {
         matchArgIndex = index;
         matchArgRegex = regex;
 
-        if (matchArgRegex.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
+        if (matchArgRegex.contains(FSPathHelper.WINDOWS_BACKSLASH)) {
             matchArgRegex =
-                    matchArgRegex.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX);
+                    matchArgRegex.replace(FSPathHelper.WINDOWS_BACKSLASH, FSPathHelper.WINDOWS_BACKSLASH_REGEX);
         }
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutput;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutputMatcher;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 
 /**
@@ -71,7 +71,7 @@ public class MockBuildCommand extends MockCommand {
             // the last arg is the package path with the wildcard target (//projects/libs/javalib0:*)
             // TODO this is returning the same set of aspects for each target in a package
             String wildcardTarget =
-                    BazelPathHelper.BAZEL_ROOT_SLASHES + packagePath + BazelPathHelper.BAZEL_COLON + ".*";
+                    BazelLabel.BAZEL_ROOT_SLASHES + packagePath + BazelLabel.BAZEL_COLON + ".*";
             MockCommandSimulatedOutputMatcher aspectCommandMatcher3 =
                     new MockCommandSimulatedOutputMatcher(7, wildcardTarget);
 

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestAspectFileCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Writes json files to the Bazel output file system that mimic what is written by the Bazel aspects. Each json file
@@ -51,21 +51,21 @@ public class TestAspectFileCreator {
      * @return the absolute File path to the file
      */
     static String createJavaAspectFileForMavenJar(File outputBase, String mavenJarName, String actualJarNameNoSuffix) {
-        String externalName = "external" + BazelPathHelper.UNIX_SLASH + mavenJarName;
+        String externalName = "external" + FSPathHelper.UNIX_SLASH + mavenJarName;
         String dependencies = null;
         List<String> sources = null;
         String mainClass = null;
         String label = "@" + mavenJarName + "//jar:jar";
         String kind = "java_import";
-        String jar = BazelPathHelper.osSepsEscaped(externalName + "/jar/" + actualJarNameNoSuffix + ".jar"); // $SLASH_OK
+        String jar = FSPathHelper.osSepsEscaped(externalName + "/jar/" + actualJarNameNoSuffix + ".jar"); // $SLASH_OK
         String interfacejar = null;
         String sourcejar =
-                BazelPathHelper.osSepsEscaped(externalName + "/jar/" + actualJarNameNoSuffix + "-sources.jar"); // $SLASH_OK
+                FSPathHelper.osSepsEscaped(externalName + "/jar/" + actualJarNameNoSuffix + "-sources.jar"); // $SLASH_OK
 
-        String json = createAspectJsonForJavaArtifact(BazelPathHelper.osSepsEscaped(externalName + "/jar/BUILD.bazel"), // $SLASH_OK
+        String json = createAspectJsonForJavaArtifact(FSPathHelper.osSepsEscaped(externalName + "/jar/BUILD.bazel"), // $SLASH_OK
             dependencies, sources, mainClass, label, kind, jar, interfacejar, sourcejar);
         File aspectJsonFile =
-                createJavaAspectFileWithThisJson(outputBase, BazelPathHelper.osSepsEscaped(externalName + "/jar"), // $SLASH_OK
+                createJavaAspectFileWithThisJson(outputBase, FSPathHelper.osSepsEscaped(externalName + "/jar"), // $SLASH_OK
                     "jar.bzljavasdk-data.json", json);
 
         return aspectJsonFile.getAbsolutePath();
@@ -95,13 +95,13 @@ public class TestAspectFileCreator {
         }
         String mainClass = null;
         String label = packageRelativePath + ":" + targetName;
-        String jar = BazelPathHelper
+        String jar = FSPathHelper
                 .osSepsEscaped("bazel-out/darwin-fastbuild/bin/" + packageRelativePath + "/lib" + targetName + ".jar");
-        String interfacejar = BazelPathHelper.osSepsEscaped(
+        String interfacejar = FSPathHelper.osSepsEscaped(
             "bazel-out/darwin-fastbuild/bin/" + packageRelativePath + "/lib" + targetName + "-hjar.jar");
-        String sourcejar = BazelPathHelper.osSepsEscaped(
+        String sourcejar = FSPathHelper.osSepsEscaped(
             "bazel-out/darwin-fastbuild/bin/" + packageRelativePath + "/lib" + targetName + "-src.jar");
-        String buildFile = BazelPathHelper.osSepsEscaped(packageRelativePath + "/BUILD");
+        String buildFile = FSPathHelper.osSepsEscaped(packageRelativePath + "/BUILD");
 
         return createAspectJsonForJavaArtifact(buildFile, dependencies, sources, mainClass, label, "java_library", jar,
             interfacejar, sourcejar);
@@ -137,12 +137,12 @@ public class TestAspectFileCreator {
         }
         String mainClass = null;
         String label = packageRelativePath + ":" + testTargetName;
-        String jar = BazelPathHelper.osSepsEscaped(
+        String jar = FSPathHelper.osSepsEscaped(
             "bazel-out/darwin-fastbuild/bin/" + packageRelativePath + "/lib" + testTargetName + ".jar");
         String interfacejar = null;
-        String sourcejar = BazelPathHelper.osSepsEscaped(
+        String sourcejar = FSPathHelper.osSepsEscaped(
             "bazel-out/darwin-fastbuild/bin/" + packageRelativePath + "/lib" + testTargetName + "-src.jar");
-        String buildFile = BazelPathHelper.osSepsEscaped(packageRelativePath + "/BUILD");
+        String buildFile = FSPathHelper.osSepsEscaped(packageRelativePath + "/BUILD");
 
         return createAspectJsonForJavaArtifact(buildFile, dependencies, sources, mainClass, label, "java_test", jar,
             interfacejar, sourcejar);
@@ -218,7 +218,7 @@ public class TestAspectFileCreator {
         if (sources != null) {
             for (String source : sources) {
                 sb.append("    \""); // $SLASH_OK: escape char
-                source = source.replace(BazelPathHelper.WINDOWS_BACKSLASH, BazelPathHelper.WINDOWS_BACKSLASH_REGEX); // hack because Windows paths need to be json escaped
+                source = source.replace(FSPathHelper.WINDOWS_BACKSLASH, FSPathHelper.WINDOWS_BACKSLASH_REGEX); // hack because Windows paths need to be json escaped
                 sb.append(source);
                 sb.append("\",\n"); // $SLASH_OK: line continue
             }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Descriptor for a manufactured bazel package in a test workspace.
@@ -28,7 +28,7 @@ public class TestBazelPackageDescriptor {
     public TestBazelPackageDescriptor(TestBazelWorkspaceDescriptor parentWorkspace, String packagePath,
             String packageName, File diskLocation) {
 
-        if (packagePath.contains(BazelPathHelper.WINDOWS_BACKSLASH)) {
+        if (packagePath.contains(FSPathHelper.WINDOWS_BACKSLASH)) {
             // Windows bug, someone passed in a Windows path
             throw new IllegalArgumentException(
                     "Windows filesystem path passed to TestBazelPackageDescriptor instead of the Bazel package path: "

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelTargetDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelTargetDescriptor.java
@@ -1,6 +1,6 @@
 package com.salesforce.bazel.sdk.workspace.test;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 
 /**
  * Descriptor for a manufactured target (java_library, java_test, etc) in a manufactured bazel package in a test
@@ -21,7 +21,7 @@ public class TestBazelTargetDescriptor {
 
     public TestBazelTargetDescriptor(TestBazelPackageDescriptor parentPackage, String targetName, String targetType) {
         this.parentPackage = parentPackage;
-        this.targetPath = parentPackage.packagePath + BazelPathHelper.BAZEL_COLON + targetName;
+        this.targetPath = parentPackage.packagePath + BazelLabel.BAZEL_COLON + targetName;
         this.targetName = targetName;
         this.targetType = targetType;
 

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Utility class to generate a Bazel workspace and other artifacts on the filesystem. As of this writing, the workspace
@@ -64,7 +65,7 @@ public class TestBazelWorkspaceFactory {
         }
 
         // make the test runner jar file, just in case a project in this workspace uses it (see ImplicitDependencyHelper)
-        String testRunnerPath = BazelPathHelper
+        String testRunnerPath = FSPathHelper
                 .osSeps("external/bazel_tools/tools/jdk/_ijar/TestRunner/external/remote_java_tools_linux/java_tools"); // $SLASH_OK
         File testRunnerDir = new File(workspaceDescriptor.dirBazelBin, testRunnerPath);
         testRunnerDir.mkdirs();
@@ -85,7 +86,7 @@ public class TestBazelWorkspaceFactory {
         for (int i = 0; i < workspaceDescriptor.numberJavaPackages; i++) {
             String packageName = "javalib" + i;
             String packageRelativeBazelPath = libsRelativeBazelPath + "/" + packageName; // $SLASH_OK bazel path
-            String packageRelativeFilePath = BazelPathHelper.osSeps(packageRelativeBazelPath);
+            String packageRelativeFilePath = FSPathHelper.osSeps(packageRelativeBazelPath);
             File javaPackageDir = new File(libsDir, packageName);
             javaPackageDir.mkdir();
 
@@ -103,24 +104,24 @@ public class TestBazelWorkspaceFactory {
 
             // main source
             List<String> sourceFiles = new ArrayList<>();
-            String srcMainPath = BazelPathHelper.osSeps("src/main/java/com/salesforce/fruit" + i); // $SLASH_OK
+            String srcMainPath = FSPathHelper.osSeps("src/main/java/com/salesforce/fruit" + i); // $SLASH_OK
             File javaSrcMainDir = new File(javaPackageDir, srcMainPath);
             javaSrcMainDir.mkdirs();
             // Apple.java
             File javaFile1 = new File(javaSrcMainDir, "Apple" + i + ".java");
             javaFile1.createNewFile();
             String appleSrc =
-                    BazelPathHelper.osSeps(packageRelativeBazelPath + "/" + srcMainPath + "/Apple" + i + ".java"); // $SLASH_OK
+                    FSPathHelper.osSeps(packageRelativeBazelPath + "/" + srcMainPath + "/Apple" + i + ".java"); // $SLASH_OK
             sourceFiles.add(appleSrc);
             // Banana.java
             File javaFile2 = new File(javaSrcMainDir, "Banana" + i + ".java");
             javaFile2.createNewFile();
             String bananaSrc =
-                    BazelPathHelper.osSeps(packageRelativeBazelPath + "/" + srcMainPath + "/Banana" + i + ".java"); // $SLASH_OK
+                    FSPathHelper.osSeps(packageRelativeBazelPath + "/" + srcMainPath + "/Banana" + i + ".java"); // $SLASH_OK
             sourceFiles.add(bananaSrc);
 
             // main resources
-            String srcMainResourcesPath = BazelPathHelper.osSeps("src/main/resources"); // $SLASH_OK
+            String srcMainResourcesPath = FSPathHelper.osSeps("src/main/resources"); // $SLASH_OK
             File javaSrcMainResourcesDir = new File(javaPackageDir, srcMainResourcesPath);
             javaSrcMainResourcesDir.mkdirs();
             File resourceFile = new File(javaSrcMainResourcesDir, "main.properties");
@@ -145,18 +146,18 @@ public class TestBazelWorkspaceFactory {
 
             // test source
             List<String> testSourceFiles = new ArrayList<>();
-            String srcTestPath = BazelPathHelper.osSeps("src/test/java/com/salesforce/fruit" + i); // $SLASH_OK
+            String srcTestPath = FSPathHelper.osSeps("src/test/java/com/salesforce/fruit" + i); // $SLASH_OK
             File javaSrcTestDir = new File(javaPackageDir, srcTestPath);
             javaSrcTestDir.mkdirs();
             File javaTestFile1 = new File(javaSrcTestDir, "Apple" + i + "Test.java");
             javaTestFile1.createNewFile();
             String appleTestSrc =
-                    BazelPathHelper.osSeps(packageRelativeBazelPath + "/" + srcTestPath + "/Apple" + i + "Test.java"); // $SLASH_OK
+                    FSPathHelper.osSeps(packageRelativeBazelPath + "/" + srcTestPath + "/Apple" + i + "Test.java"); // $SLASH_OK
             testSourceFiles.add(appleTestSrc);
             File javaTestFile2 = new File(javaSrcTestDir, "Banana" + i + "Test.java");
             javaTestFile2.createNewFile();
             String bananaTestSrc =
-                    BazelPathHelper.osSeps(packageRelativeBazelPath + "/" + srcTestPath + "/Banana" + i + "Test.java"); // $SLASH_OK
+                    FSPathHelper.osSeps(packageRelativeBazelPath + "/" + srcTestPath + "/Banana" + i + "Test.java"); // $SLASH_OK
             testSourceFiles.add(bananaTestSrc);
 
             // test fruit source aspect
@@ -166,7 +167,7 @@ public class TestBazelWorkspaceFactory {
             packageAspectFiles.add(aspectFilePath_testsource);
 
             // test resources
-            String srcTestResourcesPath = BazelPathHelper.osSeps("src/test/resources"); // $SLASH_OK
+            String srcTestResourcesPath = FSPathHelper.osSeps("src/test/resources"); // $SLASH_OK
             File javaSrcTestResourcesDir = new File(javaPackageDir, srcTestResourcesPath);
             javaSrcTestResourcesDir.mkdirs();
             File testResourceFile = new File(javaSrcTestResourcesDir, "test.properties");
@@ -191,7 +192,7 @@ public class TestBazelWorkspaceFactory {
                 packageAspectFiles.add(previousAspectFilePath);
             }
             // now save off our current lib target to add to the next
-            previousJavaLibTarget = packageRelativeBazelPath + BazelPathHelper.BAZEL_COLON + packageName;
+            previousJavaLibTarget = packageRelativeBazelPath + BazelLabel.BAZEL_COLON + packageName;
             previousAspectFilePath = aspectFilePath_mainsource;
 
             // write fake jar files to the filesystem for this project
@@ -216,7 +217,7 @@ public class TestBazelWorkspaceFactory {
             createGenruleBuildFile(buildFile, packageDescriptor);
 
             File shellScript = new File(genruleLib, "gocrazy" + i + ".sh");
-            if (!BazelPathHelper.isUnix) {
+            if (!FSPathHelper.isUnix) {
                 shellScript = new File(genruleLib, "gocrazy" + i + ".cmd");
             }
             shellScript.createNewFile();
@@ -269,7 +270,7 @@ public class TestBazelWorkspaceFactory {
         sb.append(packageName);
         sb.append("\",\n"); // $SLASH_OK: line continue
         sb.append("   tools = \"gocrazy.sh\",\n"); // $SLASH_OK: escape char
-        if (BazelPathHelper.isUnix) {
+        if (FSPathHelper.isUnix) {
             sb.append("   cmd = \"./$(location gocrazy.sh) abc\",\n"); // $SLASH_OK
         } else {
             sb.append("   cmd = \"./$(location gocrazy.cmd) abc\",\n");
@@ -280,12 +281,12 @@ public class TestBazelWorkspaceFactory {
     }
 
     private void createFakeExternalJars(File dirOutputBase, String foldername, String jarname) throws IOException {
-        String fakeJarPath = BazelPathHelper.osSeps("external/" + foldername + "/jar/" + jarname + ".jar"); // $SLASH_OK
+        String fakeJarPath = FSPathHelper.osSeps("external/" + foldername + "/jar/" + jarname + ".jar"); // $SLASH_OK
         File fakeJar = new File(dirOutputBase, fakeJarPath);
         fakeJar.createNewFile();
 
         String fakeSourceJarPath =
-                BazelPathHelper.osSeps("external/" + foldername + "/jar/" + jarname + "-sources.jar"); // $SLASH_OK
+                FSPathHelper.osSeps("external/" + foldername + "/jar/" + jarname + "-sources.jar"); // $SLASH_OK
         File fakeSourceJar = new File(dirOutputBase, fakeSourceJarPath);
         fakeSourceJar.createNewFile();
     }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
@@ -5,7 +5,7 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.Map;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class TestJavaRuleCreator {
     public static void createJavaBuildFile(TestBazelWorkspaceDescriptor workspaceDescriptor, File buildFile,
@@ -24,8 +24,8 @@ public class TestJavaRuleCreator {
 
     @SuppressWarnings("unused")
     private static String createJavaBinaryRule(String packageName, int packageIndex) {
-        String main = BazelPathHelper.osSeps("src/main/java/**/*.java"); // $SLASH_OK
-        String mainProps = BazelPathHelper.osSeps("src/main/resources/main.properties"); // $SLASH_OK
+        String main = FSPathHelper.osSeps("src/main/java/**/*.java"); // $SLASH_OK
+        String mainProps = FSPathHelper.osSeps("src/main/resources/main.properties"); // $SLASH_OK
 
         StringBuffer sb = new StringBuffer();
         sb.append("java_binary(\n   name=\""); // $SLASH_OK: escape char
@@ -40,7 +40,7 @@ public class TestJavaRuleCreator {
     }
 
     private static String createJavaLibraryRule(String packageName) {
-        String main = BazelPathHelper.osSeps("src/main/java/**/*.java"); // $SLASH_OK
+        String main = FSPathHelper.osSeps("src/main/java/**/*.java"); // $SLASH_OK
         StringBuffer sb = new StringBuffer();
         sb.append("java_library(\n   name=\""); // $SLASH_OK: escape char
         sb.append(packageName);
@@ -53,8 +53,8 @@ public class TestJavaRuleCreator {
 
     private static String createJavaTestRule(String packageName, Map<String, String> commandOptions) {
         boolean explicitJavaTestDeps = "true".equals(commandOptions.get("explicit_java_test_deps"));
-        String test = BazelPathHelper.osSeps("src/test/java/**/*.java"); // $SLASH_OK
-        String testProps = BazelPathHelper.osSeps("src/test/resources/test.properties"); // $SLASH_OK
+        String test = FSPathHelper.osSeps("src/test/java/**/*.java"); // $SLASH_OK
+        String testProps = FSPathHelper.osSeps("src/test/resources/test.properties"); // $SLASH_OK
 
         StringBuffer sb = new StringBuffer();
         sb.append("java_test(\n   name=\""); // $SLASH_OK: escape char
@@ -85,7 +85,7 @@ public class TestJavaRuleCreator {
 
     @SuppressWarnings("unused")
     private static String createSpringBootTestRule(String packageName) {
-        String src = BazelPathHelper.osSeps("src/**/*.java"); // $SLASH_OK
+        String src = FSPathHelper.osSeps("src/**/*.java"); // $SLASH_OK
 
         StringBuffer sb = new StringBuffer();
         sb.append("springboot_test(\n   name=\""); // $SLASH_OK: escape char

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfo.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfo.java
@@ -39,6 +39,8 @@ package com.salesforce.bazel.sdk.aspect;
 import java.io.File;
 import java.util.List;
 
+import com.salesforce.bazel.sdk.model.BazelLabel;
+
 /**
  * A parsed version of the JSON file produced by the application of the Bazel aspect. Each target in each package will
  * have such a file. Look for subclasses of this class for extended information added for specific rule types.
@@ -126,8 +128,15 @@ public class AspectTargetInfo {
     /**
      * Label of the target.
      */
-    public String getLabel() {
+    public String getLabelPath() {
         return label;
+    }
+
+    /**
+     * Label of the target.
+     */
+    public BazelLabel getLabel() {
+        return new BazelLabel(label);
     }
 
     /**

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfoFactory.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfoFactory.java
@@ -60,7 +60,7 @@ public class AspectTargetInfoFactory {
         Map<String, AspectTargetInfo> infos = new HashMap<>();
         for (File aspectFile : aspectFiles) {
             AspectTargetInfo buildInfo = loadAspectFile(aspectFile);
-            infos.put(buildInfo.getLabel(), buildInfo);
+            infos.put(buildInfo.getLabelPath(), buildInfo);
         }
         return infos;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfos.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/aspect/AspectTargetInfos.java
@@ -62,11 +62,11 @@ public class AspectTargetInfos {
 
     public AspectTargetInfos(Collection<AspectTargetInfo> aspectTargetInfos) {
         for (AspectTargetInfo aspectTargetInfo : aspectTargetInfos) {
-            AspectTargetInfo previousValue = labelToAspectTargetInfo.put(aspectTargetInfo.getLabel(), aspectTargetInfo);
+            AspectTargetInfo previousValue = labelToAspectTargetInfo.put(aspectTargetInfo.getLabelPath(), aspectTargetInfo);
             if (previousValue != null) {
                 if (!previousValue.toString().equals(aspectTargetInfo.toString())) {
                     throw new IllegalStateException(
-                            "Did not expect a duplicate label with different contents: " + previousValue.getLabel());
+                            "Did not expect a duplicate label with different contents: " + previousValue.getLabelPath());
                 }
             }
         }
@@ -84,7 +84,7 @@ public class AspectTargetInfos {
 
     public void addAll(Set<AspectTargetInfo> aspectTargetInfoSet) {
         for (AspectTargetInfo info : aspectTargetInfoSet) {
-            labelToAspectTargetInfo.put(info.getLabel(), info);
+            labelToAspectTargetInfo.put(info.getLabelPath(), info);
         }
     }
 
@@ -103,7 +103,7 @@ public class AspectTargetInfos {
                     matchedTargetInfos.add(aspectTargetInfo);
                 }
             } else {
-                System.err.println("AspectTargetInfo " + aspectTargetInfo.getLabel() + " has an unknown kind: "
+                System.err.println("AspectTargetInfo " + aspectTargetInfo.getLabelPath() + " has an unknown kind: "
                         + aspectTargetInfo.getKind());
             }
         }
@@ -146,7 +146,7 @@ public class AspectTargetInfos {
     private static void assertAllSourcesHaveSameRootPath(Path rootSourcePath, AspectTargetInfo aspectTargetInfo) {
         for (String sourcePath : aspectTargetInfo.getSources()) {
             if (!Paths.get(sourcePath).startsWith(rootSourcePath)) {
-                throw new IllegalStateException("AspectTargetInfo " + aspectTargetInfo.getLabel()
+                throw new IllegalStateException("AspectTargetInfo " + aspectTargetInfo.getLabelPath()
                         + " has sources that are not under " + rootSourcePath + ": " + aspectTargetInfo.getSources());
             }
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelLauncherBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelLauncherBuilder.java
@@ -188,7 +188,7 @@ public class BazelLauncherBuilder {
         args.add("--flaky_test_attempts=1");
         args.addAll(extraArgs);
         args.add("--");
-        args.add(bazelTarget.getLabel());
+        args.add(bazelTarget.getLabelPath());
 
         if (isDebugMode) {
             args.add("--test_arg=--wrapper_script_flag=--debug=" + debugHost + ":" + debugPort);

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
@@ -34,7 +34,7 @@
 package com.salesforce.bazel.sdk.command;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Knows how to build paths to various files under bazel output directories (bazel-bin etc)
@@ -49,13 +49,13 @@ public class BazelOutputDirectoryBuilder {
     public String getRunScriptPath(BazelLabel label) {
         StringBuilder sb = new StringBuilder();
         sb.append("bazel-bin");
-        sb.append(BazelPathHelper.UNIX_SLASH);
+        sb.append(FSPathHelper.UNIX_SLASH);
         sb.append(label.getPackagePath());
-        sb.append(BazelPathHelper.UNIX_SLASH);
+        sb.append(FSPathHelper.UNIX_SLASH);
         sb.append(label.getTargetName());
 
         // generate the String, converting to Windows style path if necessary
-        String path = BazelPathHelper.osSeps(sb.toString());
+        String path = FSPathHelper.osSeps(sb.toString());
 
         return path;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectProcessor.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectProcessor.java
@@ -276,17 +276,17 @@ public class BazelWorkspaceAspectProcessor {
         // find starting point, based on target - this is trivial, but we also support wildcard
         // targets (so that we can run a single bazal build cmd and get all aspects)
         for (AspectTargetInfo ati : depNameToTargetInfo.values()) {
-            BazelLabel currentLabel = new BazelLabel(ati.getLabel());
+            BazelLabel currentLabel = new BazelLabel(ati.getLabelPath());
             if (requestingLabel.isConcrete()) {
                 if (requestingLabel.equals(currentLabel)) {
                     Set<AspectTargetInfo> allDeps = getTransitiveClosure(ati, depNameToTargetInfo);
-                    transitivesClosures.put(new BazelLabel(ati.getLabel()), allDeps);
+                    transitivesClosures.put(new BazelLabel(ati.getLabelPath()), allDeps);
                 }
             } else {
                 // all targets in the requested package qualify
                 if (currentLabel.getPackagePath().equals(requestingLabel.getPackagePath())) {
                     Set<AspectTargetInfo> allDeps = getTransitiveClosure(ati, depNameToTargetInfo);
-                    transitivesClosures.put(new BazelLabel(ati.getLabel()), allDeps);
+                    transitivesClosures.put(new BazelLabel(ati.getLabelPath()), allDeps);
                 }
             }
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryDependencyGraph.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryDependencyGraph.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 
 /**
@@ -88,7 +89,7 @@ public class InMemoryDependencyGraph extends BazelDependencyGraph {
     public void addDependency(String sourceLabel, String depLabel) {
         allDepLabels.add(depLabel);
         allSourceLabels.add(sourceLabel);
-        boolean isDepAnExternal = depLabel.startsWith("@");
+        boolean isDepAnExternal = depLabel.startsWith(BazelLabel.BAZEL_EXTERNALREPO_AT);
         LOG.debug("{} depends on {}", sourceLabel, depLabel);
 
         // remove dep as a candidate root
@@ -329,7 +330,7 @@ public class InMemoryDependencyGraph extends BazelDependencyGraph {
 
     private boolean isDependencyRecur(String label, String possibleDependency, Map<String, Boolean> depCache,
             Set<String> processedLabels, boolean followExternalTransitives) {
-        if (!followExternalTransitives && label.startsWith("@")) {
+        if (!followExternalTransitives && label.startsWith(BazelLabel.BAZEL_EXTERNALREPO_AT)) {
             return false;
         }
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryPackageLocation.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/graph/InMemoryPackageLocation.java
@@ -3,8 +3,8 @@ package com.salesforce.bazel.sdk.graph;
 import java.io.File;
 import java.util.List;
 
+import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * In memory package location.
@@ -23,7 +23,9 @@ public class InMemoryPackageLocation implements BazelPackageLocation {
     }
 
     public InMemoryPackageLocation(String path) {
-        if (path.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
+
+        // TODO the fact that we are doing this indicates we aren't sure if the caller is passing a fs path, or bazel path
+        if (path.startsWith(BazelLabel.BAZEL_ROOT_SLASHES)) {
             this.path = path.substring(2);
         } else {
             this.path = path;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
@@ -33,7 +33,7 @@ import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
 import com.salesforce.bazel.sdk.index.model.ClassIdentifier;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Crawler that descends into nested directories of jar files and adds found files to the index.
@@ -145,7 +145,7 @@ public class JavaJarCrawler {
                 continue;
             }
             // convert path / into . to form the legal package name, and trim the .class off the end
-            fqClassname = fqClassname.replace(BazelPathHelper.JAR_SLASH, ".");
+            fqClassname = fqClassname.replace(FSPathHelper.JAR_SLASH, ".");
             fqClassname = fqClassname.substring(0, fqClassname.length() - 6);
             LOG.debug("Indexer found classname: {} in jar {}", fqClassname, jarId.locationIdentifier);
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/source/SourceFileCrawler.java
@@ -32,7 +32,7 @@ import com.salesforce.bazel.sdk.index.CodeIndex;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
 import com.salesforce.bazel.sdk.index.model.CodeLocationIdentifier;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Crawler that descends into nested directories of source files and adds found files to the index.
@@ -105,10 +105,10 @@ public class SourceFileCrawler {
                         }
                         String childRelative = candidateFile.getName();
                         if (!relativePathToClosestArtifact.isEmpty()) {
-                            childRelative = relativePathToClosestArtifact + BazelPathHelper.UNIX_SLASH
+                            childRelative = relativePathToClosestArtifact + FSPathHelper.UNIX_SLASH
                                     + candidateFile.getName();
                             // convert to Windows path if necessary
-                            childRelative = BazelPathHelper.osSeps(childRelative);
+                            childRelative = FSPathHelper.osSeps(childRelative);
                         }
                         indexRecur(candidateFile, childRelative, closestArtifactLocationDescriptor, false);
                     } else if (candidateFile.canRead()) {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
@@ -183,7 +183,7 @@ public class BazelJvmClasspath {
                     }
                     JVMAspectTargetInfo jvmTargetInfo = (JVMAspectTargetInfo) targetInfo;
 
-                    if (actualActivatedTargets.contains(jvmTargetInfo.getLabel())) {
+                    if (actualActivatedTargets.contains(jvmTargetInfo.getLabelPath())) {
                         if ("java_library".equals(jvmTargetInfo.getKind())) {
                             // this info describes a java_library target in the current package; don't add it to the classpath
                             // as all java_library targets in this package are assumed to be represented by source code entries

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/ImplicitClasspathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/ImplicitClasspathHelper.java
@@ -9,7 +9,7 @@ import com.salesforce.bazel.sdk.aspect.AspectTargetInfo;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * Bazel generally requires BUILD file authors to list all dependencies explicitly. However, there are a few legacy
@@ -65,28 +65,28 @@ public class ImplicitClasspathHelper {
 
     String computeFilePathForRunnerJar(BazelWorkspace bazelWorkspace, AspectTargetInfo targetInfo) {
         File bazelBinDir = bazelWorkspace.getBazelBinDirectory();
-        File testRunnerDir = new File(bazelBinDir, BazelPathHelper.osSeps(IMPLICIT_RUNNER));
+        File testRunnerDir = new File(bazelBinDir, FSPathHelper.osSeps(IMPLICIT_RUNNER));
 
         LogHelper logger = LogHelper.log(this.getClass());
         if (!testRunnerDir.exists()) {
-            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabel() + "], directory ["
-                    + BazelPathHelper.getCanonicalPathStringSafely(testRunnerDir) + "] does not exist.");
+            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabelPath() + "], directory ["
+                    + FSPathHelper.getCanonicalPathStringSafely(testRunnerDir) + "] does not exist.");
             return null;
         }
-        String javaToolsPath = BazelPathHelper.osSeps("external/remote_java_tools_"
-                + bazelWorkspace.getOperatingSystemFoldername() + BazelPathHelper.UNIX_SLASH + "java_tools"); // $SLASH_OK
+        String javaToolsPath = FSPathHelper.osSeps("external/remote_java_tools_"
+                + bazelWorkspace.getOperatingSystemFoldername() + FSPathHelper.UNIX_SLASH + "java_tools"); // $SLASH_OK
         File javaToolsDir = new File(testRunnerDir, javaToolsPath);
         if (!javaToolsDir.exists()) {
-            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabel() + "], directory ["
-                    + BazelPathHelper.getCanonicalPathStringSafely(javaToolsDir) + "] does not exist.");
+            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabelPath() + "], directory ["
+                    + FSPathHelper.getCanonicalPathStringSafely(javaToolsDir) + "] does not exist.");
             return null;
         }
         File runnerJar = new File(javaToolsDir, "Runner_deploy-ijar.jar");
         if (!runnerJar.exists()) {
-            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabel() + "], test runner jar ["
-                    + BazelPathHelper.getCanonicalPathStringSafely(runnerJar) + "] does not exist.");
+            logger.error("Could not add implicit test deps to target [" + targetInfo.getLabelPath() + "], test runner jar ["
+                    + FSPathHelper.getCanonicalPathStringSafely(runnerJar) + "] does not exist.");
             return null;
         }
-        return BazelPathHelper.getCanonicalPathStringSafely(runnerJar);
+        return FSPathHelper.getCanonicalPathStringSafely(runnerJar);
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
@@ -15,7 +15,7 @@ public final class BazelLabelUtil {
     public static Map<BazelLabel, Collection<BazelLabel>> groupByPackage(Collection<BazelLabel> labels) {
         Map<BazelLabel, Collection<BazelLabel>> packageToLabels = new HashMap<>();
         for (BazelLabel label : labels) {
-            BazelLabel pack = label.toDefaultPackageLabel();
+            BazelLabel pack = label.getPackageLabel();
             Collection<BazelLabel> group = packageToLabels.get(pack);
             if (group == null) {
                 group = new HashSet<>();

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageLocation.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageLocation.java
@@ -57,6 +57,8 @@ public interface BazelPackageLocation {
     /**
      * Builds a list containing this node, plus all children (recursively). The pathFilter must be in the form
      * "projects/libs/foo" and will limit the gathering to that path and descendents of that path.
+     * <p>
+     * TODO convert pathFilter to a BazelLabel; SDK Issue #37
      */
     public List<BazelPackageLocation> gatherChildren(String pathFilter);
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelProblem.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Objects;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
  * A wrapper for a Bazel logical "problem" (error/warning).
@@ -147,7 +147,7 @@ public class BazelProblem {
 
     private String getRelativeResourcePath(BazelLabel label) {
         String bazelPackagePath = label.getPackagePath();
-        String relativeFilePath = BazelPathHelper.osSeps(bazelPackagePath + BazelPathHelper.UNIX_SLASH);
+        String relativeFilePath = FSPathHelper.osSeps(bazelPackagePath + FSPathHelper.UNIX_SLASH);
         if (resourcePath.startsWith(relativeFilePath) && (resourcePath.length() > (relativeFilePath.length()))) {
             return File.separator + resourcePath.substring(relativeFilePath.length());
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
 import com.salesforce.bazel.sdk.workspace.BazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
 
@@ -141,7 +140,7 @@ public class BazelWorkspace {
     public List<String> getTargetsForBazelQuery(String query) {
         List<String> results = new ArrayList<String>();
         for (String line : metadataStrategy.computeBazelQuery(query)) {
-            if (line.startsWith(BazelPathHelper.BAZEL_ROOT_SLASHES)) {
+            if (line.startsWith(BazelLabel.BAZEL_ROOT_SLASHES)) {
                 results.add(line);
             }
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
@@ -6,35 +6,10 @@ import java.io.IOException;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 
 /**
- * Static utilities to help with file system paths, especially cross platform.
+ * Constants and utils for file system paths.
  */
-public class BazelPathHelper {
-    private static final LogHelper LOG = LogHelper.log(BazelPathHelper.class);
-
-    // BAZEL PATH ELEMENTS
-
-    // Double slash characters for root of Bazel paths
-    public static final String BAZEL_ROOT_SLASHES = "//";
-
-    // All packages wildcard 
-    public static final String BAZEL_ALL_REPO_PACKAGES = "//...";
-
-    // Slash character for Bazel paths
-    public static final String BAZEL_SLASH = "/";
-
-    // Colon character for Bazel paths that delimits the target
-    public static final String BAZEL_COLON = ":";
-
-    // Wildcard used as a package, that identifies all packages at the current level or below
-    public static final String BAZEL_WILDCARD_ALLPACKAGES = "...";
-
-    // Wildcard used as a target, that identifies all targets 
-    public static final String BAZEL_WILDCARD_ALLTARGETS = "all";
-
-    // Wildcard used as a target, that identifies all targets including implicit targets (_deploy.jar etc) 
-    public static final String BAZEL_WILDCARD_ALLTARGETS_STAR = "*";
-
-    // FILE SYSTEM PATH ELEMENTS
+public class FSPathHelper {
+    private static final LogHelper LOG = LogHelper.log(FSPathHelper.class);
 
     // Slash character for unix file paths
     public static final String UNIX_SLASH = "/";
@@ -57,10 +32,9 @@ public class BazelPathHelper {
      * Primary feature toggle. isUnix is true for all platforms except Windows.
      */
     public static boolean isUnix = true;
-
     static {
         if (System.getProperty("os.name").contains("Windows")) {
-            isUnix = false;
+            FSPathHelper.isUnix = false;
         }
     }
 
@@ -144,14 +118,4 @@ public class BazelPathHelper {
         return path;
     }
 
-    /**
-     * Convert a slash style relative path to Windows backslash, if running on Windows
-     */
-    public static String bazelLabelSeps(String fsPath) {
-        String path = fsPath;
-        if (!isUnix) {
-            path = fsPath.replace(WINDOWS_BACKSLASH, UNIX_SLASH);
-        }
-        return path;
-    }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectTargets.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.salesforce.bazel.sdk.model.BazelBuildFile;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 
 /**
  * Object that encapsulates the logic and state regarding the active targets configured for a BazelProject.
@@ -75,7 +75,7 @@ public class BazelProjectTargets {
 
     public void activateWildcardTarget(String wildcardTarget) {
         this.isActivatedWildcardTarget = true;
-        this.configuredTargets.add(projectBazelLabel + BazelPathHelper.BAZEL_COLON + wildcardTarget);
+        this.configuredTargets.add(projectBazelLabel + BazelLabel.BAZEL_COLON + wildcardTarget);
     }
 
     public void activateSpecificTargets(Set<String> activatedTargets) {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectView.java
@@ -91,7 +91,7 @@ public class ProjectView {
             sb.append(System.lineSeparator());
             sb.append(TARGETS_SECTION).append(System.lineSeparator());
             for (BazelLabel target : targetToLineNumber.keySet()) {
-                sb.append(INDENT).append(target.getLabel()).append(System.lineSeparator());
+                sb.append(INDENT).append(target.getLabelPath()).append(System.lineSeparator());
             }
         }
         return sb.toString();

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
 
 /**
  * Represents a line in a project view file.
@@ -63,9 +62,9 @@ public class ProjectViewPackageLocation implements BazelPackageLocation {
             // somehow handle that workspace differently
             // Docs should indicate that a better practice is to keep the root dir free of an actual package
             // For now, assume that anything referring to the root dir is a proxy for 'whole repo'
-            return BazelPathHelper.BAZEL_ALL_REPO_PACKAGES;
+            return BazelLabel.BAZEL_ALL_REPO_PACKAGES;
         }
-        return BazelPathHelper.BAZEL_ROOT_SLASHES + packagePath;
+        return BazelLabel.BAZEL_ROOT_SLASHES + packagePath;
     }
 
     @Override

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/util/BazelConstants.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
 
 public interface BazelConstants {
 
@@ -58,6 +58,6 @@ public interface BazelConstants {
      * The targets configured by default for each imported Bazel package.
      */
     Collection<String> DEFAULT_PACKAGE_TARGETS =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(BazelPathHelper.BAZEL_WILDCARD_ALLTARGETS_STAR)));
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR)));
 
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.Set;
 
 import com.salesforce.bazel.sdk.logging.LogHelper;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 import com.salesforce.bazel.sdk.util.BazelConstants;
 import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
 
@@ -49,7 +49,7 @@ public class BazelPackageFinder {
                     // great, this dir is a Bazel package (but this may be a non-Java package)
                     // scan the BUILD file looking for java rules, only add if this is a java project
                     if (BuildFileSupport.hasRegisteredRules(dirFile)) {
-                        buildFileLocations.add(BazelPathHelper.getCanonicalFileSafely(dir));
+                        buildFileLocations.add(FSPathHelper.getCanonicalFileSafely(dir));
                     }
                 } else if (dirFile.isDirectory()) {
                     findBuildFileLocations(dirFile, monitor, buildFileLocations, depth + 1);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/config/EclipseBazelProjectManager.java
@@ -76,7 +76,7 @@ public class EclipseBazelProjectManager extends BazelProjectManager {
 
         String canonicalSourcePathString =
                 BazelPathHelper.getCanonicalPathStringSafely(bazelWorkspace.getBazelWorkspaceRootDirectory())
-                        + File.separator + sourcePath;
+                + File.separator + sourcePath;
         Path canonicalSourcePath = new File(canonicalSourcePathString).toPath();
 
         for (BazelProject candidateProject : bazelProjects) {
@@ -231,7 +231,7 @@ public class EclipseBazelProjectManager extends BazelProjectManager {
                 String target = eclipseProjectBazelPrefs.get(propertyName, "");
                 if (!target.isEmpty()) {
                     BazelLabel label = new BazelLabel(target);
-                    if (!label.getLabel().startsWith(projectLabel)) {
+                    if (!label.getLabelPath().startsWith(projectLabel)) {
                         // the user jammed in a label not associated with this project, ignore
                         //continue;
                     }
@@ -289,7 +289,7 @@ public class EclipseBazelProjectManager extends BazelProjectManager {
 
         int i = 0;
         for (BazelLabel bazelTarget : bazelTargets) {
-            eclipseProjectBazelPrefs.put(TARGET_PROPERTY_PREFIX + i, bazelTarget.getLabel());
+            eclipseProjectBazelPrefs.put(TARGET_PROPERTY_PREFIX + i, bazelTarget.getLabelPath());
             i++;
         }
         i = 0;

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationSupport.java
@@ -191,7 +191,7 @@ class BazelLaunchConfigurationSupport {
         Objects.requireNonNull(config);
         Objects.requireNonNull(projectName);
 
-        String labelStr = label == null ? null : label.getLabel();
+        String labelStr = label == null ? null : label.getLabelPath();
         String kindStr = targetKind == null ? null : targetKind.getKindName();
         config.setAttribute(BazelLaunchConfigAttributes.PROJECT.getAttributeName(), projectName);
         config.setAttribute(BazelLaunchConfigAttributes.LABEL.getAttributeName(), labelStr);
@@ -231,7 +231,7 @@ class BazelLaunchConfigurationSupport {
     List<TypedBazelLabel> getBazelTargetsForProject(IProject project, Set<BazelTargetKind> targetTypes) {
         List<TypedBazelLabel> typedBazelLabels = new ArrayList<>();
         for (AspectTargetInfo api : getAspectTargetInfosForProject(project, targetTypes)) {
-            BazelLabel label = new BazelLabel(api.getLabel());
+            BazelLabel label = api.getLabel();
             BazelTargetKind kind = BazelTargetKind.valueOfIgnoresCase(api.getKind());
             typedBazelLabels.add(new TypedBazelLabel(label, kind));
         }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationTab.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationTab.java
@@ -194,7 +194,7 @@ public class BazelLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
         if (labelsForSelectedProject == null) {
             labelsForSelectedProject = support.getLaunchableBazelTargetsForProject(project);
             labelsForSelectedProject
-                    .sort((t1, t2) -> t1.getBazelLabel().getLabel().compareTo(t2.getBazelLabel().getLabel()));
+            .sort((t1, t2) -> t1.getBazelLabel().getLabelPath().compareTo(t2.getBazelLabel().getLabelPath()));
         }
     }
 
@@ -323,10 +323,11 @@ public class BazelLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
         // if the target name uses a path-like syntax: my/target/name, then return
         // "name (my/target/name)" ($SLASH_OK bazel path)
         // otherwise just return the target name
-        if (label.getLastComponentOfTargetName().equals(label.getTargetName())) {
+        // TODO is it even legal to have slashes in target names? who does this?
+        if (label.getTargetNameLastComponent().equals(label.getTargetName())) {
             return label.getTargetName();
         } else {
-            return label.getLastComponentOfTargetName() + " (" + label.getTargetName() + ")";
+            return label.getTargetNameLastComponent() + " (" + label.getTargetName() + ")";
         }
     }
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTargetLaunchShortcut.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTargetLaunchShortcut.java
@@ -104,7 +104,7 @@ public class BazelTargetLaunchShortcut implements ILaunchShortcut {
             // however bazel does not like the common "src/main/java" root:
             // error: "main_class was not provided and cannot be inferred: source path doesn't include a known root (java, javatests, src, testsrc)"
             throw new IllegalStateException(
-                    "Unable to find a java_binary target that has a main_class of " + fqClassName);
+                "Unable to find a java_binary target that has a main_class of " + fqClassName);
         } else if (mainClassInfos.size() > 1) {
             // surface correctly
             throw new IllegalStateException("Found multiple java_binary targets that have a main_class of "
@@ -117,7 +117,7 @@ public class BazelTargetLaunchShortcut implements ILaunchShortcut {
             ILaunchConfigurationWorkingCopy config = type.newInstance(null, fileName);
             support.setLaunchConfigDefaults(config);
             AspectTargetInfo api = mainClassInfos.iterator().next();
-            BazelLabel label = new BazelLabel(api.getLabel());
+            BazelLabel label = api.getLabel();
             BazelTargetKind kind = BazelTargetKind.valueOfIgnoresCase(api.getKind());
             support.populateBazelLaunchConfig(config, projectName, label, kind);
             DebugUITools.launch(config.doSave(), mode);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/LoadAspectsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/LoadAspectsFlow.java
@@ -69,7 +69,7 @@ public class LoadAspectsFlow implements ImportFlow {
             List<BazelLabel> targets = map.get(packageLocation);
             targets = Objects.requireNonNull(targets);
             for (BazelLabel target : targets) {
-                labels.add(target.getLabel());
+                labels.add(target.getLabelPath());
             }
         }
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -91,7 +91,7 @@ public class BazelImportWizardPage extends WizardPage {
         // that the user correctly pointed the location control to a Bazel workspace, and it found one or
         // more Java packages.
         Object[] checkedElements = projectTree.projectTreeViewer.getCheckedElements();
-        boolean isComplete = checkedElements != null && checkedElements.length > 0;
+        boolean isComplete = (checkedElements != null) && (checkedElements.length > 0);
         setPageComplete(isComplete);
         LOG.info("BazelImportWizardPage.setPageComplete: {}", isComplete);
     }
@@ -106,34 +106,34 @@ public class BazelImportWizardPage extends WizardPage {
 
             // get the selected location
             // when the wizard is first opened, the location field is blank and we have a null root package
-            if (this.locationControl.rootDirectory != null) {
-                this.projectTree.setRootWorkspaceDirectory(this.locationControl.rootDirectory);
-                this.workspaceRootPackage = workspaceScanner.getPackages(this.locationControl.rootDirectory);
+            if (locationControl.rootDirectory != null) {
+                projectTree.setRootWorkspaceDirectory(locationControl.rootDirectory);
+                workspaceRootPackage = workspaceScanner.getPackages(locationControl.rootDirectory);
                 if (workspaceRootPackage != null) {
                     // make sure the user chose a Bazel workspace
                     newEclipseProjects.add(workspaceRootPackage);
                     newFilesystemLocations.add(workspaceRootPackage.getBazelPackageFSAbsolutePath());
-                    this.projectTree.projectTreeViewer.setInput(newEclipseProjects);
-                    this.projectTree.projectTreeViewer.expandAll();
-                    this.projectTree.importProjectViewButton.setEnabled(true);
+                    projectTree.projectTreeViewer.setInput(newEclipseProjects);
+                    projectTree.projectTreeViewer.expandAll();
+                    projectTree.importProjectViewButton.setEnabled(true);
                     if (workspaceRootPackage.getChildPackageInfos().size() < 10) {
                         // short term usability hack, enable all for import if there are less than 10 Bazel packages
-                        this.projectTree.projectTreeViewer.setAllChecked(true);
+                        projectTree.projectTreeViewer.setAllChecked(true);
                     }
-                    uncheckAlreadyImportedProjects(this.projectTree.projectTreeViewer, this.workspaceRootPackage);
+                    uncheckAlreadyImportedProjects(projectTree.projectTreeViewer, workspaceRootPackage);
                 } else {
-                    this.projectTree.projectTreeViewer.setAllChecked(true);
+                    projectTree.projectTreeViewer.setAllChecked(true);
                 }
             }
 
-            this.locationControl.locations = newFilesystemLocations;
+            locationControl.locations = newFilesystemLocations;
 
             setPageComplete();
             setErrorMessage(null);
             setMessage(null);
 
-            this.loadingErrorMessage = null;
-            this.workingSetControl.updateWorkingSet(this.workspaceRootPackage);
+            loadingErrorMessage = null;
+            workingSetControl.updateWorkingSet(workspaceRootPackage);
         } catch (Exception anyE) {
             LOG.error(anyE.getMessage(), anyE);
             setErrorMessage("Error importing the Bazel workspace. Details: " + anyE.getMessage());
@@ -166,7 +166,7 @@ public class BazelImportWizardPage extends WizardPage {
             String target = bazelProjectManager.getConfiguredBazelTargets(bazelProject, false).getConfiguredTargets()
                     .iterator().next();
             BazelLabel label = new BazelLabel(target);
-            String pack = label.toDefaultPackageLabel().getLabel();
+            String pack = label.getPackagePath(true);
             BazelPackageInfo bpi = rootPackage.findByPackage(pack);
             if (bpi != null) {
                 importedPackages.add(bpi);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectOutputJarsTest.java
@@ -7,7 +7,7 @@ import org.json.simple.JSONObject;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectOutputJarSet;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class AspectOutputJarsTest {
 
@@ -16,11 +16,11 @@ public class AspectOutputJarsTest {
     //   "interface_jar":"bazel-out/darwin-fastbuild/bin/external/com_google_guava_guava/jar/_ijar/jar/external/com_google_guava_guava/jar/guava-20.0-ijar.jar", $SLASH_OK: sample code
     //   "source_jar":"external/com_google_guava_guava/jar/guava-20.0-sources.jar" $SLASH_OK: sample code
     //  }
-    private final String GUAVA_JAR = BazelPathHelper.osSeps("external/com_google_guava_guava/jar/guava-20.0.jar"); // $SLASH_OK
-    private final String GUAVA_IJAR = BazelPathHelper.osSeps(
+    private final String GUAVA_JAR = FSPathHelper.osSeps("external/com_google_guava_guava/jar/guava-20.0.jar"); // $SLASH_OK
+    private final String GUAVA_IJAR = FSPathHelper.osSeps(
         "bazel-out/darwin-fastbuild/bin/external/com_google_guava_guava/jar/_ijar/jar/external/com_google_guava_guava/jar/guava-20.0-ijar.jar"); // $SLASH_OK
     private final String GUAVA_SJAR =
-            BazelPathHelper.osSeps("external/com_google_guava_guava/jar/guava-20.0-sources.jar"); // $SLASH_OK
+            FSPathHelper.osSeps("external/com_google_guava_guava/jar/guava-20.0-sources.jar"); // $SLASH_OK
 
     @Test
     public void testDeserializationHappy() {

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/aspect/AspectTargetInfosTest.java
@@ -48,14 +48,14 @@ import org.junit.Test;
 
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class AspectTargetInfosTest {
 
-    private final String libPath = BazelPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
-    private final String testPath = BazelPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
-    private final String binPath = BazelPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
-    private final String selPath = BazelPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
+    private final String libPath = FSPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
+    private final String testPath = FSPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
+    private final String binPath = FSPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
+    private final String selPath = FSPathHelper.osSeps("a/b/c/d/Foo.java"); // $SLASH_OK
 
     @Test
     public void testLookupByLabel() {
@@ -114,11 +114,11 @@ public class AspectTargetInfosTest {
 
         AspectTargetInfos infos = new AspectTargetInfos(api);
 
-        assertSame(api, infos.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/d/Foo.java")).iterator().next());
-        assertSame(api, infos.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/d")).iterator().next());
-        assertSame(api, infos.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/")).iterator().next());
-        assertSame(api, infos.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b")).iterator().next());
-        assertSame(api, infos.lookupByRootSourcePath(BazelPathHelper.osSeps("a/")).iterator().next());
+        assertSame(api, infos.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/d/Foo.java")).iterator().next());
+        assertSame(api, infos.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/d")).iterator().next());
+        assertSame(api, infos.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/")).iterator().next());
+        assertSame(api, infos.lookupByRootSourcePath(FSPathHelper.osSeps("a/b")).iterator().next());
+        assertSame(api, infos.lookupByRootSourcePath(FSPathHelper.osSeps("a/")).iterator().next());
         assertSame(api, infos.lookupByRootSourcePath("a").iterator().next());
         assertEquals(0, infos.lookupByRootSourcePath("f").size());
     }
@@ -126,65 +126,65 @@ public class AspectTargetInfosTest {
     @Test
     public void testLookupByRootSourcePath__noSubstringMatch() {
         AspectTargetInfo api =
-                getAspectTargetInfo("myclass", BazelPathHelper.osSeps("projects/services/scone/MyClass.java")); // $SLASH_OK
+                getAspectTargetInfo("myclass", FSPathHelper.osSeps("projects/services/scone/MyClass.java")); // $SLASH_OK
 
         AspectTargetInfos apis = new AspectTargetInfos(api);
         Collection<AspectTargetInfo> infos =
-                apis.lookupByRootSourcePath(BazelPathHelper.osSeps("projects/services/scone")); // $SLASH_OK
+                apis.lookupByRootSourcePath(FSPathHelper.osSeps("projects/services/scone")); // $SLASH_OK
 
         assertEquals(1, infos.size());
         assertSame(api, infos.iterator().next());
-        assertEquals(0, apis.lookupByRootSourcePath(BazelPathHelper.osSeps("projects/services/scon")).size()); // $SLASH_OK
+        assertEquals(0, apis.lookupByRootSourcePath(FSPathHelper.osSeps("projects/services/scon")).size()); // $SLASH_OK
     }
 
     @Test
     public void testLookupByRootSourcePath__multipleMatching() {
-        AspectTargetInfo foo = getAspectTargetInfo("foo", BazelPathHelper.osSeps("a/b/c/aaa/Foo.java")); // $SLASH_OK
-        AspectTargetInfo blah = getAspectTargetInfo("blah", BazelPathHelper.osSeps("a/b/c/zzz/Blah.java")); // $SLASH_OK
+        AspectTargetInfo foo = getAspectTargetInfo("foo", FSPathHelper.osSeps("a/b/c/aaa/Foo.java")); // $SLASH_OK
+        AspectTargetInfo blah = getAspectTargetInfo("blah", FSPathHelper.osSeps("a/b/c/zzz/Blah.java")); // $SLASH_OK
 
         AspectTargetInfos apis = new AspectTargetInfos(foo, blah);
 
-        Collection<AspectTargetInfo> infos = apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c")); // $SLASH_OK
+        Collection<AspectTargetInfo> infos = apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c")); // $SLASH_OK
         assertEquals(2, infos.size());
         assertTrue(infos.contains(foo));
         assertTrue(infos.contains(blah));
-        infos = apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
+        infos = apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
         assertEquals(1, infos.size());
         assertTrue(infos.contains(foo));
     }
 
     @Test
     public void testLookupByRootSourcePath__sourcesWithCommonRootPathValidation() {
-        AspectTargetInfo foo = getAspectTargetInfo("foo", BazelPathHelper.osSeps("a/b/c/aaa/ccc/Foo.java"), // $SLASH_OK
-            BazelPathHelper.osSeps("a/b/c/aaa/ddd/Blah.java")); // $SLASH_OK
+        AspectTargetInfo foo = getAspectTargetInfo("foo", FSPathHelper.osSeps("a/b/c/aaa/ccc/Foo.java"), // $SLASH_OK
+            FSPathHelper.osSeps("a/b/c/aaa/ddd/Blah.java")); // $SLASH_OK
 
         AspectTargetInfos apis = new AspectTargetInfos(foo);
 
-        Collection<AspectTargetInfo> infos = apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c")); // $SLASH_OK
+        Collection<AspectTargetInfo> infos = apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c")); // $SLASH_OK
         assertEquals(1, infos.size());
 
-        infos = apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
+        infos = apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
         assertEquals(1, infos.size());
     }
 
     @Test(expected = IllegalStateException.class)
     public void testLookupByRootSourcePath__sourcesWithoutCommonRootPathValidation_partialPath() {
-        AspectTargetInfo foo = getAspectTargetInfo("foo", BazelPathHelper.osSeps("a/b/c/aaa/Foo.java"), // $SLASH_OK
-            BazelPathHelper.osSeps("a/b/c/zzz/Blah.java")); // $SLASH_OK
+        AspectTargetInfo foo = getAspectTargetInfo("foo", FSPathHelper.osSeps("a/b/c/aaa/Foo.java"), // $SLASH_OK
+            FSPathHelper.osSeps("a/b/c/zzz/Blah.java")); // $SLASH_OK
 
         AspectTargetInfos apis = new AspectTargetInfos(foo);
 
-        apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
+        apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c/aaa")); // $SLASH_OK
     }
 
     @Test(expected = IllegalStateException.class)
     public void testLookupByRootSourcePath__sourcesWithoutCommonRootPathValidation_fullPath() {
-        AspectTargetInfo foo = getAspectTargetInfo("foo", BazelPathHelper.osSeps("a/b/c/aaa/Foo.java"), // $SLASH_OK
-            BazelPathHelper.osSeps("x/y/z/aaa/Blah.java")); // $SLASH_OK
+        AspectTargetInfo foo = getAspectTargetInfo("foo", FSPathHelper.osSeps("a/b/c/aaa/Foo.java"), // $SLASH_OK
+            FSPathHelper.osSeps("x/y/z/aaa/Blah.java")); // $SLASH_OK
 
         AspectTargetInfos apis = new AspectTargetInfos(foo);
 
-        apis.lookupByRootSourcePath(BazelPathHelper.osSeps("a/b/c")); // $SLASH_OK
+        apis.lookupByRootSourcePath(FSPathHelper.osSeps("a/b/c")); // $SLASH_OK
     }
 
     private static AspectTargetInfo getAspectTargetInfo(String label, String... sourcePaths) {

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
@@ -42,7 +42,7 @@ import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
 
@@ -64,13 +64,13 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyList());
 
-        addBazelCommandOutput(env, 0, BazelPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0"), // $SLASH_OK
+        addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0"), // $SLASH_OK
             "fake bazel launcher script result");
 
         Command command = launcherBuilder.build();
         BazelProcessBuilder processBuilder = command.getProcessBuilder();
         List<String> cmdTokens = processBuilder.command();
-        String filesystemPath = BazelPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
+        String filesystemPath = FSPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
         assertTrue(cmdTokens.get(0).endsWith(filesystemPath));
         assertFalse(cmdTokens.contains("debug"));
     }
@@ -88,12 +88,12 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyList());
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
 
-        addBazelCommandOutput(env, 0, BazelPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0"), // $SLASH_OK
+        addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0"), // $SLASH_OK
             "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
-        String filesystemPath = BazelPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
+        String filesystemPath = FSPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
         assertTrue(cmdTokens.get(0).endsWith(filesystemPath));
         assertFalse(cmdTokens.contains("debug=" + DEBUG_PORT));
     }
@@ -115,7 +115,7 @@ public class BazelLauncherBuilderTest {
 
         assertEquals(env.bazelExecutable.getAbsolutePath(), cmdTokens.get(0));
         assertEquals("test", cmdTokens.get(1));
-        assertTrue(cmdTokens.contains(label.getLabel()));
+        assertTrue(cmdTokens.contains(label.getLabelPath()));
         assertFalse(cmdTokens.toString().contains("debug"));
     }
 
@@ -136,7 +136,7 @@ public class BazelLauncherBuilderTest {
 
         assertEquals(env.bazelExecutable.getAbsolutePath(), cmdTokens.get(0));
         assertEquals("test", cmdTokens.get(1));
-        assertTrue(cmdTokens.contains(label.getLabel()));
+        assertTrue(cmdTokens.contains(label.getLabelPath()));
         assertFalse(cmdTokens.toString().contains("debug"));
     }
 
@@ -160,7 +160,7 @@ public class BazelLauncherBuilderTest {
         assertEquals(env.bazelExecutable.getAbsolutePath(), cmdTokens.get(0));
         assertEquals("test", cmdTokens.get(1));
         assertTrue(cmdTokens.contains("--test_filter=someBazelTestFilter"));
-        assertTrue(cmdTokens.contains(label.getLabel()));
+        assertTrue(cmdTokens.contains(label.getLabelPath()));
         assertFalse(cmdTokens.toString().contains("debug"));
     }
 
@@ -182,7 +182,7 @@ public class BazelLauncherBuilderTest {
 
         assertEquals(env.bazelExecutable.getAbsolutePath(), cmdTokens.get(0));
         assertEquals("test", cmdTokens.get(1));
-        assertTrue(cmdTokens.contains(label.getLabel()));
+        assertTrue(cmdTokens.contains(label.getLabelPath()));
         assertTrue(cmdTokens.toString().contains("debug"));
         assertTrue(cmdTokens.contains("--test_arg=--wrapper_script_flag=--debug=localhost:" + DEBUG_PORT));
     }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.model.BazelLabel;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class BazelOutputDirectoryBuilderTest {
 
@@ -48,12 +48,12 @@ public class BazelOutputDirectoryBuilderTest {
     public void testGetRunScriptPath() {
         BazelLabel label = new BazelLabel("//projects/services/apple:projects/services/apple_apprun"); // $SLASH_OK bazel path
         String path = builder.getRunScriptPath(label);
-        String osPath = BazelPathHelper.osSeps("bazel-bin/projects/services/apple/projects/services/apple_apprun"); // $SLASH_OK
+        String osPath = FSPathHelper.osSeps("bazel-bin/projects/services/apple/projects/services/apple_apprun"); // $SLASH_OK
         assertEquals(osPath, path);
 
         label = new BazelLabel("//projects/services/apple:test"); // $SLASH_OK bazel path
         path = builder.getRunScriptPath(label);
-        osPath = BazelPathHelper.osSeps("bazel-bin/projects/services/apple/test"); // $SLASH_OK
+        osPath = FSPathHelper.osSeps("bazel-bin/projects/services/apple/test"); // $SLASH_OK
         assertEquals(osPath, path);
     }
 }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProblemTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProblemTest.java
@@ -44,13 +44,13 @@ import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class BazelProblemTest {
 
     @Test
     public void getOwningLabel__matchingLabel() {
-        BazelProblem details = BazelProblem.createError(BazelPathHelper.osSeps("a/b/c/d"), 1, "desc"); // $SLASH_OK
+        BazelProblem details = BazelProblem.createError(FSPathHelper.osSeps("a/b/c/d"), 1, "desc"); // $SLASH_OK
         BazelLabel l1 = new BazelLabel("x/y/z"); // $SLASH_OK bazel path
         BazelLabel l2 = new BazelLabel("a/b/c"); // $SLASH_OK bazel path
 
@@ -79,8 +79,8 @@ public class BazelProblemTest {
     @Test
     @Ignore // Windows TODO
     public void toErrorWithRelativizedResourcePath__matchingBazelPackage() {
-        String partialPath = BazelPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
-        String fullPath = BazelPathHelper.osSeps("projects/libs/cake/abstractions" + partialPath); // $SLASH_OK
+        String partialPath = FSPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
+        String fullPath = FSPathHelper.osSeps("projects/libs/cake/abstractions" + partialPath); // $SLASH_OK
         BazelProblem details = BazelProblem.createError(fullPath, 1, "desc");
 
         details = details.toErrorWithRelativizedResourcePath(new BazelLabel("//projects/libs/cake/abstractions")); // $SLASH_OK bazel path
@@ -100,8 +100,8 @@ public class BazelProblemTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void toErrorWithRelativizedResourcePath__matchingBazelPackagePrefix() {
-        String partialPath = BazelPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
-        String fullPath = BazelPathHelper.osSeps("projects/libs/cake/abstractions_foo" + partialPath); // $SLASH_OK
+        String partialPath = FSPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
+        String fullPath = FSPathHelper.osSeps("projects/libs/cake/abstractions_foo" + partialPath); // $SLASH_OK
 
         BazelProblem details = BazelProblem.createError(fullPath, 1, "desc");
 
@@ -110,8 +110,8 @@ public class BazelProblemTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void toErrorWithRelativizedResourcePath__differentBazelPackage() {
-        String partialPath = BazelPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
-        String fullPath = BazelPathHelper.osSeps("projects/libs/cake/metrics-abstractions" + partialPath); // $SLASH_OK
+        String partialPath = FSPathHelper.osSeps("/src/main/java/com/MyClass.java"); // $SLASH_OK
+        String fullPath = FSPathHelper.osSeps("projects/libs/cake/metrics-abstractions" + partialPath); // $SLASH_OK
 
         BazelProblem details = BazelProblem.createError(fullPath, 1, "desc");
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelWorkspaceTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
 import com.salesforce.bazel.sdk.model.test.MockBazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.model.test.MockOperatingEnvironmentDetectionStrategy;
-import com.salesforce.bazel.sdk.path.BazelPathHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class BazelWorkspaceTest {
 
@@ -24,8 +24,8 @@ public class BazelWorkspaceTest {
         assertTrue(
             ws.getBazelOutputBaseDirectory().getAbsolutePath().contains("bazel-java-sdk-" + wsName + "-outputdir"));
         assertTrue(ws.getBazelExecRootDirectory().getAbsolutePath().contains("execroot" + File.separatorChar + wsName));
-        String binDir = BazelPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
-        String binDirExpect = BazelPathHelper.osSeps("execroot/" + wsName + "/bazel-out/darwin-fastbuild/bin"); // $SLASH_OK
+        String binDir = FSPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
+        String binDirExpect = FSPathHelper.osSeps("execroot/" + wsName + "/bazel-out/darwin-fastbuild/bin"); // $SLASH_OK
         assertTrue(binDir.contains(binDirExpect));
     }
 
@@ -40,8 +40,8 @@ public class BazelWorkspaceTest {
         assertTrue(
             ws.getBazelOutputBaseDirectory().getAbsolutePath().contains("bazel-java-sdk-" + wsName + "-outputdir"));
         assertTrue(ws.getBazelExecRootDirectory().getAbsolutePath().contains("execroot" + File.separatorChar + wsName));
-        String binDir = BazelPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
-        String binDirExpect = BazelPathHelper.osSeps("execroot/" + wsName + "/bazel-out/linux-fastbuild/bin"); // $SLASH_OK
+        String binDir = FSPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
+        String binDirExpect = FSPathHelper.osSeps("execroot/" + wsName + "/bazel-out/linux-fastbuild/bin"); // $SLASH_OK
         assertTrue(binDir.contains(binDirExpect));
     }
 
@@ -56,8 +56,8 @@ public class BazelWorkspaceTest {
         assertTrue(
             ws.getBazelOutputBaseDirectory().getAbsolutePath().contains("bazel-java-sdk-" + wsName + "-outputdir"));
         assertTrue(ws.getBazelExecRootDirectory().getAbsolutePath().contains("execroot" + File.separator + wsName));
-        String binDir = BazelPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
-        String binDirExpect = BazelPathHelper.osSeps("execroot/" + wsName + "/bazel-out/windows-fastbuild/bin"); // $SLASH_OK
+        String binDir = FSPathHelper.osSeps(ws.getBazelBinDirectory().getAbsolutePath()); // $SLASH_OK
+        String binDirExpect = FSPathHelper.osSeps("execroot/" + wsName + "/bazel-out/windows-fastbuild/bin"); // $SLASH_OK
         assertTrue(binDir.contains(binDirExpect));
     }
 


### PR DESCRIPTION
Lots of renames, what a mess. The BazelLabel class is one of the most important in the SDK, and had organically grown. It had inconsistent naming conventions. Also the newer BazelPathHelper class was folded into BazelLabel because they were modeling the same thing. New class FSPathHelper now contains the file system path utils.

Copybara'd from the SDK repo.