### PR TITLE
enhanced test classpath computation to fix several bugs

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/TestBazelCommandEnvironmentFactory.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/TestBazelCommandEnvironmentFactory.java
@@ -93,13 +93,15 @@ public class TestBazelCommandEnvironmentFactory {
         commandBuilder = new MockCommandBuilder(commandConsole, testWorkspace, testOptions);
 
         BazelCommandManager bazelCommandManager = new BazelCommandManager(bazelAspectLocation, commandBuilder,
-                commandConsole, bazelExecutable.bazelExecutableFile);
+            commandConsole, bazelExecutable.bazelExecutableFile);
         bazelCommandManager.setBazelExecutablePath(bazelExecutable.bazelExecutableFile.getAbsolutePath());
 
         OperatingEnvironmentDetectionStrategy osStrategy = Mockito.mock(OperatingEnvironmentDetectionStrategy.class);
         BazelWorkspace bazelWorkspace =
                 new BazelWorkspace("test", testWorkspace.workspaceDescriptor.workspaceRootDirectory, osStrategy);
-        bazelWorkspace.setBazelWorkspaceMetadataStrategy(bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace));
+        BazelWorkspaceCommandRunner commandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);
+        bazelWorkspace.setBazelWorkspaceMetadataStrategy(commandRunner);
+        bazelWorkspace.setBazelWorkspaceCommandRunner(commandRunner);
 
         globalCommandRunner = bazelCommandManager.getGlobalCommandRunner();
         bazelWorkspaceCommandRunner = bazelCommandManager.getWorkspaceCommandRunner(bazelWorkspace);

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelWorkspace.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandOptions;
+import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
 import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.workspace.BazelWorkspaceMetadataStrategy;
 import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
