### PR TITLE
core impl of the non-maven layout support

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmSourceFolderResolver.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmSourceFolderResolver.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.sdk.lang.jvm;
+
+import java.io.File;
+
+import com.salesforce.bazel.sdk.project.SourcePath;
+
+/**
+ * Takes a project relative path to a JVM source file, and splits the path into two parts:
+ * <ul>
+ * <li>src/main/java</li>
+ * <li>com/salesforce/foo/Foo.java</li>
+ * </ul>
+ */
+public class BazelJvmSourceFolderResolver {
+    // TODO this needs to follow an interface as it needs to be pluggable to support other langs than java
+
+    public static SourcePath formalizeSourcePath(File basePath, String relativePathToSourceFile) {
+        // We want relativePathToSourceFile to be like this:  src/main/java/com/salesforce/foo/Foo.java
+
+        String packageName = null;
+        if (relativePathToSourceFile.endsWith(".java")) {
+            packageName = findJavaFilePackage(basePath, relativePathToSourceFile);
+        }
+
+        // We expect the package name, like: com.salesforce.foo
+        if (packageName == null) {
+            // not enough information to split the path correctly
+            return null;
+        }
+        // convert it to: com/salesforce/foo
+        String packagePath = packageName.replace(".", File.separator);
+
+        // split it
+        SourcePath sourcePath = SourcePath.splitNamespacedPath(relativePathToSourceFile, packagePath);
+
+        return sourcePath;
+    }
+
+    private static String findJavaFilePackage(File basePath, String relativePathToSourceFile) {
+        File srcFile = new File(basePath + File.separator + relativePathToSourceFile);
+        JavaSourceFile javaSrcFile = new JavaSourceFile(srcFile);
+        String packageName = javaSrcFile.readPackageFromFile();
+
+        return packageName;
+
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JavaSourceFile.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JavaSourceFile.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.lang.jvm;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+
+import com.salesforce.bazel.sdk.logging.LogHelper;
+
+/**
+ * Models a java source file.
+ */
+public class JavaSourceFile {
+    static final LogHelper LOG = LogHelper.log(JavaSourceFile.class);
+
+    private final String absolutePath;
+    private final File javaFile;
+
+    public JavaSourceFile(File javaFile) {
+        if (javaFile == null) {
+            throw new IllegalArgumentException("Caller passed a null JavaFile to the constructor.");
+        }
+        absolutePath = javaFile.getAbsolutePath();
+        this.javaFile = javaFile;
+
+        if (!absolutePath.endsWith(".java")) {
+            throw new IllegalArgumentException("Caller passed a non JavaFile to the constructor. Path: "+absolutePath);
+        }
+    }
+
+    /**
+     * Returns the JVM package (ex: "a.b.c") if the "package a.b.c;" line is in this File, null otherwise.
+     */
+    public String readPackageFromFile() {
+        if (!javaFile.exists()) {
+            throw new IllegalStateException("Cannot parse missing JavaFile: " + javaFile.getAbsolutePath());
+        }
+        String packageName = null;
+
+        try (Reader reader = new FileReader(javaFile)) {
+            packageName = getPackageFromReader(reader);
+        } catch (Exception anyE) {
+            LOG.error(anyE.getMessage(), anyE);
+        }
+
+        return packageName;
+    }
+
+    /**
+     * Returns the JVM package if the "package a.b.c;" line is in this reader, null otherwise.
+     */
+    String getPackageFromReader(Reader lines) {
+        try (BufferedReader br = new BufferedReader(lines)) {
+            String javaFileLine = br.readLine();
+            while (javaFileLine != null) {
+                String packageName = getPackageFromLine(javaFileLine);
+                if (packageName != null) {
+                    return packageName;
+                }
+                javaFileLine = br.readLine();
+            }
+
+        } catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the JVM package if it is on this line, null otherwise.
+     */
+    String getPackageFromLine(String line) {
+        line = line.trim();
+        String packageName = null;
+        if (line.startsWith("package")) {
+            int lineLength = line.length();
+
+            if (lineLength < 10) {
+                // somebody put the package statement and packageName on different lines, cant be bothered to support this
+                return null;
+            }
+
+            if (line.endsWith(";")) {
+                packageName = line.substring(8, lineLength - 1);
+            } else {
+                LOG.warn("This package line [{}] from Java file [{}] does not end in a semicolon", line,
+                    javaFile.getAbsolutePath());
+                packageName = line.substring(8);
+            }
+
+            // remove any extra whitespace caused by crazies like this:
+            //   package      com.salesforce.foo       ;
+            packageName = packageName.trim();
+        }
+        return packageName;
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/SourcePath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/SourcePath.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.sdk.project;
+
+import java.io.File;
+
+/**
+ * Models a project relative path to a JVM source file, and splits the path into two parts:
+ * <ul>
+ * <li>src/main/java</li>
+ * <li>com/salesforce/foo/Foo.java</li>
+ * </ul>
+ */
+public class SourcePath {
+    public String pathToDirectory;
+    public String pathToFile;
+
+    /**
+     * Utility function that can be useful for all languages that use directory paths to express namespace/package (like
+     * Java). It splits the passed path into the dir and file parts. You must know the namespace/package path in order
+     * for this function to know where to make the split. The package path is usually retrieved from parsing the file
+     * itself.
+     *
+     * @param relativePathToSourceFile
+     *            src/main/java/com/salesforce/foo/Foo.java
+     * @param packagePath
+     *            com/salesforce/foo; default package would be empty string
+     */
+    public static SourcePath splitNamespacedPath(String relativePathToSourceFile, String packagePath) {
+        if ((relativePathToSourceFile == null) || (packagePath == null)) {
+            return null;
+        }
+
+        if (relativePathToSourceFile.startsWith(File.separator)) {
+            relativePathToSourceFile = relativePathToSourceFile.substring(1);
+        }
+        if (relativePathToSourceFile.endsWith(File.separator)) {
+            relativePathToSourceFile = relativePathToSourceFile.substring(0, relativePathToSourceFile.length() - 1);
+        }
+
+        // Strip the filename:  src/main/java/com/salesforce/foo
+        int lastSlash = relativePathToSourceFile.lastIndexOf(File.separator);
+        if (lastSlash == -1) {
+            // what?
+            return null;
+        }
+        String relativePathToWithoutSourceFile = relativePathToSourceFile.substring(0, lastSlash);
+
+        // We can now expect that relativePathToWithoutSourceFile ends with packagePath
+        SourcePath sourcePath = new SourcePath();
+        if (relativePathToWithoutSourceFile.endsWith(packagePath)) {
+            // hooray, we know what we are doing, do some fancy math to figure it out
+            int lastIndex = relativePathToWithoutSourceFile.length() - packagePath.length();
+            if (packagePath.length() == 0) {
+                // default package, makes for weird math
+                lastIndex = relativePathToWithoutSourceFile.length() + 1;
+            }
+            sourcePath.pathToDirectory = relativePathToWithoutSourceFile.substring(0, lastIndex - 1);
+            sourcePath.pathToFile = relativePathToSourceFile.substring(lastIndex);
+        } else {
+            // what?
+            return null;
+        }
+
+        return sourcePath;
+
+    }
+}

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/EclipseClasspathUtil.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/EclipseClasspathUtil.java
@@ -84,7 +84,7 @@ public final class EclipseClasspathUtil {
 
             IPath outputDir = null; // null is a legal value, it means use the default
             boolean isTestSource = false;
-            if (path.endsWith(FSPathHelper.osSeps("src/test/java"))) { // NON_CONFORMING PROJECT SUPPORT, $SLASH_OK
+            if (path.contains(File.separator + "test")) { // NON_CONFORMING PROJECT SUPPORT, $SLASH_OK
                 isTestSource = true;
                 outputDir = new Path(javaProject.getPath().toOSString() + File.separatorChar + "testbin");
             }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
@@ -50,7 +50,6 @@ import com.salesforce.bazel.sdk.model.BazelPackageLocation;
  * Determines the configured targets, for import, for each Bazel Package being imported.
  */
 public class DetermineTargetsFlow implements ImportFlow {
-
     private static final LogHelper LOG = LogHelper.log(DetermineTargetsFlow.class);
 
     @Override
@@ -70,7 +69,13 @@ public class DetermineTargetsFlow implements ImportFlow {
             List<BazelLabel> targets = packageLocation.getBazelTargets();
             if (targets == null) {
                 EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
-                targets = structure.getBazelTargets();
+                if (structure != null) {
+                    targets = structure.getBazelTargets();
+                } else {
+                    LOG.warn("Could not determine the project structure of package {}. Ignoring...",
+                        packageLocation.getBazelPackageFSRelativePath());
+                    continue;
+                }
             }
             packageLocationToTargets.put(packageLocation, Collections.unmodifiableList(targets));
             LOG.info("Configured targets for " + packageLocation.getBazelPackageFSRelativePath() + ": " + targets);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/lang/jvm/JavaSourceFileTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/lang/jvm/JavaSourceFileTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.lang.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.StringReader;
+
+import org.junit.Test;
+
+public class JavaSourceFileTest {
+
+    @Test
+    public void happyPackageLineTests() {
+        JavaSourceFile javaFile = new JavaSourceFile(new File("FakeJavaFile.java"));
+
+        String packageName = javaFile.getPackageFromLine("package com.salesforce.foo;");
+        assertNotNull(packageName);
+        assertEquals("com.salesforce.foo", packageName);
+
+        packageName = javaFile.getPackageFromLine("package foo;");
+        assertNotNull(packageName);
+        assertEquals("foo", packageName);
+
+        // seriously, do people do this?
+        packageName = javaFile.getPackageFromLine("package     com.salesforce.foo-bar.feelz     ;");
+        assertNotNull(packageName);
+        assertEquals("com.salesforce.foo-bar.feelz", packageName);
+    }
+
+    @Test
+    public void negativePackageLineTests() {
+        JavaSourceFile javaFile = new JavaSourceFile(new File("FakeJavaFile.java"));
+        String packageName = javaFile.getPackageFromLine("public class FakeJavaFile {");
+        assertNull(packageName);
+
+        // somebody put the package statement on a different line than the package. no sympathy.
+        packageName = javaFile.getPackageFromLine("package");
+        assertNull(packageName);
+    }
+
+    @Test
+    public void happyFileTests() {
+        JavaSourceFile javaFile = new JavaSourceFile(new File("FakeJavaFile.java"));
+
+        StringBuffer sb = new StringBuffer();
+        sb.append("// just sample content\n");
+        sb.append("// just sample content\n");
+        sb.append("// just sample content\n");
+        sb.append("package com.salesforce.foo;\n");
+        sb.append("// just sample content\n");
+        sb.append("// just sample content\n");
+        sb.append("// just sample content\n");
+
+        StringReader sr = new StringReader(sb.toString());
+
+        String packageName = javaFile.getPackageFromReader(sr);
+        assertNotNull(packageName);
+        assertEquals("com.salesforce.foo", packageName);
+    }
+}

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/project/SourcePathTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/project/SourcePathTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.sdk.project;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.salesforce.bazel.sdk.path.FSPathHelper;
+
+public class SourcePathTest {
+
+    @Test
+    @Ignore // make Windows compat
+    public void happyTests() {
+        // Maven main
+        SourcePath sp =
+                SourcePath.splitNamespacedPath("src/main/java/com/salesforce/foo/Foo.java", "com/salesforce/foo");
+        assertNotNull(sp);
+        assertEquals("src/main/java", sp.pathToDirectory);
+        assertEquals("com/salesforce/foo/Foo.java", sp.pathToFile);
+
+        // Maven test
+        sp = SourcePath.splitNamespacedPath("src/main/test/com/salesforce/foo/Foo.java", "com/salesforce/foo");
+        assertNotNull(sp);
+        assertEquals("src/main/test", sp.pathToDirectory);
+        assertEquals("com/salesforce/foo/Foo.java", sp.pathToFile);
+
+        // default package
+        sp = SourcePath.splitNamespacedPath("src/main/java/Foo.java", "");
+        assertNotNull(sp);
+        assertEquals("src/main/java", sp.pathToDirectory);
+        assertEquals("Foo.java", sp.pathToFile);
+
+        // custom
+        sp = SourcePath.splitNamespacedPath("sources/com/salesforce/foo/Foo.java", "com/salesforce/foo");
+        assertNotNull(sp);
+        assertEquals("sources", sp.pathToDirectory);
+        assertEquals("com/salesforce/foo/Foo.java", sp.pathToFile);
+    }
+
+    @Test
+    @Ignore // make Windows compat
+    public void unhappyTests() {
+        // package mismatch
+        String path = FSPathHelper.osSeps("src/main/java/com/salesforce/foo/Foo.java");
+        SourcePath sp = SourcePath.splitNamespacedPath(path, "com/salesforce/bar");
+        assertNull(sp);
+
+        // subpackage
+        sp = SourcePath.splitNamespacedPath("src/main/test/com/salesforce/foo/bar/Foo.java", "com/salesforce/foo");
+        assertNull(sp);
+
+        // no path
+        sp = SourcePath.splitNamespacedPath("Foo.java", "com/salesforce/foo");
+        assertNull(sp);
+
+        // null path
+        sp = SourcePath.splitNamespacedPath(null, "something");
+        assertNull(sp);
+
+        // null package
+        sp = SourcePath.splitNamespacedPath("Foo.java", null);
+        assertNull(sp);
+
+        // Forgot the file
+        sp = SourcePath.splitNamespacedPath("src/main/java/com/salesforce/foo", "com/salesforce/foo");
+        assertNull(sp);
+
+        // Forgot the file 2
+        sp = SourcePath.splitNamespacedPath("src/main/java/com/salesforce/foo/", "com/salesforce/foo");
+        assertNull(sp);
+    }
+
+    @Test
+    @Ignore // make Windows compat
+    public void edgeCaseTests() {
+        // Duped path elements
+        SourcePath sp = SourcePath.splitNamespacedPath("src/main/java/com/salesforce/foo/com/salesforce/foo/Foo.java",
+                "com/salesforce/foo");
+        assertNotNull(sp);
+        assertEquals("src/main/java/com/salesforce/foo", sp.pathToDirectory);
+        assertEquals("com/salesforce/foo/Foo.java", sp.pathToFile);
+    }
+}


### PR DESCRIPTION
This is the core implementation of support for non-Maven layouts #8 , which is the main feature of the BEF 1.5.0 release. It will first try to find source files using a Maven layout, since that is the fastest. If that fails, it will resort to using Bazel Query to track down the source folders for the project. This is the better approach, but is much slower so we will try to avoid it.

Right now it is hard coded to look for java files, but I have a handful of follow ups to do with this, including make it lang-pluggable. And some functional tests. Etc.

I will also make the structure strategies pluggable, so we can add more over time and ideally create a way for users to define their own if their company uses a non-Maven, but predictable, layout for their projects.