### PR TITLE
Use standard JUnit launcher for Bazel junit tests #18 #251

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
+++ b/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
@@ -96,6 +96,7 @@
          </run>
       </builder>
    </extension>
+   
    <extension
          id="com.salesforce.bazel.eclipse.launch"
          point="org.eclipse.debug.core.launchConfigurationTypes">
@@ -106,14 +107,16 @@
             name="Bazel Target">
       </launchConfigurationType>
    </extension>
+   
    <extension
         point="org.eclipse.debug.ui.launchConfigurationTypeImages">
-    <launchConfigurationTypeImage
-            id="com.salesforce.bazel.eclipse.launch.image"
-            configTypeID="com.salesforce.bazel.eclipse.launch"
-            icon="resources/bazelicon.gif">
-    </launchConfigurationTypeImage>
+        <launchConfigurationTypeImage
+                id="com.salesforce.bazel.eclipse.launch.image"
+                configTypeID="com.salesforce.bazel.eclipse.launch"
+                icon="resources/bazelicon.gif">
+        </launchConfigurationTypeImage>
    </extension>   
+   
    <extension
          id="com.salesforce.bazel.eclipse.launch.tab"
          point="org.eclipse.debug.ui.launchConfigurationTabGroups">
@@ -126,71 +129,55 @@
    
    <extension
     point="org.eclipse.debug.ui.launchShortcuts">
-    <shortcut
-        class="com.salesforce.bazel.eclipse.launch.BazelTargetLaunchShortcut"
-        icon="resources/bazelicon.gif"
-        id="com.salesforce.bazel.eclipse.launch.shortcut"
-        label="Bazel Target"
-        modes="run, debug">
-        <contextualLaunch>
-            <enablement>
-                <with
-                    variable="selection">
-                    <count
-                        value="+">
-                    </count>
-                    <iterate>
-                       <and>
-                           <adapt type="org.eclipse.core.resources.IResource">
-                               <test property="org.eclipse.core.resources.path"  value="*/src/main/java*">
-                               </test>
-                           </adapt>
-                           <or>
-                               <test property="org.eclipse.debug.ui.matchesPattern" value="*.java"/>
-                               <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
-                           </or>
-                        </and>
-                    </iterate>
-                </with>
-            </enablement>
-        </contextualLaunch>
-    </shortcut>
+        <shortcut
+            class="com.salesforce.bazel.eclipse.launch.BazelTargetLaunchShortcut"
+            icon="resources/bazelicon.gif"
+            id="com.salesforce.bazel.eclipse.launch.shortcut"
+            label="Bazel Target"
+            modes="run, debug">
+            <contextualLaunch>
+                <enablement>
+                    <with
+                        variable="selection">
+                        <count
+                            value="+">
+                        </count>
+                        <iterate>
+                           <and>
+                               <adapt type="org.eclipse.core.resources.IResource">
+                                   <test property="org.eclipse.core.resources.path"  value="*/src/main/java*">
+                                   </test>
+                               </adapt>
+                               <or>
+                                   <test property="org.eclipse.debug.ui.matchesPattern" value="*.java"/>
+                                   <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
+                               </or>
+                            </and>
+                        </iterate>
+                    </with>
+                </enablement>
+            </contextualLaunch>
+        </shortcut>
+   </extension>
     
-    <shortcut
-    class="com.salesforce.bazel.eclipse.launch.BazelJunitTargetLaunchShortcut"
-    category="com.salesforce.bazel.eclipse.launch"
-    icon="resources/bazelicon.gif"
-    id="com.salesforce.bazel.eclipse.launch.junit.shortcut"
-    label="JUnit Bazel Target"
-    modes="run, debug">
-	    <contextualLaunch>
-	        <enablement>
-	            <with
-	                variable="selection">
-	                <count
-	                    value="+">
-	                </count>
-	                <iterate>
-	                 <or>
-	                   <and>
-	                       <adapt type="org.eclipse.core.resources.IResource">
-                             <test property="org.eclipse.core.resources.path" value="*/src/test/java*">
-                             </test>
-                           </adapt>
-                           <test property="org.eclipse.debug.ui.matchesPattern" value="*.java"/>
-                       </and>
-	                   <and>
-	                       <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
-	                       <test property="com.salesforce.bazel.eclipse.isTestJavaElement"/>
-	                   </and>
-	                 </or>
-	                </iterate>
-	            </with>
-	        </enablement>
-	    </contextualLaunch>
-    </shortcut>
+   <extension
+         point="org.eclipse.debug.core.launchDelegates">
+      <launchDelegate
+            name="Bazel JUnit"
+            modes="run, debug"
+            type="org.eclipse.jdt.junit.launchconfig"
+            delegate="com.salesforce.bazel.eclipse.launch.BazelJunitLaunchConfigurationDelegate"
+            id="bazel.junit.launcher">
+      </launchDelegate>
    </extension>
    
+   <extension
+         point="org.eclipse.jdt.junit.testRunListeners">
+      <testRunListener
+            class="com.salesforce.bazel.eclipse.launch.BazelTestRunListener">
+      </testRunListener>
+   </extension>
+
    <extension point="org.eclipse.ui.commands">
       <command
             name="Bazel Target"

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelJunitLaunchConfigurationDelegate.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelJunitLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, Salesforce.com, Inc. All rights reserved.
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met:
@@ -33,24 +33,28 @@
  * specific language governing permissions and limitations under the License.
  *
  */
-
 package com.salesforce.bazel.eclipse.launch;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.junit.launcher.JUnitLaunchShortcut;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate;
 
 /**
- * Launch target for Bazel JUnit Tests - enables the BazelRuntimeClasspathProviders
+ * Plug point into the Eclipse JUnit launcher call chain; allows us to inject the Bazel runtime classpath provider so
+ * the test uses the Bazel computed classpath.
  */
