### PR TITLE
make alg for splitting source paths pluggable

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/init/JvmRuleInit.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/init/JvmRuleInit.java
@@ -35,8 +35,10 @@ package com.salesforce.bazel.sdk.init;
 
 import com.salesforce.bazel.sdk.aspect.AspectTargetInfoFactory;
 import com.salesforce.bazel.sdk.aspect.jvm.JVMAspectTargetInfoFactoryProvider;
+import com.salesforce.bazel.sdk.lang.jvm.JavaSourcePathSplitterStrategy;
 import com.salesforce.bazel.sdk.lang.jvm.MavenProjectStructureStrategy;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
+import com.salesforce.bazel.sdk.path.SourcePathSplitterStrategy;
 import com.salesforce.bazel.sdk.project.structure.ProjectStructureStrategy;
 
 /**
@@ -65,11 +67,20 @@ public class JvmRuleInit {
      * Call once at the start of the tool to initialize the JVM rule support.
      */
     public static void initialize() {
+        // Provider that can parse the JVM specific bits out of the Aspect data files
         AspectTargetInfoFactory.addProvider(new JVMAspectTargetInfoFactoryProvider());
 
+        // Strategy impl for short cutting our computation of source folders if we detect that the project layout
+        // follows Maven conventions
         if (ENABLE_MAVEN_STRUCTURE_STRATEGY) {
             ProjectStructureStrategy.projectStructureStrategies.add(0, new MavenProjectStructureStrategy());
         }
+
+        // Strategy impl for splitting Java source file paths (source/java/com/salesforce/foo/Foo.java) into
+        // the sourceDir part and file part (source/java and com/salesforce/foo/Foo.java). This is used when
+        // a project does not follow Maven conventions and we have to determine the correct directories to use
+        // as source folders
+        SourcePathSplitterStrategy.splitterStrategies.put(".java", new JavaSourcePathSplitterStrategy());
     }
 
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JavaSourcePathSplitterStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JavaSourcePathSplitterStrategy.java
@@ -35,20 +35,24 @@ package com.salesforce.bazel.sdk.lang.jvm;
 
 import java.io.File;
 
-import com.salesforce.bazel.sdk.project.SourcePath;
+import com.salesforce.bazel.sdk.path.SourcePathSplitterStrategy;
+import com.salesforce.bazel.sdk.path.SplitSourcePath;
 
 /**
- * Takes a project relative path to a JVM source file, and splits the path into two parts:
+ * Takes a project relative path to a Java source file, and splits the path into two parts:
  * <ul>
- * <li>src/main/java</li>
+ * <li>source/java</li>
  * <li>com/salesforce/foo/Foo.java</li>
  * </ul>
+ * <p>
+ * To do this the splitter must parse the .java file to see the "package com.salesforce.foo;" statement which makes this
+ * operation a bit expensive.
  */
