### PR TITLE
make structure strategies pluggable, move down to SDK

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel-java-sdk/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Export-Package: com.salesforce.bazel.sdk.aspect,
  com.salesforce.bazel.sdk.model,
  com.salesforce.bazel.sdk.path,
  com.salesforce.bazel.sdk.project,
+ com.salesforce.bazel.sdk.project.structure,
  com.salesforce.bazel.sdk.util,
  com.salesforce.bazel.sdk.workspace
 Bundle-Vendor: Salesforce

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/init/JvmRuleInit.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/init/JvmRuleInit.java
@@ -33,31 +33,43 @@
  */
 package com.salesforce.bazel.sdk.init;
 
- import com.salesforce.bazel.sdk.aspect.AspectTargetInfoFactory;
- import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectTargetInfoFactoryProvider;
- import com.salesforce.bazel.sdk.model.BazelTargetKind;
+import com.salesforce.bazel.sdk.aspect.AspectTargetInfoFactory;
+import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectTargetInfoFactoryProvider;
+import com.salesforce.bazel.sdk.lang.jvm.MavenProjectStructureStrategy;
+import com.salesforce.bazel.sdk.model.BazelTargetKind;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructureStrategy;
 
- /**
-  * Initializer to install support for Java rules into the SDK. Call initialize() once at startup.
-  */
- public class JvmRuleInit {
+/**
+ * Initializer to install support for Java rules into the SDK. Call initialize() once at startup.
+ */
+public class JvmRuleInit {
 
-     // register the collection of Java rules that we want to handle
-     public static final BazelTargetKind KIND_JAVA_LIBRARY = new BazelTargetKind("java_library", false, false);
-     public static final BazelTargetKind KIND_JAVA_TEST = new BazelTargetKind("java_test", false, true);
-     public static final BazelTargetKind KIND_JAVA_BINARY = new BazelTargetKind("java_binary", true, false);
-     public static final BazelTargetKind KIND_SELENIUM_TEST = new BazelTargetKind("java_web_test_suite", false, true);
-     public static final BazelTargetKind KIND_SPRINGBOOT = new BazelTargetKind("springboot", true, false);
-     public static final BazelTargetKind KIND_PROTO_LIBRARY = new BazelTargetKind("java_proto_library", false, false);
-     public static final BazelTargetKind KIND_PROTO_LITE_LIBRARY =
-             new BazelTargetKind("java_lite_proto_library", false, false);
-     public static final BazelTargetKind KIND_GRPC_LIBRARY = new BazelTargetKind("java_grpc_library", false, false);
+    // register the collection of Java rules that we want to handle
+    public static final BazelTargetKind KIND_JAVA_LIBRARY = new BazelTargetKind("java_library", false, false);
+    public static final BazelTargetKind KIND_JAVA_TEST = new BazelTargetKind("java_test", false, true);
+    public static final BazelTargetKind KIND_JAVA_BINARY = new BazelTargetKind("java_binary", true, false);
+    public static final BazelTargetKind KIND_SELENIUM_TEST = new BazelTargetKind("java_web_test_suite", false, true);
+    public static final BazelTargetKind KIND_SPRINGBOOT = new BazelTargetKind("springboot", true, false);
+    public static final BazelTargetKind KIND_PROTO_LIBRARY = new BazelTargetKind("java_proto_library", false, false);
+    public static final BazelTargetKind KIND_PROTO_LITE_LIBRARY =
+            new BazelTargetKind("java_lite_proto_library", false, false);
+    public static final BazelTargetKind KIND_GRPC_LIBRARY = new BazelTargetKind("java_grpc_library", false, false);
 
-     /**
-      * Call once at the start of the tool to initialize the JVM rule support.
-      */
-     public static void initialize() {
-         AspectTargetInfoFactory.addProvider(new JVMAspectTargetInfoFactoryProvider());
-     }
+    // The Maven strategy quickly locates source directories if it detects a Bazel package has a Maven-like layout (src/main/java).
+    // We will always want the Maven strategy enabled for official builds, but for internal testing we sometimes want
+    // to disable this so we can be sure the Bazel Query strategy is working for some of our internal repos that happen to
+    // follow Maven conventions.
+    public static boolean ENABLE_MAVEN_STRUCTURE_STRATEGY = true;
 
- }
+    /**
+     * Call once at the start of the tool to initialize the JVM rule support.
+     */
+    public static void initialize() {
+        AspectTargetInfoFactory.addProvider(new JVMAspectTargetInfoFactoryProvider());
+
+        if (ENABLE_MAVEN_STRUCTURE_STRATEGY) {
+            ProjectStructureStrategy.projectStructureStrategies.add(0, new MavenProjectStructureStrategy());
+        }
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/MavenProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/MavenProjectStructureStrategy.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.lang.jvm;
+
+import java.io.File;
+
+import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructureStrategy;
+
+/**
+ * Project structure strategy that is optimized to quickly determine if this project is laid out with Maven conventions
+ * (src/main/java, src/test/java).
+ */
+public class MavenProjectStructureStrategy extends ProjectStructureStrategy {
+
+    @Override
+    public ProjectStructure doStructureAnalysis(BazelWorkspace bazelWorkspace, BazelPackageLocation packageNode,
+            BazelWorkspaceCommandRunner commandRunner) {
+        ProjectStructure result = new ProjectStructure();
+
+        // NOTE: order of adding the result.packageSourceCodeFSPaths array is important. Eclipse
+        // will honor that order in the project explorer
+
+        File workspaceRootDir = bazelWorkspace.getBazelWorkspaceRootDirectory();
+        String packageRelPath = packageNode.getBazelPackageFSRelativePath();
+
+        // MAVEN MAIN SRC
+        String mainSrcRelPath =
+                packageRelPath + File.separator + "src" + File.separator + "main" + File.separator + "java";
+        File mainSrcDir = new File(workspaceRootDir, mainSrcRelPath);
+        if (mainSrcDir.exists()) {
+            result.packageSourceCodeFSPaths.add(mainSrcRelPath);
+        } else {
+            // by design, this strategy will only be ineffect if src/main/java exists
+            return null;
+        }
+
+        // MAVEN MAIN RESOURCES
+        String mainResourcesRelPath =
+                packageRelPath + File.separator + "src" + File.separator + "main" + File.separator + "resources";
+        File mainResourcesDir = new File(workspaceRootDir, mainResourcesRelPath);
+        if (mainResourcesDir.exists()) {
+            result.packageSourceCodeFSPaths.add(mainResourcesRelPath);
+        }
+
+        // MAVEN TEST SRC
+        String testSrcRelPath =
+                packageRelPath + File.separator + "src" + File.separator + "test" + File.separator + "java";
+        File testSrcDir = new File(workspaceRootDir, testSrcRelPath);
+        if (testSrcDir.exists()) {
+            result.packageSourceCodeFSPaths.add(testSrcRelPath);
+        }
+        // MAVEN TEST RESOURCES
+        String testResourcesRelPath =
+                packageRelPath + File.separator + "src" + File.separator + "test" + File.separator + "resources";
+        File testResourcesDir = new File(workspaceRootDir, testResourcesRelPath);
+        if (testResourcesDir.exists()) {
+            result.packageSourceCodeFSPaths.add(testResourcesRelPath);
+        }
+
+        return result;
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.project.structure;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
+import com.salesforce.bazel.sdk.lang.jvm.BazelJvmSourceFolderResolver;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelLabel;
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.path.FSTree;
+import com.salesforce.bazel.sdk.project.SourcePath;
+
+/**
+ * ProjectStructureStrategy that locates the source directories in a project by using Bazel Query. This is an expensive
+ * strategy, so is used as the last resort.
+ */
+public class BazelQueryProjectStructureStrategy extends ProjectStructureStrategy {
+    private static final LogHelper LOG = LogHelper.log(BazelQueryProjectStructureStrategy.class);
+
+    @Override
+    public ProjectStructure doStructureAnalysis(BazelWorkspace bazelWorkspace, BazelPackageLocation packageNode,
+            BazelWorkspaceCommandRunner commandRunner) {
+        ProjectStructure result = new ProjectStructure();
+
+        File workspaceRootDir = bazelWorkspace.getBazelWorkspaceRootDirectory();
+        String packageRelPath = packageNode.getBazelPackageFSRelativePath();
+        File packageDir = new File(workspaceRootDir, packageRelPath); // TODO move this to the PackageLocation api
+
+        BazelLabel packageLabel =
+                new BazelLabel(packageRelPath, BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR);
+
+        Collection<String> results = null;
+        try {
+            results = commandRunner.querySourceFilesForTarget(workspaceRootDir, packageLabel);
+        } catch (Exception anyE) {
+            LOG.error("Failed querying package [{}] for source files.", anyE, packageLabel);
+        }
+
+        if ((results != null) && (results.size() > 0)) {
+            // the results will contain paths like this:
+            //   source/dev/com/salesforce/foo/Bar.java
+            // but it can also have non-java source files, so we need to check for that
+
+            Set<String> alreadySeenBasePaths = new HashSet<>();
+            FSTree otherSourcePaths = new FSTree();
+
+            for (String srcPath : results) {
+                File sourceFile = new File(packageDir, srcPath);
+                if (!sourceFile.exists()) {
+                    // this file is coming from a package outside of our package from somewhere else in the
+                    // Bazel workspace, so we don't consider it for our project source paths
+                    continue;
+                }
+
+                // it is expensive to formalize the source path as it involves parsing the source file,
+                // so try to bail out here early
+                boolean alreadySeen = false;
+                for (String alreadySeenBasePath : alreadySeenBasePaths) {
+                    if (srcPath.startsWith(alreadySeenBasePath)) {
+                        alreadySeen = true;
+                        break;
+                    }
+                }
+
+                if (!alreadySeen) {
+                    if (srcPath.endsWith(".java")) {
+                        SourcePath srcPathObj = BazelJvmSourceFolderResolver.formalizeSourcePath(packageDir, srcPath);
+                        if (srcPathObj != null) {
+                            String workspacePathToSourceDirectory =
+                                    packageRelPath + File.separator + srcPathObj.pathToDirectory;
+                            result.packageSourceCodeFSPaths.add(workspacePathToSourceDirectory);
+                            alreadySeenBasePaths.add(srcPathObj.pathToDirectory);
+                            LOG.info("Found source path {} for package {}", srcPathObj.pathToDirectory,
+                                packageRelPath);
+                        } else {
+                            LOG.info("Could not derive source path from {} for package {}", srcPath,
+                                packageRelPath);
+                        }
+                    } else {
+                        LOG.info("Found file of unknown type for source path from {} for package {}?", srcPath,
+                            packageRelPath);
+                        FSTree.addNode(otherSourcePaths, srcPath, File.separator, true);
+                    }
+                }
+            }
+
+            // now figure out a reasonable way to represent the source paths of resource files
+            computeResourceDirectories(packageRelPath, result, otherSourcePaths);
+
+            // NOTE: the order of result.packageSourceCodeFSPaths array is important. Eclipse
+            // will honor that order in the project explorer. Because we don't know the proper order
+            // based on folder names (e.g. main, test) we just sort alphabetically.
+            Collections.sort(result.packageSourceCodeFSPaths);
+        } else {
+            LOG.info("Did not find any source files for package [{}], ignoring for import.", packageLabel);
+            result = null;
+        }
+
+        return result;
+    }
+
+    private static void computeResourceDirectories(String bazelPackageFSRelativePath, ProjectStructure result,
+            FSTree otherSourcePaths) {
+
+        // this is not an exact science, see the FSTree class for the algorithm for identifying directories that would
+        // be helpful to add
+        List<String> resourceDirectoryPaths = FSTree.computeMeaningfulDirectories(otherSourcePaths, File.separator);
+        for (String resourceDirectoryPath : resourceDirectoryPaths) {
+            String path = bazelPackageFSRelativePath + File.separator + resourceDirectoryPath;
+            result.packageSourceCodeFSPaths.add(path);
+        }
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
@@ -21,7 +21,7 @@
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.bazel.eclipse.project;
+package com.salesforce.bazel.sdk.project.structure;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,30 +29,34 @@ import java.util.List;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 
 /**
- * Value object that holds the primary model of a Bazel aware Eclipse project.
+ * Value object that holds the layout of source directories in a Bazel project.
+ * <p>
+ * TODO merge this with BazelProject?
  */
-public class EclipseProjectStructure {
+public class ProjectStructure {
 
     /**
-     * The relative file system path, starting at the root of the workspace, to the directory containing the source
-     * files. For languages like Java that use directories to organize files into packages, the path will be to the base
-     * of the package.
+     * The relative file system path, starting at the root of the workspace, to the directories containing the source
+     * files. For languages like Java that use directories to organize files by Java package (com.salesforce.foo), the
+     * path will be to the base of the package (the directory that contains the "com" directory).
      * <p>
      * Example: projects/libs/apple/apple-api/src/main/java
      */
-    final List<String> packageSourceCodeFSPaths = new ArrayList<>();
+    public final List<String> packageSourceCodeFSPaths = new ArrayList<>();
 
     /**
-     * The list of Bazel targets enabled for this Eclipse project.
+     * The list of Bazel targets enabled for this project.
      * <p>
      * Example: //projects/foo:foo, //projects/foo:foo_tests
      */
-    final List<BazelLabel> bazelTargets = new ArrayList<>();
+    public final List<BazelLabel> bazelTargets = new ArrayList<>();
+
 
     public List<String> getPackageSourceCodeFSPaths() {
         return packageSourceCodeFSPaths;
     }
 
+    @Deprecated // this should be coming from somewhere else
     public List<BazelLabel> getBazelTargets() {
         return bazelTargets;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructureStrategy.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.project.structure;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
+import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
+
+/**
+ * Pluggable strategy for establishing the basic structure of a project. Used early during import.
+ */
+public abstract class ProjectStructureStrategy {
+
+    /**
+     * List of pluggable strategies used to derive the source directories for a project during import. The list is
+     * public and is intended to be modified by SDK extensions. Each supported language will likely have one or more
+     * strategies based on conventions for the language. For example, for Java, the Maven layout (src/main/java,
+     * src/test/java) is a common one and so there is a Maven strategy.
+     * <p>
+     * The list is processed in order, and the first strategy that recognizes the project structure wins. The last
+     * strategy in the list (Bazel Query) uses a general purpose strategy that is expensive but is suitable for cases
+     * where the Bazel package has a custom layout.
+     */
+    public static List<ProjectStructureStrategy> projectStructureStrategies = new ArrayList<>();
+    static {
+        // Bazel Query should be the last one in the list; it is general purpose, but expensive to run
+        projectStructureStrategies.add(new BazelQueryProjectStructureStrategy());
+    }
+
+    public static ProjectStructure determineProjectStructure(BazelWorkspace bazelWorkspace,
+            BazelPackageLocation packageNode, BazelWorkspaceCommandRunner commandRunner) {
+        ProjectStructure result = null;
+
+        for (ProjectStructureStrategy strategy : ProjectStructureStrategy.projectStructureStrategies) {
+            result = strategy.doStructureAnalysis(bazelWorkspace, packageNode, commandRunner);
+            if (result != null) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Inspect the project and determine the structure of this project. If this strategy is not suited to analyze the
+     * particular project, it will return null.
+     *
+     * @param bazelWorkspace
+     *            the workspace object
+     * @param packageNode
+     *            the package for which to do the analysis
+     * @param commandRunner
+     *            the Bazel command runner in case this strategy needs to run ad-hoc Bazel commands to do the analysis
+     */
+    public abstract ProjectStructure doStructureAnalysis(BazelWorkspace bazelWorkspace,
+            BazelPackageLocation packageNode, BazelWorkspaceCommandRunner commandRunner);
+}

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
@@ -46,6 +46,7 @@ import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 import com.salesforce.bazel.sdk.project.BazelProject;
 import com.salesforce.bazel.sdk.project.BazelProjectManager;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
 import com.salesforce.bazel.sdk.util.BazelDirectoryStructureUtil;
 
 /**
@@ -76,7 +77,7 @@ public class EclipseProjectCreator {
 
         String projectName = EclipseProjectUtils.computeEclipseProjectNameForBazelPackage(packageLocation,
             existingImportedProjects, currentImportedProjects);
-        EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
+        ProjectStructure structure = ctx.getProjectStructure(packageLocation);
         String packageFSPath = packageLocation.getBazelPackageFSRelativePath();
         List<BazelLabel> targets = Objects.requireNonNull(bazelTargets);
         IProject project = null;

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectStructureInspector.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectStructureInspector.java
@@ -25,75 +25,56 @@ package com.salesforce.bazel.eclipse.project;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
-import com.salesforce.bazel.sdk.lang.jvm.BazelJvmSourceFolderResolver;
-import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
 import com.salesforce.bazel.sdk.path.FSPathHelper;
-import com.salesforce.bazel.sdk.path.FSTree;
-import com.salesforce.bazel.sdk.project.SourcePath;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructureStrategy;
 import com.salesforce.bazel.sdk.util.BazelConstants;
 
 /**
  * Discovers well know paths in a bazel project. Invoked during import.
  * <p>
- * This is expensive to compute, so you should be calling the getProjectStructure() method on ImportContext instead, as
- * it caches the results for the duration of the import.
+ * This can be expensive to compute, so you should be calling the getProjectStructure() method on ImportContext instead,
+ * as it caches the results for the duration of the import.
  */
 public class EclipseProjectStructureInspector {
-    private static final LogHelper LOG = LogHelper.log(EclipseProjectStructureInspector.class);
 
-    // We will always want Maven optimization enabled for official builds, but for internal testing we sometimes want
-    // to disable this so we can be sure the bazel query path is working for some of our internal repos that happen to
-    // follow Maven conventions. We should really make a pref for this TODO
-    public static boolean ENABLE_MAVEN_OPTIMIZATION = true;
+    // TODO after cleaning this up, there might not be anything left of this operation in the Core plugin; it should
+    // be all done in the SDK
 
-    public static EclipseProjectStructure computePackageSourceCodePaths(BazelPackageLocation packageNode) {
-        EclipseProjectStructure result = null;
+    public static ProjectStructure computePackageSourceCodePaths(BazelPackageLocation packageNode) {
+        ProjectStructure result = null;
 
-        // add this node buildable target
-        File workspaceRootDir = packageNode.getWorkspaceRootDirectory();
-        String bazelWorkspaceRootPath = FSPathHelper.getCanonicalPathStringSafely(workspaceRootDir);
-        String bazelPackageFSRelativePath = packageNode.getBazelPackageFSRelativePath();
-        File packageDir = new File(workspaceRootDir, bazelPackageFSRelativePath);
+        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
+        BazelWorkspaceCommandRunner commandRunner =
+                BazelPluginActivator.getBazelCommandManager().getWorkspaceCommandRunner(bazelWorkspace);
 
-        // first check for the common case of Maven-like directory structure; this is the quickest way
-        // to find the source files for a project
-        if (ENABLE_MAVEN_OPTIMIZATION) {
-            result = doCheapMavenStructureCheck(packageNode, workspaceRootDir, bazelWorkspaceRootPath,
-                bazelPackageFSRelativePath, packageDir);
-        }
-
-        if (result == null) {
-            // we didn't find any Maven style source paths, so we need to do the expensive Bazel Query option
-            LOG.info("Starting Bazel Query strategy for finding source files in package {}...",
-                bazelPackageFSRelativePath);
-            result = doExpensiveBazelQueryStructureCheck(packageNode, workspaceRootDir, bazelWorkspaceRootPath,
-                bazelPackageFSRelativePath, packageDir);
-        }
+        result = ProjectStructureStrategy.determineProjectStructure(bazelWorkspace, packageNode, commandRunner);
 
         if (result != null) {
             // we found some source paths
+
+            File workspaceRootDir = packageNode.getWorkspaceRootDirectory();
+            String bazelPackageFSRelativePath = packageNode.getBazelPackageFSRelativePath();
+            File packageDir = new File(workspaceRootDir, bazelPackageFSRelativePath);
 
             // we dont do much for proto files (at least, not currently, see #60) so only
             // check for proto files if we already have other source files
             //   https://github.com/salesforce/bazel-eclipse/issues/60
             // proto files are generally in the toplevel folder (not a Maven convention, but common), lets check for those now
             // eventually we should use bazel query for these as well
+            // TODO I don't think we need this anymore, we now surface all files in the root of package automatically
             if (packageDir.list(new ProtoFileFilter()).length > 0) {
                 result.packageSourceCodeFSPaths.add(packageNode.getBazelPackageFSRelativePath());
             }
 
-            // TODO derive the list of active targets, this isnt quite right, we should be honoring the list we already have
+            // TODO derive the list of active targets, this isnt right, we should be honoring the list we already have,
+            // also these targets do not belong in the structure object
             String packagePath = packageNode.getBazelPackageFSRelativePath();
             String labelPath = packagePath.replace(FSPathHelper.WINDOWS_BACKSLASH, BazelLabel.BAZEL_SLASH); // convert Windows style paths to Bazel label paths
             for (String target : BazelConstants.DEFAULT_PACKAGE_TARGETS) {
@@ -102,141 +83,6 @@ public class EclipseProjectStructureInspector {
         }
 
         return result;
-    }
-
-    private static EclipseProjectStructure doCheapMavenStructureCheck(BazelPackageLocation packageNode,
-            File workspaceRootDir, String bazelWorkspaceRootPath, String bazelPackageFSRelativePath, File packageDir) {
-        EclipseProjectStructure result = new EclipseProjectStructure();
-
-        // NOTE: order of adding the result.packageSourceCodeFSPaths array is important. Eclipse
-        // will honor that order in the project explorer
-
-        // MAVEN MAIN SRC
-        String mainSrcRelPath = bazelPackageFSRelativePath + File.separator + "src" + File.separator
-                + "main" + File.separator + "java";
-        File mainSrcDir = new File(bazelWorkspaceRootPath + File.separator + mainSrcRelPath);
-        if (mainSrcDir.exists()) {
-            result.packageSourceCodeFSPaths.add(mainSrcRelPath);
-        } else {
-            // by design, this strategy will only be ineffect if src/main/java exists
-            return null;
-        }
-
-        // MAVEN MAIN RESOURCES
-        String mainResourcesRelPath = bazelPackageFSRelativePath + File.separator + "src"
-                + File.separator + "main" + File.separator + "resources";
-        File mainResourcesDir = new File(bazelWorkspaceRootPath + File.separator + mainResourcesRelPath);
-        if (mainResourcesDir.exists()) {
-            result.packageSourceCodeFSPaths.add(mainResourcesRelPath);
-        }
-
-        // MAVEN TEST SRC
-        String testSrcRelPath = bazelPackageFSRelativePath + File.separator + "src" + File.separator
-                + "test" + File.separator + "java";
-        File testSrcDir = new File(bazelWorkspaceRootPath + File.separator + testSrcRelPath);
-        if (testSrcDir.exists()) {
-            result.packageSourceCodeFSPaths.add(testSrcRelPath);
-        }
-        // MAVEN TEST RESOURCES
-        String testResourcesRelPath = bazelPackageFSRelativePath + File.separator + "src"
-                + File.separator + "test" + File.separator + "resources";
-        File testResourcesDir = new File(bazelWorkspaceRootPath + File.separator + testResourcesRelPath);
-        if (testResourcesDir.exists()) {
-            result.packageSourceCodeFSPaths.add(testResourcesRelPath);
-        }
-
-        return result;
-    }
-
-    private static EclipseProjectStructure doExpensiveBazelQueryStructureCheck(BazelPackageLocation packageNode,
-            File workspaceRootDir, String bazelWorkspaceRootPath, String bazelPackageFSRelativePath, File packageDir) {
-        EclipseProjectStructure result = new EclipseProjectStructure();
-
-        BazelWorkspace bazelWorkspace = BazelPluginActivator.getBazelWorkspace();
-        BazelWorkspaceCommandRunner commandRunner =
-                BazelPluginActivator.getBazelCommandManager().getWorkspaceCommandRunner(bazelWorkspace);
-        BazelLabel packageLabel =
-                new BazelLabel(bazelPackageFSRelativePath, BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR);
-        Collection<String> results = null;
-        try {
-            results = commandRunner.querySourceFilesForTarget(workspaceRootDir, packageLabel);
-        } catch (Exception anyE) {
-            LOG.error("Failed querying package [{}] for source files.", anyE, packageLabel);
-        }
-
-        if ((results != null) && (results.size() > 0)) {
-            // the results will contain paths like this:
-            //   source/dev/com/salesforce/foo/Bar.java
-            // but it can also have non-java source files, so we need to check for that
-
-            Set<String> alreadySeenBasePaths = new HashSet<>();
-            FSTree otherSourcePaths = new FSTree();
-
-            for (String srcPath : results) {
-                File sourceFile = new File(packageDir, srcPath);
-                if (!sourceFile.exists()) {
-                    // this file is coming from a package outside of our package from somewhere else in the
-                    // Bazel workspace, so we don't consider it for our project source paths
-                    continue;
-                }
-
-                // it is expensive to formalize the source path as it involves parsing the source file,
-                // so try to bail out here early
-                boolean alreadySeen = false;
-                for (String alreadySeenBasePath : alreadySeenBasePaths) {
-                    if (srcPath.startsWith(alreadySeenBasePath)) {
-                        alreadySeen = true;
-                        break;
-                    }
-                }
-
-                if (!alreadySeen) {
-                    if (srcPath.endsWith(".java")) {
-                        SourcePath srcPathObj = BazelJvmSourceFolderResolver.formalizeSourcePath(packageDir, srcPath);
-                        if (srcPathObj != null) {
-                            String workspacePathToSourceDirectory =
-                                    bazelPackageFSRelativePath + File.separator + srcPathObj.pathToDirectory;
-                            result.packageSourceCodeFSPaths.add(workspacePathToSourceDirectory);
-                            alreadySeenBasePaths.add(srcPathObj.pathToDirectory);
-                            LOG.info("Found source path {} for package {}", srcPathObj.pathToDirectory,
-                                bazelPackageFSRelativePath);
-                        } else {
-                            LOG.info("Could not derive source path from {} for package {}", srcPath,
-                                bazelPackageFSRelativePath);
-                        }
-                    } else {
-                        LOG.info("Found file of unknown type for source path from {} for package {}?", srcPath,
-                            bazelPackageFSRelativePath);
-                        FSTree.addNode(otherSourcePaths, srcPath, File.separator, true);
-                    }
-                }
-            }
-
-            // now figure out a reasonable way to represent the source paths of resource files
-            computeResourceDirectories(bazelPackageFSRelativePath, result, otherSourcePaths);
-
-            // NOTE: the order of result.packageSourceCodeFSPaths array is important. Eclipse
-            // will honor that order in the project explorer. Because we don't know the proper order
-            // based on folder names (e.g. main, test) we just sort alphabetically.
-            Collections.sort(result.packageSourceCodeFSPaths);
-        } else {
-            LOG.info("Did not find any source files for package [{}], ignoring for import.", packageLabel);
-            result = null;
-        }
-
-        return result;
-    }
-
-    private static void computeResourceDirectories(String bazelPackageFSRelativePath, EclipseProjectStructure result,
-            FSTree otherSourcePaths) {
-
-        // this is not an exact science, see the FSTree class for the algorithm for identifying directories that would
-        // be helpful to add
-        List<String> resourceDirectoryPaths = FSTree.computeMeaningfulDirectories(otherSourcePaths, File.separator);
-        for (String resourceDirectoryPath : resourceDirectoryPaths) {
-            String path = bazelPackageFSRelativePath + File.separator + resourceDirectoryPath;
-            result.packageSourceCodeFSPaths.add(path);
-        }
     }
 
     private static class ProtoFileFilter implements FilenameFilter {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
@@ -41,10 +41,10 @@ import java.util.Objects;
 
 import org.eclipse.core.runtime.SubMonitor;
 
-import com.salesforce.bazel.eclipse.project.EclipseProjectStructure;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
 
 /**
  * Determines the configured targets, for import, for each Bazel Package being imported.
@@ -68,7 +68,7 @@ public class DetermineTargetsFlow implements ImportFlow {
         for (BazelPackageLocation packageLocation : ctx.getSelectedBazelPackages()) {
             List<BazelLabel> targets = packageLocation.getBazelTargets();
             if (targets == null) {
-                EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
+                ProjectStructure structure = ctx.getProjectStructure(packageLocation);
                 if (structure != null) {
                     targets = structure.getBazelTargets();
                 } else {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportContext.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportContext.java
@@ -34,11 +34,11 @@ import org.eclipse.core.resources.IProject;
 
 import com.salesforce.bazel.eclipse.project.EclipseFileLinker;
 import com.salesforce.bazel.eclipse.project.EclipseProjectCreator;
-import com.salesforce.bazel.eclipse.project.EclipseProjectStructure;
 import com.salesforce.bazel.eclipse.project.EclipseProjectStructureInspector;
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfos;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
 import com.salesforce.bazel.sdk.workspace.ProjectOrderResolver;
 
 /**
@@ -49,7 +49,7 @@ public class ImportContext {
     private final BazelPackageLocation bazelWorkspaceRootPackageInfo;
     private final List<BazelPackageLocation> selectedBazelPackages;
     private final ProjectOrderResolver projectOrderResolver;
-    private final Map<String, EclipseProjectStructure> eclipseProjectStructureCache = new HashMap<>();
+    private final Map<String, ProjectStructure> ProjectSourceStructureCache = new HashMap<>();
 
     private final List<IProject> importedProjects = new ArrayList<>();
     private final Map<IProject, BazelPackageLocation> projectToPackageLocation = new HashMap<>();
@@ -176,13 +176,13 @@ public class ImportContext {
      * The importer flows will look up the structure of each Eclipse project multiple times during import. They are
      * expensive to compute, and so caching them for the duration of import is a big benefit.
      */
-    public EclipseProjectStructure getProjectStructure(BazelPackageLocation packageNode) {
+    public ProjectStructure getProjectStructure(BazelPackageLocation packageNode) {
         String cacheKey = packageNode.getBazelPackageFSRelativePath();
-        EclipseProjectStructure structure = eclipseProjectStructureCache.get(cacheKey);
+        ProjectStructure structure = ProjectSourceStructureCache.get(cacheKey);
 
         if (structure == null) {
             structure = EclipseProjectStructureInspector.computePackageSourceCodePaths(packageNode);
-            eclipseProjectStructureCache.put(cacheKey, structure);
+            ProjectSourceStructureCache.put(cacheKey, structure);
         }
 
         return structure;

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
@@ -34,8 +34,8 @@ import org.eclipse.jdt.core.IJavaProject;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.classpath.EclipseClasspathUtil;
-import com.salesforce.bazel.eclipse.project.EclipseProjectStructure;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
 
 /**
  * Configures the classpath container for each project.
@@ -63,7 +63,7 @@ public class SetupClasspathContainersFlow implements ImportFlow {
         List<IProject> importedProjects = ctx.getImportedProjects();
         for (IProject project : importedProjects) {
             BazelPackageLocation packageLocation = ctx.getPackageLocationForProject(project);
-            EclipseProjectStructure structure = ctx.getProjectStructure(packageLocation);
+            ProjectStructure structure = ctx.getProjectStructure(packageLocation);
             String packageFSPath = packageLocation.getBazelPackageFSRelativePath();
             IJavaProject javaProject = BazelPluginActivator.getJavaCoreHelper().getJavaProjectForProject(project);
 


### PR DESCRIPTION
First, this behavior should be in the SDK, not in the Eclipse plugin. Second, each language we support may have one or more strategies for quickly identifying the source directories in a package. We have Bazel Query as the backup, but that is slow so each lang should provide quicker approaches. For example, Java has Maven conventions that are sometimes followed even in Bazel packages. This PR makes all this pluggable.