-public class BazelJunitTargetLaunchShortcut extends JUnitLaunchShortcut {
+public class BazelJunitLaunchConfigurationDelegate extends JUnitLaunchConfigurationDelegate {
 
     @Override
-    protected ILaunchConfigurationWorkingCopy createLaunchConfiguration(IJavaElement element) throws CoreException {
-        ILaunchConfigurationWorkingCopy config = createLaunchConfiguration(element, null);
-        BazelRuntimeClasspathProvider.enable(config);
+    public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
+            throws CoreException {
+
+        BazelRuntimeClasspathProvider.enable(configuration);
         BazelRuntimeClasspathProvider.canOpenErrorDialog.set(true);
-        return config;
+
+        super.launch(configuration, mode, launch, monitor);
     }
+
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegate.java
@@ -71,7 +71,7 @@ import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
 
 /**
- * Runs a previously configured Bazel target.
+ * Runs a Bazel non-test target, like a java_binary.
  */
 public class BazelLaunchConfigurationDelegate implements ILaunchConfigurationDelegate {
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestRunListener.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestRunListener.java
@@ -1,0 +1,41 @@
+package com.salesforce.bazel.eclipse.launch;
+
+import org.eclipse.jdt.junit.TestRunListener;
+import org.eclipse.jdt.junit.model.ITestCaseElement;
+import org.eclipse.jdt.junit.model.ITestRunSession;
+
+import com.salesforce.bazel.sdk.logging.LogHelper;
+
+/**
+ * Logging hooks for test execution from BEF.
+ */
+public class BazelTestRunListener extends TestRunListener {
+    static final LogHelper LOG = LogHelper.log(BazelTestRunListener.class);
+
+    @Override
+    public void sessionLaunched(ITestRunSession session) {
+        LOG.info("test session launched for project {}", session.getLaunchedProject().getProject().getName());
+    }
+
+    @Override
+    public void sessionStarted(ITestRunSession session) {
+        LOG.info("test session started for project {} run {}", session.getLaunchedProject().getProject().getName(),
+            session.getTestRunName());
+    }
+
+    @Override
+    public void sessionFinished(ITestRunSession session) {
+        LOG.info("test session finished for project {}", session.getLaunchedProject().getProject().getName());
+    }
+
+    @Override
+    public void testCaseStarted(ITestCaseElement testCaseElement) {
+        LOG.info("test case {}.{} started", testCaseElement.getTestClassName(), testCaseElement.getTestMethodName());
+    }
+
+    @Override
+    public void testCaseFinished(ITestCaseElement testCaseElement) {
+        LOG.info("test case {}.{} finished", testCaseElement.getTestClassName(), testCaseElement.getTestMethodName());
+    }
+
+}

--- a/docs/using_the_feature_launching.md
+++ b/docs/using_the_feature_launching.md
@@ -34,23 +34,28 @@ You can also debug it, with breakpoints, by launching as a *Debug Configuration*
 
 There are several paths to run (or debug) tests from BEF.
 
-Method 1: top level Run menu
+**Method 1: top-level Run menu**
 
-1. Navigate to the *Run* menu, choose *Run As...* and click the *New* button for *Bazel Target*
-1. Select the project, and then the test target from the drop down.
-1. You should now be able to run the test.
+1. In the Package Explorer view, click on the test folder (*src/test/java*), a test Java package (*com.salesforce.hello*), or a specific test class (*HelloWorldTest.java*)
+1. Navigate to the top-level *Run* menu, choose *Run As* and then *JUnit Test*
+1. The JUnit view will populate with the test results
 
-You can also debug it, with breakpoints, by launching as a *Debug Configuration*.
+You can also debug it, with breakpoints, by launching it as a *Debug Configuration*.
 
-Method 2: Package Explorer context menu
+**Method 2: Package Explorer context menu**
 
 1. In the Package Explorer view, click on the test folder (*src/test/java*), a test Java package (*com.salesforce.hello*), or a specific test class (*HelloWorldTest.java*)
 1. Right click on it, and find the *Run As* or *Debug As* item in the context menu
-1. Choose *JUnit Bazel Target*
+1. Choose *JUnit Test*
 1. The JUnit view will populate with the test results
 
-:warning: the standard JUnit Launcher *JUnit Test* does not work.
-[Issue 18](https://github.com/salesforce/bazel-eclipse/issues/18) tracks that work item.
+:point_right: The first time you run JUnit tests in your Eclipse workspace, you will be presented
+  with a dialog to choose the *Preferred Launcher*.
+The **Bazel JUnit Launcher** is the correct one to choose.
+You can configure this per launcher, or for most cases click the *Change Workspace Settings* link
+  and configure it for all launchers in your Eclipse workspace.
+When doing this, click on both *\[Debug\]* and *\[Run\]* types, and check the box for
+  *Bazel JUnit Launcher* for each.
 
 ### Next Topic: Explore!
 


### PR DESCRIPTION
Since early times, we didn't know how to properly wire in Bazel into the Eclipse/JDT standard JUnit launcher code path in Eclipse. We had a workaround with a "Bazel JUnit" test launcher. But it didn't work in all cases.

This PR eliminates the custom launcher. It uses an Eclipse/JDT plug point to swap out the _JUnitLaunchConfigurationDelegate_ instead of the entire launcher. The delegate plug point gives us the ability to change the classpath for tests to use the Bazel classpath, which is what we needed.

After this PR is released, users will need to delete their existing launchers.

Fixes #18 and #251 