-public class BazelJvmSourceFolderResolver {
-    // TODO this needs to follow an interface as it needs to be pluggable to support other langs than java
+public class JavaSourcePathSplitterStrategy extends SourcePathSplitterStrategy {
 
-    public static SourcePath formalizeSourcePath(File basePath, String relativePathToSourceFile) {
-        // We want relativePathToSourceFile to be like this:  src/main/java/com/salesforce/foo/Foo.java
+    @Override
+    public SplitSourcePath splitSourcePath(File basePath, String relativePathToSourceFile) {
+        // we expect relativePathToSourceFile to be like this:  source/java/com/salesforce/foo/Foo.java
 
         String packageName = null;
         if (relativePathToSourceFile.endsWith(".java")) {
@@ -64,7 +68,7 @@ public class BazelJvmSourceFolderResolver {
         String packagePath = packageName.replace(".", File.separator);
 
         // split it
-        SourcePath sourcePath = SourcePath.splitNamespacedPath(relativePathToSourceFile, packagePath);
+        SplitSourcePath sourcePath = SplitSourcePath.splitNamespacedPath(relativePathToSourceFile, packagePath);
 
         return sourcePath;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SourcePathSplitterStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SourcePathSplitterStrategy.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.sdk.path;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pluggable strategy for splitting a source path into two components like:
+ * <ul>
+ * <li>src/main/java</li>
+ * <li>com/salesforce/foo/Foo.java</li>
+ * </ul>
+ */
+public abstract class SourcePathSplitterStrategy {
+
+    /**
+     * Map of pluggable strategies used to split a source path (src/main/java/com/salesforce/foo/Foo.java) into two
+     * components based on language specific rules:
+     * <ul>
+     * <li>src/main/java</li>
+     * <li>com/salesforce/foo/Foo.java</li>
+     * </ul>
+     * <p>
+     * This Map is public because each supported language will need to plug one or more strategies into the map. The key
+     * is a String file extension (.java) and the value is the splitter for that file type.
+     */
+    public static Map<String, SourcePathSplitterStrategy> splitterStrategies = new HashMap<>();
+
+    /**
+     * Looks up the splitter using the extension from the sourceFilePath (a/b/c/d/Foo.java)
+     */
+    public static SourcePathSplitterStrategy getSplitterForFilePath(String sourceFilePath) {
+        SourcePathSplitterStrategy splitter = null;
+        int lastDot = sourceFilePath.lastIndexOf(".");
+        if (lastDot > -1) {
+            String extension = sourceFilePath.substring(lastDot);
+            splitter = SourcePathSplitterStrategy.splitterStrategies.get(extension);
+        }
+        return splitter;
+    }
+
+    /**
+     * Split a source path (src/main/java/com/salesforce/foo/Foo.java) into two components based on language specific
+     * rules:
+     * <ul>
+     * <li>src/main/java</li>
+     * <li>com/salesforce/foo/Foo.java</li>
+     * </ul>
+     */
+    public abstract SplitSourcePath splitSourcePath(File basePath, String relativePathToSourceFile);
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SplitSourcePath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SplitSourcePath.java
@@ -31,20 +31,28 @@
  * specific language governing permissions and limitations under the License.
  *
  */
-package com.salesforce.bazel.sdk.project;
+package com.salesforce.bazel.sdk.path;
 
 import java.io.File;
 
 /**
- * Models a project relative path to a JVM source file, and splits the path into two parts:
+ * Models a project/package relative path to a source file, and splits the path into two parts like:
  * <ul>
- * <li>src/main/java</li>
+ * <li>source/java</li>
  * <li>com/salesforce/foo/Foo.java</li>
  * </ul>
  */
-public class SourcePath {
-    public String pathToDirectory;
-    public String pathToFile;
+public class SplitSourcePath {
+
+    /**
+     * The source directory part of the original path. Example: source/java
+     */
+    public String sourceDirectoryPath;
+
+    /**
+     * The file path part of the original path. Example: com/salesforce/foo/Foo.java
+     */
+    public String filePath;
 
     /**
      * Utility function that can be useful for all languages that use directory paths to express namespace/package (like
@@ -53,11 +61,11 @@ public class SourcePath {
      * itself.
      *
      * @param relativePathToSourceFile
-     *            src/main/java/com/salesforce/foo/Foo.java
+     *            source/java/com/salesforce/foo/Foo.java
      * @param packagePath
      *            com/salesforce/foo; default package would be empty string
      */
-    public static SourcePath splitNamespacedPath(String relativePathToSourceFile, String packagePath) {
+    public static SplitSourcePath splitNamespacedPath(String relativePathToSourceFile, String packagePath) {
         if ((relativePathToSourceFile == null) || (packagePath == null)) {
             return null;
         }
@@ -69,7 +77,7 @@ public class SourcePath {
             relativePathToSourceFile = relativePathToSourceFile.substring(0, relativePathToSourceFile.length() - 1);
         }
 
-        // Strip the filename:  src/main/java/com/salesforce/foo
+        // Strip the filename:  source/java/com/salesforce/foo
         int lastSlash = relativePathToSourceFile.lastIndexOf(File.separator);
         if (lastSlash == -1) {
             // what?
@@ -78,7 +86,7 @@ public class SourcePath {
         String relativePathToWithoutSourceFile = relativePathToSourceFile.substring(0, lastSlash);
 
         // We can now expect that relativePathToWithoutSourceFile ends with packagePath
-        SourcePath sourcePath = new SourcePath();
+        SplitSourcePath sourcePath = new SplitSourcePath();
         if (relativePathToWithoutSourceFile.endsWith(packagePath)) {
             // hooray, we know what we are doing, do some fancy math to figure it out
             int lastIndex = relativePathToWithoutSourceFile.length() - packagePath.length();
@@ -86,8 +94,8 @@ public class SourcePath {
                 // default package, makes for weird math
                 lastIndex = relativePathToWithoutSourceFile.length() + 1;
             }
-            sourcePath.pathToDirectory = relativePathToWithoutSourceFile.substring(0, lastIndex - 1);
-            sourcePath.pathToFile = relativePathToSourceFile.substring(lastIndex);
+            sourcePath.sourceDirectoryPath = relativePathToWithoutSourceFile.substring(0, lastIndex - 1);
+            sourcePath.filePath = relativePathToSourceFile.substring(lastIndex);
         } else {
             // what?
             return null;

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/project/SourcePathTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/project/SourcePathTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 import com.salesforce.bazel.sdk.path.FSPathHelper;
+import com.salesforce.bazel.sdk.path.SplitSourcePath;
 
 /**
  * SourcePath helps us split paths to source files into the source directory and pkg+file path.
@@ -55,34 +56,34 @@ public class SourcePathTest {
         // Maven main
         String filepath = seps("src/main/java/com/salesforce/foo/Foo.java");
         String pkgpath = seps("com/salesforce/foo");
-        SourcePath sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        SplitSourcePath sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNotNull(sp);
-        assertEquals(seps("src/main/java"), sp.pathToDirectory);
-        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.pathToFile);
+        assertEquals(seps("src/main/java"), sp.sourceDirectoryPath);
+        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.filePath);
 
         // Maven test
         filepath = seps("src/test/java/com/salesforce/foo/Foo.java");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNotNull(sp);
-        assertEquals(seps("src/test/java"), sp.pathToDirectory);
-        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.pathToFile);
+        assertEquals(seps("src/test/java"), sp.sourceDirectoryPath);
+        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.filePath);
 
         // default package
         filepath = seps("src/main/java/Foo.java");
         pkgpath = seps("");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNotNull(sp);
-        assertEquals(seps("src/main/java"), sp.pathToDirectory);
-        assertEquals("Foo.java", sp.pathToFile);
+        assertEquals(seps("src/main/java"), sp.sourceDirectoryPath);
+        assertEquals("Foo.java", sp.filePath);
 
         // custom
         filepath = seps("sources/com/salesforce/foo/Foo.java");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNotNull(sp);
-        assertEquals("sources", sp.pathToDirectory);
-        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.pathToFile);
+        assertEquals("sources", sp.sourceDirectoryPath);
+        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.filePath);
     }
 
     @Test
@@ -90,39 +91,39 @@ public class SourcePathTest {
         // package mismatch (bar vs foo)
         String filepath = seps("src/main/java/com/salesforce/foo/Foo.java");
         String pkgpath = seps("com/salesforce/bar");
-        SourcePath sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        SplitSourcePath sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNull(sp);
 
         // subpackage
         filepath = seps("src/main/com/salesforce/foo/bar/Foo.java");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNull(sp);
 
         // no path for file
         filepath = seps("Foo.java");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNull(sp);
 
         // null path
-        sp = SourcePath.splitNamespacedPath(null, "something");
+        sp = SplitSourcePath.splitNamespacedPath(null, "something");
         assertNull(sp);
 
         // null package
-        sp = SourcePath.splitNamespacedPath("Foo.java", null);
+        sp = SplitSourcePath.splitNamespacedPath("Foo.java", null);
         assertNull(sp);
 
         // Forgot the file
         filepath = seps("src/main/java/com/salesforce/foo");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNull(sp);
 
         // Forgot the file 2
         filepath = seps("src/main/java/com/salesforce/foo/");
         pkgpath = seps("com/salesforce/foo");
-        sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNull(sp);
     }
 
@@ -131,10 +132,10 @@ public class SourcePathTest {
         // Duped path elements
         String filepath = seps("src/main/java/com/salesforce/foo/com/salesforce/foo/Foo.java");
         String pkgpath = seps("com/salesforce/foo");
-        SourcePath sp = SourcePath.splitNamespacedPath(filepath, pkgpath);
+        SplitSourcePath sp = SplitSourcePath.splitNamespacedPath(filepath, pkgpath);
         assertNotNull(sp);
-        assertEquals(seps("src/main/java/com/salesforce/foo"), sp.pathToDirectory);
-        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.pathToFile);
+        assertEquals(seps("src/main/java/com/salesforce/foo"), sp.sourceDirectoryPath);
+        assertEquals(seps("com/salesforce/foo/Foo.java"), sp.filePath);
     }
 
     // convert unix paths to windows paths, if running tests on windows


### PR DESCRIPTION
When a package does not follow a particular layout convention (e.g. Maven style directory structure) we have to run Bazel Query to find all the source files. Then we need to determine the best directories to use as source paths. To do that, we use language specific logic. This PR makes that logic pluggable. More work on #8.