### PR TITLE
initial refactor for dynamic classpath

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
@@ -60,16 +60,16 @@ import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
  * within the package are excluded from the classpath, as they are presumed to be represented by source code found in
  * source folders.
  */
-public class BazelJvmClasspath {
+public class BazelJvmClasspath implements JvmClasspath {
     // TODO make classpath cache timeout configurable
     private static final long CLASSPATH_CACHE_TIMEOUT_MS = 300000;
 
-    private final BazelWorkspace bazelWorkspace;
-    private final BazelProjectManager bazelProjectManager;
-    private final BazelProject bazelProject;
-    private final ImplicitClasspathHelper implicitDependencyHelper;
-    private final OperatingEnvironmentDetectionStrategy osDetector;
-    private final BazelCommandManager bazelCommandManager;
+    protected final BazelWorkspace bazelWorkspace;
+    protected final BazelProjectManager bazelProjectManager;
+    protected final BazelProject bazelProject;
+    protected final ImplicitClasspathHelper implicitDependencyHelper;
+    protected final OperatingEnvironmentDetectionStrategy osDetector;
+    protected final BazelCommandManager bazelCommandManager;
     private final LogHelper logger;
 
     private BazelJvmClasspathResponse cachedEntries;
@@ -99,6 +99,7 @@ public class BazelJvmClasspath {
      * TODO provide different classpath strategies. This one the Maven-like/Eclipse JDT style, where the classpath is
      * the union of the classpaths of all java rules in the package.
      */
+    @Override
     public BazelJvmClasspathResponse getClasspathEntries() {
         // sanity check
         if (bazelWorkspace == null) {
@@ -195,7 +196,7 @@ public class BazelJvmClasspath {
                             // some other case like java_binary, proto_library, java_proto_library, etc
                             // proceed but log a warn
                             logger.info("Found unsupported target type as dependency: " + jvmTargetInfo.getKind()
-                                    + "; the JVM classpath processor currently supports java_library or java_import.");
+                            + "; the JVM classpath processor currently supports java_library or java_import.");
                         }
                     }
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/DynamicBazelJvmClasspath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/DynamicBazelJvmClasspath.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.lang.jvm;
+
+import java.io.File;
+import java.util.Set;
+
+import com.salesforce.bazel.sdk.command.BazelCommandManager;
+import com.salesforce.bazel.sdk.index.CodeIndexEntry;
+import com.salesforce.bazel.sdk.index.jvm.BazelJvmIndexClasspath;
+import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
+import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
+import com.salesforce.bazel.sdk.project.BazelProject;
+import com.salesforce.bazel.sdk.project.BazelProjectManager;
+import com.salesforce.bazel.sdk.project.structure.ProjectStructure;
+import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
+
+/**
+ * Classpath loader that uses import data from the Java files to determine the actual classpath,
+ * as opposed to the BazelClasspathContainer that uses the Bazel BUILD file.
+ */
+public class DynamicBazelJvmClasspath extends BazelJvmClasspath {
+    private static final LogHelper LOG = LogHelper.log(DynamicBazelJvmClasspath.class);
+
+    protected BazelJvmIndexClasspath classIndex;
+    /**
+     *
+     * @param bazelWorkspace gateway to a number of workspace level features
+     * @param bazelProjectManager project manager is used to help build references to other projects
+     * @param bazelProject the project (aka a Bazel package that corresponds to the concept of a Maven module)
+     * @param implicitDependencyHelper helper utility that computes annoying implicit dependencies added by Bazel
+     * @param osDetector  use this when do OS specific work - this allows us to mock the OS in tests
+     * @param bazelCommandManager gateway object for running Bazel commands
+     * @param classIndex the index of jars in the workspace, and the classes that each contains
+     */
+    public DynamicBazelJvmClasspath(BazelWorkspace bazelWorkspace, BazelProjectManager bazelProjectManager,
+            BazelProject bazelProject, ImplicitClasspathHelper implicitDependencyHelper,
+            OperatingEnvironmentDetectionStrategy osDetector, BazelCommandManager bazelCommandManager,
+            BazelJvmIndexClasspath classIndex) {
+        super(bazelWorkspace, bazelProjectManager, bazelProject, implicitDependencyHelper, osDetector,
+            bazelCommandManager);
+        this.classIndex = classIndex;
+    }
+
+    @Override
+    public BazelJvmClasspathResponse getClasspathEntries() {
+        // the structure contains the file system layout of source files
+        ProjectStructure fileStructure = bazelProject.getProjectStructure();
+
+        // get the index, if one has been computed
+        JvmCodeIndex index = JvmCodeIndex.getWorkspaceIndex(bazelWorkspace);
+
+        if (index != null) {
+            LOG.info("Computing the dynamic classpath for project {}", fileStructure.projectPath);
+            File workspaceRootDir = bazelWorkspace.getBazelWorkspaceRootDirectory();
+
+            for (String sourceDirPath : fileStructure.mainSourceDirFSPaths) {
+                File sourceDir = new File(workspaceRootDir, sourceDirPath);
+                Set<File> javaFiles = FSPathHelper.findFileLocations(sourceDir, ".java", null, 50);
+                for (File file : javaFiles) {
+                    if (file.exists()) {
+                        JavaSourceFile javaFile = new JavaSourceFile(file);
+
+                        String javaPackage = javaFile.readPackageFromFile();
+                        LOG.info("Source file {} is in Java package {}", file.getAbsolutePath(), javaPackage);
+
+                        // TODO do parsing stuff with the javaFile, for example extract the imports as a list
+                        // until we do that, we just use the index to print out the jar file that this class
+                        // is found in, to show how to use the index
+
+                        String typeName = javaPackage + "." + file.getName().substring(0, file.getName().length() - 5);
+                        CodeIndexEntry indexEntry = index.typeDictionary.get(typeName);
+
+                        if (indexEntry == null) {
+                            // it is possible the source file is not a target of any rule
+                            LOG.info("Type {} is not found in any built jar in the workspace.", typeName);
+                        } else {
+                            if (indexEntry.singleLocation != null) {
+                                LOG.info("Type {} is built into {} in the workspace.", typeName,
+                                    indexEntry.singleLocation.locationOnDisk.getAbsolutePath());
+                            } else if ((indexEntry.multipleLocations != null)
+                                    && (indexEntry.multipleLocations.size() > 0)) {
+                                for (CodeLocationDescriptor location : indexEntry.multipleLocations) {
+                                    LOG.info("Type {} is built into {} in the workspace.", typeName,
+                                        location.locationOnDisk.getAbsolutePath());
+                                }
+                            } else {
+                                // it is possible the source file is not a target of any rule
+                                LOG.info("Type {} is not found in any built jar in the workspace.", typeName);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // TODO until we have the dynamic classpath implemented, just delegate to super to compute it
+        // using the BUILD file
+        return super.getClasspathEntries();
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JvmClasspath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/JvmClasspath.java
@@ -1,0 +1,13 @@
+package com.salesforce.bazel.sdk.lang.jvm;
+
+/**
+ * Interface for generating the classpath for a Bazel package.
+ */
+public interface JvmClasspath {
+
+    /**
+     * Computes the JVM classpath for the associated Bazel package
+     */
+    BazelJvmClasspathResponse getClasspathEntries();
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/MavenProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/MavenProjectStructureStrategy.java
@@ -46,13 +46,14 @@ public class MavenProjectStructureStrategy extends ProjectStructureStrategy {
     @Override
     public ProjectStructure doStructureAnalysis(BazelWorkspace bazelWorkspace, BazelPackageLocation packageNode,
             BazelWorkspaceCommandRunner commandRunner) {
-        ProjectStructure result = new ProjectStructure();
 
         // NOTE: order of adding the result.packageSourceCodeFSPaths array is important. Eclipse
         // will honor that order in the project explorer
 
         File workspaceRootDir = bazelWorkspace.getBazelWorkspaceRootDirectory();
         String packageRelPath = packageNode.getBazelPackageFSRelativePath();
+        ProjectStructure result = new ProjectStructure();
+        result.projectPath = new File(workspaceRootDir, packageRelPath);
 
         // MAVEN MAIN SRC
         String mainSrcRelPath =

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
@@ -68,6 +68,7 @@ public class BazelQueryProjectStructureStrategy extends ProjectStructureStrategy
         File workspaceRootDir = bazelWorkspace.getBazelWorkspaceRootDirectory();
         String packageRelPath = packageNode.getBazelPackageFSRelativePath();
         File packageDir = new File(workspaceRootDir, packageRelPath); // TODO move this to the PackageLocation api
+        result.projectPath = packageDir;
 
         BazelLabel packageLabel = new BazelLabel(packageRelPath, BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR);
 

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/ProjectStructure.java
@@ -23,6 +23,7 @@
  */
 package com.salesforce.bazel.sdk.project.structure;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +33,8 @@ import com.salesforce.bazel.sdk.model.BazelLabel;
  * Value object that holds the layout of source directories in a Bazel project.
  */
 public class ProjectStructure {
+
+    public File projectPath;
 
     /**
      * The relative file system paths, starting at the root of the workspace, to the directories containing the main
@@ -52,6 +55,14 @@ public class ProjectStructure {
      * Example: projects/libs/apple/apple-api/src/test/java
      */
     public List<String> testSourceDirFSPaths = new ArrayList<>();
+
+    public ProjectStructure() {
+
+    }
+
+    public File getProjectPath() {
+        return projectPath;
+    }
 
     public List<String> getMainSourceDirFSPaths() {
         return mainSourceDirFSPaths;

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainer.java
@@ -49,16 +49,20 @@ import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
 import com.salesforce.bazel.sdk.command.BazelCommandLineToolConfigurationException;
 import com.salesforce.bazel.sdk.lang.jvm.BazelJvmClasspath;
 import com.salesforce.bazel.sdk.lang.jvm.BazelJvmClasspathResponse;
+import com.salesforce.bazel.sdk.lang.jvm.DynamicBazelJvmClasspath;
 
 public class BazelClasspathContainer extends BaseBazelClasspathContainer {
     public static final String CONTAINER_NAME = "com.salesforce.bazel.eclipse.BAZEL_CONTAINER";
 
     protected final BazelJvmClasspath bazelClasspath;
 
+    // TODO make this an Eclipse pref
+    public boolean USE_DYNAMIC_CP = false;
+
     private static List<BazelJvmClasspath> instances = new ArrayList<>();
 
     public BazelClasspathContainer(IProject eclipseProject) throws IOException, InterruptedException,
-            BackingStoreException, JavaModelException, BazelCommandLineToolConfigurationException {
+    BackingStoreException, JavaModelException, BazelCommandLineToolConfigurationException {
         this(eclipseProject, BazelPluginActivator.getResourceHelper());
     }
 
@@ -67,13 +71,22 @@ public class BazelClasspathContainer extends BaseBazelClasspathContainer {
             BazelCommandLineToolConfigurationException {
         super(eclipseProject, resourceHelper);
 
-        bazelClasspath = new BazelJvmClasspath(this.bazelWorkspace, bazelProjectManager, bazelProject,
+        if (USE_DYNAMIC_CP) {
+            bazelClasspath = new DynamicBazelJvmClasspath(bazelWorkspace, bazelProjectManager, bazelProject,
+                new EclipseImplicitClasspathHelper(), osDetector, BazelPluginActivator.getBazelCommandManager(),
+                null);
+        } else {
+            bazelClasspath = new BazelJvmClasspath(bazelWorkspace, bazelProjectManager, bazelProject,
                 new EclipseImplicitClasspathHelper(), osDetector, BazelPluginActivator.getBazelCommandManager());
+        }
         instances.add(bazelClasspath);
     }
 
     @Override
     public String getDescription() {
+        if (USE_DYNAMIC_CP) {
+            return "Dynamic Classpath Container";
+        }
         return "Bazel Classpath Container";
     }
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelGlobalSearchClasspathContainer.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelGlobalSearchClasspathContainer.java
@@ -79,7 +79,7 @@ public class BazelGlobalSearchClasspathContainer extends BaseBazelClasspathConta
     private static List<BazelJvmIndexClasspath> instances = new ArrayList<>();
 
     public BazelGlobalSearchClasspathContainer(IProject eclipseProject) throws IOException, InterruptedException,
-            BackingStoreException, JavaModelException, BazelCommandLineToolConfigurationException {
+    BackingStoreException, JavaModelException, BazelCommandLineToolConfigurationException {
         this(eclipseProject, BazelPluginActivator.getResourceHelper());
     }
 
@@ -95,17 +95,7 @@ public class BazelGlobalSearchClasspathContainer extends BaseBazelClasspathConta
         BazelExternalJarRuleManager externalJarManager = activator.getBazelExternalJarRuleManager();
 
         // check if the user has provided an additional location to look for jars
-        List<File> additionalJarLocations = null;
-        IPreferenceStore prefs = activator.getPreferenceStore();
-        String jarCacheDir = prefs.getString(BazelPreferenceKeys.EXTERNAL_JAR_CACHE_PATH_PREF_NAME);
-        if (jarCacheDir != null) {
-            // user has specified a location, make sure it exists
-            File jarCacheDirFile = new File(jarCacheDir);
-            if (jarCacheDirFile.exists()) {
-                additionalJarLocations = new ArrayList<>();
-                additionalJarLocations.add(jarCacheDirFile);
-            }
-        }
+        List<File> additionalJarLocations = loadAdditionalLocations();
 
         bazelJvmIndexClasspath =
                 new BazelJvmIndexClasspath(bazelWorkspace, os, externalJarManager, additionalJarLocations);
@@ -124,7 +114,7 @@ public class BazelGlobalSearchClasspathContainer extends BaseBazelClasspathConta
     }
 
     @Override
-    protected BazelJvmClasspathResponse computeClasspath() {
+    public BazelJvmClasspathResponse computeClasspath() {
         if (!config.isGlobalClasspathSearchEnabled()) {
             // user has disabled the global search feature
             return new BazelJvmClasspathResponse();
@@ -146,5 +136,24 @@ public class BazelGlobalSearchClasspathContainer extends BaseBazelClasspathConta
         for (BazelJvmIndexClasspath instance : instances) {
             instance.clearCache();
         }
+    }
+
+    /**
+     * Uses the preference store in Eclipse to get additional locations in which to look for jars.
+     */
+    public static List<File> loadAdditionalLocations() {
+        List<File> additionalJarLocations = null;
+        BazelPluginActivator activator = BazelPluginActivator.getInstance();
+        IPreferenceStore prefs = activator.getPreferenceStore();
+        String jarCacheDir = prefs.getString(BazelPreferenceKeys.EXTERNAL_JAR_CACHE_PATH_PREF_NAME);
+        if (jarCacheDir != null) {
+            // user has specified a location, make sure it exists
+            File jarCacheDirFile = new File(jarCacheDir);
+            if (jarCacheDirFile.exists()) {
+                additionalJarLocations = new ArrayList<>();
+                additionalJarLocations.add(jarCacheDirFile);
+            }
+        }
+        return additionalJarLocations;
     }
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/ProjectImporterFactory.java
@@ -65,7 +65,7 @@ public class ProjectImporterFactory {
 
     private final BazelPackageLocation bazelWorkspaceRootPackageInfo;
     private final List<BazelPackageLocation> selectedBazelPackages;
-    private List<ImportFlow> flows;
+    private final List<ImportFlow> flows;
     private ProjectOrderResolver projectOrderResolver = new ProjectOrderResolverImpl();
 
     public ProjectImporterFactory(BazelPackageLocation bazelWorkspaceRootPackageInfo,
@@ -74,7 +74,7 @@ public class ProjectImporterFactory {
     }
 
     ProjectImporterFactory(BazelPackageLocation bazelWorkspaceRootPackageInfo,
-            List<BazelPackageLocation> selectedBazelPackages, List<ImportFlow> flows) {
+        List<BazelPackageLocation> selectedBazelPackages, List<ImportFlow> flows) {
         this.bazelWorkspaceRootPackageInfo = Objects.requireNonNull(bazelWorkspaceRootPackageInfo);
         this.selectedBazelPackages = Objects.requireNonNull(selectedBazelPackages);
         this.flows = Objects.requireNonNull(flows);
@@ -94,15 +94,15 @@ public class ProjectImporterFactory {
 
     public ProjectImporter build() {
         return new FlowProjectImporter(flows.toArray(new ImportFlow[flows.size()]), bazelWorkspaceRootPackageInfo,
-                selectedBazelPackages, projectOrderResolver);
+            selectedBazelPackages, projectOrderResolver);
     }
 
     private static List<ImportFlow> createFlows() {
         // each project import uses a new list of flow instances so that flows can have state
         // the List returned here needs to be modifiable
-        return new ArrayList<>(Arrays.asList(new ImportFlow[] { new InitJREFlow(), new InitImportFlow(),
-                new DetermineTargetsFlow(), new LoadAspectsFlow(), new LoadTargetsFlow(), new CreateRootProjectFlow(),
-                new OrderProjectsFlow(), new CreateProjectsFlow(), new SetupProjectBuildersFlow(),
-                new SetupClasspathContainersFlow(), new SetupRootClasspathContainerFlow(), }));
+        return new ArrayList<>(Arrays.asList(new InitJREFlow(), new InitImportFlow(), new DetermineTargetsFlow(),
+            new LoadAspectsFlow(), new LoadTargetsFlow(), new CreateRootProjectFlow(),
+            new OrderProjectsFlow(), new CreateProjectsFlow(), new SetupProjectBuildersFlow(),
+            new SetupRootClasspathContainerFlow(), new SetupClasspathContainersFlow()));
     }
 }


### PR DESCRIPTION
This is a refactor to make space for a dynamic classpath container.

- It is disabled by default in BazelClasspathContainer
- DynamicBazelJvmClasspath is where the code will go eventually
- The index currently is missing the entries from within the bazel build, which is a problem, there is todo at the bottom of JvmCodeIndex.java that needs to be addressed

@guw if you wanted to do the hackathon, the stub is there in BEF now. There are the above caveats, but I think those I can solve soon. You can focus on parsing the java files and extracting the type info (using trellis?). Look for the TODOs in DynamicBazelJvmClasspath.