### PR TITLE
optimize computation of eclipse project structure on import #273

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.JavaCore;
 
 import com.salesforce.bazel.eclipse.BazelNature;
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
+import com.salesforce.bazel.eclipse.projectimport.flow.ImportContext;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelLabel;
@@ -69,20 +70,20 @@ public class EclipseProjectCreator {
         return rootProject;
     }
 
-    public IProject createProject(BazelPackageLocation packageLocation,
+    public IProject createProject(ImportContext ctx, BazelPackageLocation packageLocation,
             List<BazelLabel> bazelTargets, List<IProject> currentImportedProjects,
             List<IProject> existingImportedProjects, EclipseFileLinker fileLinker) {
 
         String projectName = EclipseProjectUtils.computeEclipseProjectNameForBazelPackage(packageLocation,
             existingImportedProjects, currentImportedProjects);
-        EclipseProjectStructureInspector inspector = new EclipseProjectStructureInspector(packageLocation);
+        EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
         String packageFSPath = packageLocation.getBazelPackageFSRelativePath();
         List<BazelLabel> targets = Objects.requireNonNull(bazelTargets);
         IProject project = null;
 
         if (BazelDirectoryStructureUtil.isBazelPackage(bazelWorkspaceRootDirectory, packageFSPath)) {
             // create the project
-            project = createProject(projectName, packageFSPath, inspector.getPackageSourceCodeFSPaths(), targets);
+            project = createProject(projectName, packageFSPath, structure.getPackageSourceCodeFSPaths(), targets);
 
             // link all files in the package root into the Eclipse project
             linkFilesInPackageDirectory(fileLinker, project, packageFSPath,

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectStructure.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectStructure.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.eclipse.project;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.salesforce.bazel.sdk.model.BazelLabel;
+
+/**
+ * Value object that holds the primary model of a Bazel aware Eclipse project.
+ */
+public class EclipseProjectStructure {
+
+    /**
+     * The relative file system path, starting at the root of the workspace, to the directory containing the source
+     * files. For languages like Java that use directories to organize files into packages, the path will be to the base
+     * of the package.
+     * <p>
+     * Example: projects/libs/apple/apple-api/src/main/java
+     */
+    final List<String> packageSourceCodeFSPaths = new ArrayList<>();
+
+    /**
+     * The list of Bazel targets enabled for this Eclipse project.
+     * <p>
+     * Example: //projects/foo:foo, //projects/foo:foo_tests
+     */
+    final List<BazelLabel> bazelTargets = new ArrayList<>();
+
+    public List<String> getPackageSourceCodeFSPaths() {
+        return packageSourceCodeFSPaths;
+    }
+
+    public List<BazelLabel> getBazelTargets() {
+        return bazelTargets;
+    }
+
+}

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateProjectsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateProjectsFlow.java
@@ -83,7 +83,7 @@ public class CreateProjectsFlow implements ImportFlow {
                 List<BazelLabel> bazelTargets = ctx.getPackageLocationToTargets().get(packageLocation);
 
                 // create the project
-                IProject project = projectCreator.createProject(packageLocation, bazelTargets,
+                IProject project = projectCreator.createProject(ctx, packageLocation, bazelTargets,
                     currentImportedProjects, existingImportedProjects, fileLinker);
 
                 if (project != null) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 
 import org.eclipse.core.runtime.SubMonitor;
 
-import com.salesforce.bazel.eclipse.project.EclipseProjectStructureInspector;
+import com.salesforce.bazel.eclipse.project.EclipseProjectStructure;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
@@ -36,8 +36,8 @@ public class DetermineTargetsFlow implements ImportFlow {
         for (BazelPackageLocation packageLocation : ctx.getSelectedBazelPackages()) {
             List<BazelLabel> targets = packageLocation.getBazelTargets();
             if (targets == null) {
-                EclipseProjectStructureInspector inspector = new EclipseProjectStructureInspector(packageLocation);
-                targets = inspector.getBazelTargets();
+                EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
+                targets = structure.getBazelTargets();
             }
             packageLocationToTargets.put(packageLocation, Collections.unmodifiableList(targets));
             LOG.info("Configured targets for " + packageLocation.getBazelPackageFSRelativePath() + ": " + targets);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.core.IJavaProject;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.classpath.EclipseClasspathUtil;
-import com.salesforce.bazel.eclipse.project.EclipseProjectStructureInspector;
+import com.salesforce.bazel.eclipse.project.EclipseProjectStructure;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 
 /**
@@ -63,12 +63,12 @@ public class SetupClasspathContainersFlow implements ImportFlow {
         List<IProject> importedProjects = ctx.getImportedProjects();
         for (IProject project : importedProjects) {
             BazelPackageLocation packageLocation = ctx.getPackageLocationForProject(project);
-            EclipseProjectStructureInspector inspector = new EclipseProjectStructureInspector(packageLocation);
+            EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
             String packageFSPath = packageLocation.getBazelPackageFSRelativePath();
             IJavaProject javaProject = BazelPluginActivator.getJavaCoreHelper().getJavaProjectForProject(project);
 
             // create the classpath; there is no return value because the cp is set directly into the passed javaProject
-            EclipseClasspathUtil.createClasspath(bazelWorkspaceRootDirectory, packageFSPath, inspector.getPackageSourceCodeFSPaths(),
+            EclipseClasspathUtil.createClasspath(bazelWorkspaceRootDirectory, packageFSPath, structure.getPackageSourceCodeFSPaths(),
                 javaProject, ctx.getJavaLanguageLevel());
 
             progressSubMonitor.worked(1);


### PR DESCRIPTION
Simple caching strategy such that we compute the locations of source files in each project only once. The cache lasts for the duration of the import.