### PR TITLE
allow java source file not to be nested in package hierarchy

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
@@ -34,10 +34,10 @@
 package com.salesforce.bazel.sdk.path;
 
 import java.io.File;
- import java.io.IOException;
- import java.util.Set;
+import java.io.IOException;
+import java.util.Set;
 
- import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.logging.LogHelper;
 
 /**
  * Constants and utils for file system paths.
@@ -159,10 +159,10 @@ public final class FSPathHelper {
 
     /**
      * Given a set of tokens, this function walks through the provided path looking for a node in the hierarchy with
-      * that name. If a resource (file/directory) is found, this function returns true.
+     * that name. If a resource (file/directory) is found, this function returns true.
      * <p>
      * An example use case is looking for a directory named 'test' or 'tests' in a file system path.
-      */
+     */
     public static boolean doesPathContainNamedResource(String filesystemPath, Set<String> targetNames) {
         String[] pathElements = filesystemPath.split(File.separator);
         for (String element : pathElements) {
@@ -171,5 +171,18 @@ public final class FSPathHelper {
             }
         }
         return false;
+    }
+
+    /**
+     * Removes the last resource from the path.
+     * <p>
+     * Example: source/java/com/salesforce/foo/Foo.java => source/java/com/salesforce/foo
+     */
+    public static String removeLastResource(String filesystemPath) {
+        int lastSlash = filesystemPath.lastIndexOf(File.separator);
+        if (lastSlash > -1) {
+            return filesystemPath.substring(0, lastSlash);
+        }
+        return "";
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SourcePathSplitterStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/SourcePathSplitterStrategy.java
@@ -46,6 +46,8 @@ import java.util.Map;
  */
 public abstract class SourcePathSplitterStrategy {
 
+    // STATIC
+
     /**
      * Map of pluggable strategies used to split a source path (src/main/java/com/salesforce/foo/Foo.java) into two
      * components based on language specific rules:
@@ -71,6 +73,8 @@ public abstract class SourcePathSplitterStrategy {
         }
         return splitter;
     }
+
+    // INSTANCES
 
     /**
      * Split a source path (src/main/java/com/salesforce/foo/Foo.java) into two components based on language specific


### PR DESCRIPTION
While testing all the PRs for #8, found a weird edge case. Bazel tolerates .java file to be in a directory that does not reflect the package hierarchy.

For example, *Foo.java* is in package *com.salesforce.foo*. Bazel is perfectly happy with it living in source/java/Foo.java. This PR updates the structure strategy to allow this, instead of rejecting the source file as before.

This is all done in the SDK layer, so perhaps some tools will be fine with it. Eclipse will flag the source file with an error because it isn't in the package hierarchy. But at least the issue is now visible to the user.