### PR TITLE
usability improvements for launching java_binary classes

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
+++ b/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
@@ -139,20 +139,11 @@
                 <enablement>
                     <with
                         variable="selection">
-                        <count
-                            value="+">
+                        <count value="+">
                         </count>
                         <iterate>
-                           <and>
-                               <adapt type="org.eclipse.core.resources.IResource">
-                                   <test property="org.eclipse.core.resources.path"  value="*/src/main/java*">
-                                   </test>
-                               </adapt>
-                               <or>
-                                   <test property="org.eclipse.debug.ui.matchesPattern" value="*.java"/>
-                                   <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
-                               </or>
-                            </and>
+                           <test property="org.eclipse.debug.ui.matchesPattern" value="*.java"/>
+                           <instanceof value="org.eclipse.jdt.core.IJavaElement"/>
                         </iterate>
                     </with>
                 </enablement>


### PR DESCRIPTION
Small improvements:
- we weren't surfacing the errors when failing to launch a Java class
- we unnecessarily limited the file tree to src/main/java when adding the Bazel Target menu item