### PR TITLE
implement a BEF pref to disable the project struct strategies

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceKeys.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferenceKeys.java
@@ -77,9 +77,15 @@ public class BazelPreferenceKeys {
     // out this is the case. This flag disables this feature, in case that logic causes problems for some users.
     // https://github.com/salesforce/bazel-eclipse/issues/164
     public static final String DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK = "DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK";
+    // We have an optimization for quickly determining the location of source files by using known conventions,
+    // but some workspaces may have structures that confuse this optimization.
+    public static final String PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME = "PROJECTSTRUCTUREOPTIMIZATIONS_ENABLED";
+
     static {
         defaultValues.put(DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK, "false");
+        defaultValues.put(PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME, "true");
     }
+
 
     // *********************************************************************
     // BEF DEVELOPER PREFS (for efficient repetitive testing of BEF)
@@ -87,16 +93,19 @@ public class BazelPreferenceKeys {
     // The import wizard will be populated by this path if set, which saves time during repetitive testing of imports
     public static final String BAZEL_DEFAULT_WORKSPACE_PATH_PREF_NAME = "BAZEL_DEFAULT_WORKSPACE_PATH";
 
+
     // *********************************************************************
     // ARRAYS
     // Be sure to add your new pref name here, as that is how the global pref file gets loaded into Eclipse prefs
 
     // prefs that have string values
     public static final String[] ALL_STRING_PREFS = new String[] { BAZEL_PATH_PREF_NAME,
-            EXTERNAL_JAR_CACHE_PATH_PREF_NAME, BAZEL_DEFAULT_WORKSPACE_PATH_PREF_NAME };
+            EXTERNAL_JAR_CACHE_PATH_PREF_NAME, BAZEL_DEFAULT_WORKSPACE_PATH_PREF_NAME,
+            PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME };
 
     // prefs that have boolean values
     public static final String[] ALL_BOOLEAN_PREFS =
-            new String[] { GLOBALCLASSPATH_SEARCH_PREF_NAME, DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK };
+            new String[] { GLOBALCLASSPATH_SEARCH_PREF_NAME, DISABLE_UNRESOLVE_WORKSPACEFILE_SOFTLINK,
+                    PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME };
 
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferencePage.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/preferences/BazelPreferencePage.java
@@ -125,6 +125,18 @@ public class BazelPreferencePage extends FieldEditorPreferencePage implements IW
         }
     }
 
+    /**
+     * Preference to control the behavior of the project structure strategies during import. See
+     * ProjectStructureStrategy for more information.
+     */
+    private static class ProjectStructureOptimizationEnabledFieldEditor extends BooleanFieldEditor {
+
+        public ProjectStructureOptimizationEnabledFieldEditor(Composite parent) {
+            super(BazelPreferenceKeys.PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME,
+                "Enable &project structure optimizations during import? (rare to disable)", SEPARATE_LABEL, parent);
+        }
+    }
+
     public BazelPreferencePage() {
         super(GRID);
     }
@@ -134,6 +146,7 @@ public class BazelPreferencePage extends FieldEditorPreferencePage implements IW
         addField(new BazelBinaryFieldEditor(getFieldEditorParent()));
         addField(new BazelGlobalClasspathSearchEnabledFieldEditor(getFieldEditorParent()));
         addField(new BazelExternalDownloadCachePathEditor(getFieldEditorParent()));
+        addField(new ProjectStructureOptimizationEnabledFieldEditor(getFieldEditorParent()));
     }
 
     @Override

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/project/EclipseProjectCreator.java
@@ -79,6 +79,11 @@ public class EclipseProjectCreator {
             existingImportedProjects, currentImportedProjects);
         ProjectStructure structure = ctx.getProjectStructure(packageLocation);
         String packageFSPath = packageLocation.getBazelPackageFSRelativePath();
+        if (bazelTargets == null) {
+            LOG.error("There were no Bazel targets found for package {}, ignoring...",
+                packageLocation.getBazelPackageFSRelativePath());
+            return null;
+        }
         List<BazelLabel> targets = Objects.requireNonNull(bazelTargets);
         IProject project = null;
 
@@ -91,6 +96,7 @@ public class EclipseProjectCreator {
                 new File(bazelWorkspaceRootDirectory, packageFSPath), null);
         } else {
             LOG.error("Could not find BUILD file for package {}", packageLocation.getBazelPackageFSRelativePath());
+            return null;
         }
         return project;
     }

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/mock/MockEclipse.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/mock/MockEclipse.java
@@ -115,8 +115,9 @@ public class MockEclipse {
         mockPrefsStore = new MockIPreferenceStore();
         mockIProjectFactory = new MockIProjectFactory();
         mockJavaCoreHelper = new MockJavaCoreHelper();
-        mockPrefsStore.strings.put(BazelPreferenceKeys.BAZEL_PATH_PREF_NAME,
-            bazelCommandEnvironment.bazelExecutable.getAbsolutePath());
+
+        // Eclipse preferences for BEF
+        setupDefaultPreferences();
 
         // feature collaborators
         pluginActivator = new BazelPluginActivator();
@@ -134,6 +135,12 @@ public class MockEclipse {
         // At this point our plugins are wired up, the Bazel workspace is created, but the user
         // has not run a Bazel Import... wizard yet. See EclipseFunctionalTestEnvironmentFactory
         // for how to run import.
+    }
+
+    private void setupDefaultPreferences() {
+        mockPrefsStore.strings.put(BazelPreferenceKeys.BAZEL_PATH_PREF_NAME,
+            bazelCommandEnvironment.bazelExecutable.getAbsolutePath());
+        mockPrefsStore.booleans.put(BazelPreferenceKeys.PROJECTSTRUCTUREOPTIMIZATIONS_PREF_NAME, true);
     }
 
     // GETTERS

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/mock/MockIPreferenceStore.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/mock/MockIPreferenceStore.java
@@ -37,7 +37,8 @@ public class MockIPreferenceStore implements IPreferenceStore {
             "MockIPreferenceStore is pay as you go, you have hit a method that is not implemented.";
 
     public Map<String, String> strings = new TreeMap<>();
-    private List<IPropertyChangeListener> propChangeListeners = new ArrayList<>();
+    public Map<String, Boolean> booleans = new TreeMap<>();
+    private final List<IPropertyChangeListener> propChangeListeners = new ArrayList<>();
 
     // MOCKED METHODS
 
@@ -56,6 +57,16 @@ public class MockIPreferenceStore implements IPreferenceStore {
         strings.put(name, value);
     }
 
+    @Override
+    public boolean getBoolean(String name) {
+        Boolean result = booleans.get(name);
+        if (result == null) {
+            // by Eclipse definition, a boolean pref has a default value of false
+            result = false;
+        }
+        return result;
+    }
+
     // UNIMPLEMENTED METHODS
     // Please move implemented methods, in alphabetical order, above this line if you implement a method.
 
@@ -66,11 +77,6 @@ public class MockIPreferenceStore implements IPreferenceStore {
 
     @Override
     public void firePropertyChangeEvent(String name, Object oldValue, Object newValue) {
-        throw new UnsupportedOperationException(UOE_MSG);
-    }
-
-    @Override
-    public boolean getBoolean(String name) {
         throw new UnsupportedOperationException(UOE_MSG);
     }
 


### PR DESCRIPTION
If the Bazel workspace has a project that is close to Maven-like, but has extra source folders, the Maven project structure strategy will guess wrong and miss those extra folders.

This PR has a pref for disabling the optimization feature. It also fixes an edge case bug in import that I found while doing testing.