@@ -26,6 +27,11 @@ public class BazelWorkspace {
     private final String name;
 
     // COLLABORATORS
+
+    /**
+     * Bazel command runner for this workspace
+     */
+    private BazelWorkspaceCommandRunner commandRunner;
 
     /**
      * Strategy delegate that can compute the data for file paths
@@ -88,6 +94,10 @@ public class BazelWorkspace {
         this.bazelWorkspaceRootDirectory = getCanonicalFileSafely(bazelWorkspaceRootDirectory);
         operatingSystem = osEnvStrategy.getOperatingSystemName();
         operatingSystemFoldername = osEnvStrategy.getOperatingSystemDirectoryName(operatingSystem);
+    }
+
+    public void setBazelWorkspaceCommandRunner(BazelWorkspaceCommandRunner runner) {
+        commandRunner = runner;
     }
 
     public void setBazelWorkspaceMetadataStrategy(BazelWorkspaceMetadataStrategy metadataStrategy) {
@@ -162,6 +172,10 @@ public class BazelWorkspace {
 
     public String getOperatingSystemFoldername() {
         return operatingSystemFoldername;
+    }
+
+    public BazelWorkspaceCommandRunner getBazelWorkspaceCommandRunner() {
+        return commandRunner;
     }
 
     public BazelWorkspaceCommandOptions getBazelWorkspaceCommandOptions() {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectManager.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProjectManager.java
@@ -59,9 +59,13 @@ public abstract class BazelProjectManager {
         logger = LogHelper.log(this.getClass());
     }
 
-    public void addProject(BazelProject project) {
-        projectMap.put(project.name, project);
-        project.bazelProjectManager = this;
+    public void addProject(BazelProject newProject) {
+        BazelProject existingProject = projectMap.get(newProject.name);
+        if (existingProject != null) {
+            newProject.merge(existingProject);
+        }
+        projectMap.put(newProject.name, newProject);
+        newProject.bazelProjectManager = this;
     }
 
     public BazelProject getProject(String name) {
@@ -166,5 +170,4 @@ public abstract class BazelProjectManager {
         cmdRunner.flushAspectInfoCacheForPackage(packageLabel);
         cmdRunner.flushQueryCache(new BazelLabel(packageLabel));
     }
-
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
@@ -30,8 +30,6 @@ import com.salesforce.bazel.sdk.model.BazelLabel;
 
 /**
  * Value object that holds the layout of source directories in a Bazel project.
- * <p>
- * TODO merge this with BazelProject?
  */
 public class ProjectStructure {
 
@@ -43,7 +41,7 @@ public class ProjectStructure {
      * <p>
      * Example: projects/libs/apple/apple-api/src/main/java
      */
-    public final List<String> mainSourceDirFSPaths = new ArrayList<>();
+    public List<String> mainSourceDirFSPaths = new ArrayList<>();
 
     /**
      * The relative file system paths, starting at the root of the workspace, to the directories containing the test
@@ -53,7 +51,7 @@ public class ProjectStructure {
      * <p>
      * Example: projects/libs/apple/apple-api/src/test/java
      */
-    public final List<String> testSourceDirFSPaths = new ArrayList<>();
+    public List<String> testSourceDirFSPaths = new ArrayList<>();
 
     public List<String> getMainSourceDirFSPaths() {
         return mainSourceDirFSPaths;
@@ -61,6 +59,26 @@ public class ProjectStructure {
 
     public List<String> getTestSourceDirFSPaths() {
         return testSourceDirFSPaths;
+    }
+
+    /**
+     * Merges this structure with the passed structure. For each element, this structure will win out if it has
+     * meaningful data, else the olderStructure data will be used for that element.
+     */
+    public void merge(ProjectStructure olderStructure) {
+        if (olderStructure == null) {
+            return;
+        }
+        if (mainSourceDirFSPaths.size() > 0) {
+            olderStructure.mainSourceDirFSPaths = mainSourceDirFSPaths;
+        } else {
+            mainSourceDirFSPaths = olderStructure.mainSourceDirFSPaths;
+        }
+        if (testSourceDirFSPaths.size() > 0) {
+            olderStructure.testSourceDirFSPaths = testSourceDirFSPaths;
+        } else {
+            testSourceDirFSPaths = olderStructure.testSourceDirFSPaths;
+        }
     }
 
     // DEPRECATED

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructureStrategy.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
+import com.salesforce.bazel.sdk.lang.jvm.MavenProjectStructureStrategy;
+import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
 
@@ -34,6 +36,7 @@ import com.salesforce.bazel.sdk.model.BazelWorkspace;
  * Pluggable strategy for establishing the basic structure of a project. Used early during import.
  */
 public abstract class ProjectStructureStrategy {
+    private static final LogHelper LOG = LogHelper.log(MavenProjectStructureStrategy.class);
 
     // STATIC UTILITIES
 
@@ -73,6 +76,8 @@ public abstract class ProjectStructureStrategy {
             if (strategy.enabled) {
                 result = strategy.doStructureAnalysis(bazelWorkspace, packageNode, commandRunner);
                 if (result != null) {
+                    LOG.info("Package {} file layout was processed by the {}",
+                        packageNode.getBazelPackageFSRelativePath(), strategy.getClass().getName());
                     break;
                 }
             }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -260,7 +260,9 @@ public class BazelPluginActivator extends AbstractUIPlugin {
             }
         }
         bazelWorkspace = new BazelWorkspace(workspaceName, rootDirectory, osEnvStrategy);
-        bazelWorkspace.setBazelWorkspaceMetadataStrategy(getWorkspaceCommandRunner());
+        BazelWorkspaceCommandRunner commandRunner = getWorkspaceCommandRunner();
+        bazelWorkspace.setBazelWorkspaceMetadataStrategy(commandRunner);
+        bazelWorkspace.setBazelWorkspaceCommandRunner(commandRunner);
 
         // write it to the preferences file
         configurationManager.setBazelWorkspacePath(rootDirectory.getAbsolutePath());

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestClasspathProvider.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestClasspathProvider.java
@@ -143,13 +143,14 @@ public class BazelTestClasspathProvider extends StandardClasspathProvider {
 
         // look for the param files for the test classname and/or targets
         BazelJvmTestClasspathHelper.ParamFileResult testParamFilesResult =
-                BazelJvmTestClasspathHelper.findParamFilesForTests(bazelWorkspace, isSource, testClassName, targets);
+                BazelJvmTestClasspathHelper.findParamFilesForTests(bazelWorkspace, bazelProject, isSource,
+                    testClassName, targets);
 
         File base = bazelWorkspace.getBazelExecRootDirectory();
         for (File paramsFile : testParamFilesResult.paramFiles) {
             List<String> jarPaths;
             try {
-                jarPaths = BazelJvmTestClasspathHelper.getSourceAndOutputJarsFromParamsFile(paramsFile);
+                jarPaths = BazelJvmTestClasspathHelper.getClasspathJarsFromParamsFile(paramsFile);
             } catch (IOException e) {
                 throw new CoreException(new Status(IStatus.ERROR, BUNDLE.getSymbolicName(),
                     "Error parsing " + paramsFile.getAbsolutePath(), e));

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProviderTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/launch/BazelRuntimeClasspathProviderTest.java
@@ -37,7 +37,7 @@ public class BazelRuntimeClasspathProviderTest {
 
     @Test
     public void getPathsToJars() {
-        List<String> result = BazelJvmTestClasspathHelper.getPathsToJars(new Scanner(PARAM_FILE_CONTENTS));
+        List<String> result = BazelJvmTestClasspathHelper.getClasspathJarsFromParamsFile(new Scanner(PARAM_FILE_CONTENTS));
 
         String deployPath = FSPathHelper.osSeps(
                 "bazel-out/darwin-fastbuild/bin/projects/libs/banana/banana-api/src/test/java/demo/banana/api/BananaTest_deploy.jar"); // $SLASH_OK


### PR DESCRIPTION
The test classpath code had a hard-coded path of src/test/java still, removed that. But also found an issue when the output directory has been cleaned and is missing a some metadata files.