### PR TITLE
ignore nested workspaces instead of rejecting the import

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelPackageDescriptor.java
@@ -26,13 +26,13 @@ public class TestBazelPackageDescriptor {
     public Map<String, TestBazelTargetDescriptor> targets = new TreeMap<>();
 
     public TestBazelPackageDescriptor(TestBazelWorkspaceDescriptor parentWorkspace, String packagePath,
-            String packageName, File diskLocation) {
+            String packageName, File diskLocation, boolean trackState) {
 
         if (packagePath.contains(FSPathHelper.WINDOWS_BACKSLASH)) {
             // Windows bug, someone passed in a Windows path
             throw new IllegalArgumentException(
-                    "Windows filesystem path passed to TestBazelPackageDescriptor instead of the Bazel package path: "
-                            + packagePath);
+                "Windows filesystem path passed to TestBazelPackageDescriptor instead of the Bazel package path: "
+                        + packagePath);
         }
 
         parentWorkspaceDescriptor = parentWorkspace;
@@ -40,6 +40,11 @@ public class TestBazelPackageDescriptor {
         this.packageName = packageName;
         this.diskLocation = diskLocation;
 
-        parentWorkspaceDescriptor.createdPackages.put(packagePath, this);
+        if (trackState) {
+            // we normally want to keep track of all the packages we have created, but in some test cases
+            // we create Java packages that we don't expect to import (e.g. in a nested workspace that isn't
+            // imported) in such cases trackState will be false
+            parentWorkspaceDescriptor.createdPackages.put(packagePath, this);
+        }
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceDescriptor.java
@@ -28,6 +28,9 @@ public class TestBazelWorkspaceDescriptor {
     public int numberJavaPackages = 0;
     public int numberGenrulePackages = 0;
 
+    // just throw a random nested workspace in the mix, to test that we ignore it
+    public boolean addFakeNestedWorkspace = true;
+
     // BUILT FIELDS (filled in after the workspace is built on disk)
 
     // directories

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
@@ -152,19 +152,6 @@ public class BazelPackageInfo implements BazelPackageLocation {
                     + "] was used to construct a BazelPackageInfo.");
         }
 
-        File workspaceFile = new File(directory, WORKSPACE_FILENAME);
-        if (workspaceFile.exists()) {
-            throw new IllegalArgumentException(
-                    "The path [" + directory.getAbsolutePath() + "] contains a " + WORKSPACE_FILENAME
-                            + " file. Nested workspaces are not supported by BazelPackageInfo at this time");
-        }
-        workspaceFile = new File(directory, WORKSPACE_FILENAME_ALT);
-        if (workspaceFile.exists()) {
-            throw new IllegalArgumentException(
-                    "The path [" + directory.getAbsolutePath() + "] contains a " + WORKSPACE_FILENAME_ALT
-                            + " file. Nested workspaces are not supported by BazelPackageInfo at this time");
-        }
-
         // compute and cache the package name
         String packageName = getBazelPackageName();
 
@@ -432,11 +419,11 @@ public class BazelPackageInfo implements BazelPackageLocation {
     public void gatherChildrenRecur(List<BazelPackageLocation> gatherList, String pathFilter) {
         if (!isWorkspaceRoot()) {
             if (pathFilter != null) {
-                if (this.relativeWorkspacePath.startsWith(pathFilter)) {
+                if (relativeWorkspacePath.startsWith(pathFilter)) {
                     // this relative path is projects/libs/foo/bar and the filter is projects/libs/foo
                     gatherList.add(this);
                     pathFilter = null; // we don't need to filter any children from here
-                } else if (this.relativeWorkspacePath.length() > pathFilter.length()) {
+                } else if (relativeWorkspacePath.length() > pathFilter.length()) {
                     // we must be in a different branch than the filter, exit this branch
                     return;
                 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelPackageFinder.java
@@ -33,109 +33,123 @@
  */
 package com.salesforce.bazel.sdk.workspace;
 
- import java.io.File;
- import java.io.IOException;
- import java.nio.file.FileVisitResult;
- import java.nio.file.FileVisitor;
- import java.nio.file.Files;
- import java.nio.file.Path;
- import java.nio.file.attribute.BasicFileAttributes;
- import java.util.ArrayList;
- import java.util.Collections;
- import java.util.List;
- import java.util.Set;
- import java.util.concurrent.ConcurrentHashMap;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
- import com.salesforce.bazel.sdk.logging.LogHelper;
- import com.salesforce.bazel.sdk.path.FSPathHelper;
- import com.salesforce.bazel.sdk.util.BazelConstants;
- import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.path.FSPathHelper;
+import com.salesforce.bazel.sdk.util.BazelConstants;
+import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
 
- /**
-  * Scanner for a Bazel workspace to locate BUILD files that contain rules that are supported by the SDK.
-  */
- public class BazelPackageFinder {
-     private final LogHelper logger = LogHelper.log(this.getClass());
+/**
+ * Scanner for a Bazel workspace to locate BUILD files that contain rules that are supported by the SDK.
+ */
+public class BazelPackageFinder {
+    private final LogHelper logger = LogHelper.log(this.getClass());
 
-     public BazelPackageFinder() {}
+    public BazelPackageFinder() {}
 
-     public void findBuildFileLocations(File dir, WorkProgressMonitor monitor, Set<File> buildFileLocations, int depth) {
-         if (!dir.isDirectory()) {
-             return;
-         }
+    public void findBuildFileLocations(File dir, WorkProgressMonitor monitor, Set<File> buildFileLocations, int depth) {
+        if (!dir.isDirectory()) {
+            return;
+        }
 
-         try {
+        try {
 
-             // collect all BUILD files
-             List<Path> buildFiles = new ArrayList<>(1000);
+            // collect all BUILD files
+            List<Path> buildFiles = new ArrayList<>(1000);
 
-             Path start = dir.toPath();
-             Files.walkFileTree(start, new FileVisitor<Path>() {
+            Path start = dir.toPath();
+            Files.walkFileTree(start, new FileVisitor<Path>() {
 
-                 @Override
-                 public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                     if (start.relativize(dir).toString().startsWith("bazel-")) {
-                         // this is a Bazel internal directory at the root of the project dir, ignore
-                         return FileVisitResult.SKIP_SUBTREE;
-                     }
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    if (start.relativize(dir).toString().startsWith("bazel-")) {
+                        // this is a Bazel internal directory at the root of the project dir, ignore
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
 
-                     if (dir.getFileName().toString().equals("target")) {
-                         // skip Maven target directories
-                         return FileVisitResult.SKIP_SUBTREE;
-                     }
+                    if (dir.getFileName().toString().equals("target")) {
+                        // skip Maven target directories
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
 
-                     if (dir.getFileName().toString().equals(".bazel")) {
-                         // skip Core .bazel directory
-                         return FileVisitResult.SKIP_SUBTREE;
-                     }
+                    if (dir.getFileName().toString().equals(".bazel")) {
+                        // skip Core .bazel directory
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
 
-                     return FileVisitResult.CONTINUE;
-                 }
+                    // ignore nested workspaces until we work on BEF issue #25
+                    if (dir.compareTo(start) != 0) {
+                        File directory = dir.toFile();
+                        for (String candidate : BazelConstants.WORKSPACE_FILE_NAMES) {
+                            File candidateWorkspaceFile = new File(directory, candidate);
+                            if (candidateWorkspaceFile.exists()) {
+                                logger.info(
+                                    "Skipping Bazel workspace path {} because we do not support nested workspaces yet.",
+                                    directory.getAbsolutePath());
+                                return FileVisitResult.SKIP_SUBTREE;
+                            }
+                        }
+                    }
 
-                 @Override
-                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                     if (isBuildFile(file)) {
-                         buildFiles.add(file);
-                     }
-                     return FileVisitResult.CONTINUE;
-                 }
+                    return FileVisitResult.CONTINUE;
+                }
 
-                 @Override
-                 public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                     return FileVisitResult.CONTINUE;
-                 }
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (isBuildFile(file)) {
+                        buildFiles.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
 
-                 @Override
-                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                     return FileVisitResult.CONTINUE;
-                 }
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
 
-             });
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
 
-             // scan all build files
-             // normally in the SDK we do not use Java streams, to make the code more accessible, but the parallel
-             // streaming here really speeds up the file system scan
-             Set<File> syncSet = Collections.synchronizedSet(buildFileLocations);
-             buildFiles.parallelStream().forEach(file -> {
-                 // great, this dir is a Bazel package (but this may be a non-Java package)
-                 // scan the BUILD file looking for java rules, only add if this is a java project
-                 if (BuildFileSupport.hasRegisteredRules(file.toFile())) {
-                     syncSet.add(FSPathHelper.getCanonicalFileSafely(file.getParent().toFile()));
-                 }
-             });
+            });
 
-         } catch (Exception anyE) {
-             logger.error("ERROR scanning for Bazel packages: {}", anyE.getMessage());
-         }
-     }
+            // scan all build files
+            // normally in the SDK we do not use Java streams, to make the code more accessible, but the parallel
+            // streaming here really speeds up the file system scan
+            Set<File> syncSet = Collections.synchronizedSet(buildFileLocations);
+            buildFiles.parallelStream().forEach(file -> {
+                // great, this dir is a Bazel package (but this may be a non-Java package)
+                // scan the BUILD file looking for java rules, only add if this is a java project
+                if (BuildFileSupport.hasRegisteredRules(file.toFile())) {
+                    syncSet.add(FSPathHelper.getCanonicalFileSafely(file.getParent().toFile()));
+                }
+            });
 
-     private static boolean isBuildFile(Path candidate) {
-         return BazelConstants.BUILD_FILE_NAMES.contains(candidate.getFileName().toString());
-     }
+        } catch (Exception anyE) {
+            logger.error("ERROR scanning for Bazel packages: {}", anyE.getMessage());
+        }
+    }
 
-     public Set<File> findBuildFileLocations(File rootDirectoryFile) throws IOException {
-         Set<File> files = ConcurrentHashMap.newKeySet();
-         findBuildFileLocations(rootDirectoryFile, null, files, 0);
-         return files;
-     }
- }
+    private static boolean isBuildFile(Path candidate) {
+        return BazelConstants.BUILD_FILE_NAMES.contains(candidate.getFileName().toString());
+    }
+
+    public Set<File> findBuildFileLocations(File rootDirectoryFile) throws IOException {
+        Set<File> files = ConcurrentHashMap.newKeySet();
+        findBuildFileLocations(rootDirectoryFile, null, files, 0);
+        return files;
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScanner.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScanner.java
@@ -49,6 +49,10 @@ import com.salesforce.bazel.sdk.model.BazelPackageInfo;
 public class BazelWorkspaceScanner {
     private static final LogHelper LOG = LogHelper.log(BazelWorkspaceScanner.class);
 
+    // list of found projects from the last scan; this is only intended to be accessed by tests
+    // this class is not intended to maintain state for real applications
+    Set<File> projects = null;
+
     private static final int MEANINGFUL_DIR_NAME_THRESHOLD = 3;
 
     public static String getBazelWorkspaceName(String bazelWorkspaceRootDirectory) {
@@ -126,7 +130,7 @@ public class BazelWorkspaceScanner {
         // TODO the correct way to do this is put the scan on another thread, and allow it to update the progress monitor.
         // Do it on-thread for now as it is easiest.
 
-        Set<File> projects = new TreeSet<>();
+        projects = new TreeSet<>();
         BazelPackageFinder packageFinder = new BazelPackageFinder();
         packageFinder.findBuildFileLocations(rootDirectoryFile, null, projects, 0);
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelPackageInfoTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelPackageInfoTest.java
@@ -72,27 +72,6 @@ public class BazelPackageInfoTest {
         assertTrue(root.getChildPackageInfos().contains(child2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNestedWorkspace() throws IOException {
-        BazelPackageInfo root = getRootBazelPackageInfo(true);
-
-        File nestedWSDir = tmpDir.newFolder("root", "nestedWS");
-        new File(nestedWSDir, "WORKSPACE").createNewFile();
-
-        // will throw, as we don't support nested workspaces yet
-        new BazelPackageInfo(root, "nestedWS");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNestedWorkspaceWithWorkspaceDotBazel() throws IOException {
-        BazelPackageInfo root = getRootBazelPackageInfo(true);
-
-        File nestedWSDir = tmpDir.newFolder("root", "nestedWS");
-        new File(nestedWSDir, "WORKSPACE.bazel").createNewFile();
-
-        // will throw, as we don't support nested workspaces yet
-        new BazelPackageInfo(root, "nestedWS");
-    }
 
     // HELPERS
 

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScannerTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScannerTest.java
@@ -63,6 +63,7 @@ public class BazelWorkspaceScannerTest {
         BazelWorkspaceScanner scanner = new BazelWorkspaceScanner();
         BazelPackageInfo rootWorkspacePackage = scanner.getPackages(tmpWorkspaceDir, null);
 
+        assertEquals(5, scanner.projects.size());
         assertEquals(5, rootWorkspacePackage.getChildPackageInfos().size());
     }
 
@@ -87,6 +88,7 @@ public class BazelWorkspaceScannerTest {
         BazelWorkspaceScanner scanner = new BazelWorkspaceScanner();
         BazelPackageInfo rootWorkspacePackage = scanner.getPackages(tmpWorkspaceDir, null);
 
+        assertEquals(0, scanner.projects.size());
         assertEquals(0, rootWorkspacePackage.getChildPackageInfos().size());
     }
 
@@ -99,6 +101,7 @@ public class BazelWorkspaceScannerTest {
         BazelWorkspaceScanner scanner = new BazelWorkspaceScanner();
         BazelPackageInfo rootWorkspacePackage = scanner.getPackages(tmpWorkspaceDir, null);
 
+        assertEquals(0, scanner.projects.size());
         assertEquals(0, rootWorkspacePackage.getChildPackageInfos().size());
     }
 }

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerFTest.java
@@ -224,8 +224,8 @@ public class BazelClasspathContainerFTest {
         javalib1_IProject = mockEclipse.getImportedProject("javalib1");
         javalib1_IJavaProject = BazelPluginActivator.getJavaCoreHelper().getJavaProjectForProject(javalib1_IProject);
 
-        assertTrue(mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdPackages.size() == 4);
-        //        assertTrue(mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdTargets.size() == 4);
+        assertEquals(4, mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdPackages.size());
+        //        assertEquals(4, mockEclipse.getBazelWorkspaceCreator().workspaceDescriptor.createdTargets.size());
 
         return mockEclipse;
     }


### PR DESCRIPTION
This PR changes the behavior at import. We don't currently support the import of nested Bazel workspaces, but the current behavior is to block the import of any Bazel workspace that has one. This PR changes it so the nested workspace is ignored, and the outer Bazel workspace is allowed to be imported.