### PR TITLE
overhaul test fwk, add project structure tests

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/MockCommandBuilder.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.Command;
 import com.salesforce.bazel.sdk.command.CommandBuilder;
@@ -41,6 +40,7 @@ import com.salesforce.bazel.sdk.command.test.type.MockTestCommand;
 import com.salesforce.bazel.sdk.command.test.type.MockVersionCommand;
 import com.salesforce.bazel.sdk.console.CommandConsoleFactory;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * This is the main component of the mocking layer for the Bazel command line. This command builder creates command
@@ -66,7 +66,7 @@ public class MockCommandBuilder extends CommandBuilder {
     // arbitrary option map provided by the test, can be interpreted by the Commands in a specific way
     // see the Mock*Command classes for details on what is available
     // for example, you may wish for a certain package to fail to build, that is an option in MockBuildCommand
-    private final Map<String, String> testOptions;
+    private final TestOptions testOptions;
 
     /**
      * This is an ordered list of output/error lines that will be returned from the Mock commands. Tests need to
@@ -84,7 +84,7 @@ public class MockCommandBuilder extends CommandBuilder {
      */
 
     public MockCommandBuilder(CommandConsoleFactory consoleFactory, TestBazelWorkspaceFactory testWorkspaceFactory,
-            Map<String, String> testOptions) {
+            TestOptions testOptions) {
         super(consoleFactory);
         this.testWorkspaceFactory = testWorkspaceFactory;
         this.testOptions = testOptions;

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockBuildCommand.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.internal.BazelWorkspaceAspectProcessor;
 import com.salesforce.bazel.sdk.command.test.MockCommand;
@@ -12,13 +11,14 @@ import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutput;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutputMatcher;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * Simulates a "bazel build //a/b/c" command
  */
 public class MockBuildCommand extends MockCommand {
 
-    public MockBuildCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockBuildCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory) {
         super(commandTokens, testOptions, testWorkspaceFactory);
 
@@ -75,13 +75,12 @@ public class MockBuildCommand extends MockCommand {
                     BazelLabel.BAZEL_ROOT_SLASHES + packagePath + BazelLabel.BAZEL_COLON + ".*";
             MockCommandSimulatedOutputMatcher aspectCommandMatcher3 =
                     new MockCommandSimulatedOutputMatcher(BazelWorkspaceAspectProcessor.ASPECTCMD_TARGETLABEL_ARGINDEX,
-                            wildcardTarget);
+                        wildcardTarget);
 
             List<MockCommandSimulatedOutputMatcher> matchers = new ArrayList<>();
             Collections.addAll(matchers, aspectCommandMatcher1, aspectCommandMatcher2, aspectCommandMatcher3);
 
-            List<String> aspectFilePathsList = new ArrayList<>();
-            aspectFilePathsList.addAll(testWorkspaceFactory.workspaceDescriptor.aspectFileSets.get(packagePath));
+            List<String> aspectFilePathsList = new ArrayList<>(testWorkspaceFactory.workspaceDescriptor.aspectFileSets.get(packagePath));
             String nameForLog = "Aspect file set for target: " + wildcardTarget;
             MockCommandSimulatedOutput aspectOutput =
                     new MockCommandSimulatedOutput(nameForLog, outputLines, aspectFilePathsList, matchers);

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockCleanCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockCleanCommand.java
@@ -1,10 +1,10 @@
 package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * Simulates a 'bazel clean' command. BEF doesn't do much of interest with clean, so this is just a basic no-op style
@@ -12,7 +12,7 @@ import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
  */
 public class MockCleanCommand extends MockCommand {
 
-    public MockCleanCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockCleanCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory) {
         super(commandTokens, testOptions, testWorkspaceFactory);
 

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockCustomCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockCustomCommand.java
@@ -1,11 +1,11 @@
 package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutput;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * You may want to run a test that invokes a command not already supported by specific code. This is a catch all mock
@@ -16,7 +16,7 @@ public class MockCustomCommand extends MockCommand {
     /**
      * Test must provide a set of simulatedOutputLinesProvidedByTest
      */
-    public MockCustomCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockCustomCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory,
             List<MockCommandSimulatedOutput> simulatedOutputLinesProvidedByTest) {
         super(commandTokens, testOptions, testWorkspaceFactory);
@@ -38,9 +38,9 @@ public class MockCustomCommand extends MockCommand {
                 commandPretty = commandPretty + token + " ";
             }
             throw new IllegalStateException(
-                    "The MockCustomCommand does not have enough output to provide to simulate the Bazel command. There are "
-                            + simulatedOutputLinesProvidedByTest.size() + " outputs configured. Command as received:\n"
-                            + commandPretty);
+                "The MockCustomCommand does not have enough output to provide to simulate the Bazel command. There are "
+                        + simulatedOutputLinesProvidedByTest.size() + " outputs configured. Command as received:\n"
+                        + commandPretty);
         }
 
     }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockInfoCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockInfoCommand.java
@@ -1,17 +1,17 @@
 package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * Simulates an info command (bazel info XYZ) where XYZ is one of a set of descriptors supported by Bazel.
  */
 public class MockInfoCommand extends MockCommand {
 
-    public MockInfoCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockInfoCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory) {
         super(commandTokens, testOptions, testWorkspaceFactory);
 
@@ -20,7 +20,8 @@ public class MockInfoCommand extends MockCommand {
             // we probably should not be issuing this command from BEF, we should use the more specific forms instead
             throw new IllegalArgumentException(
                     "The plugin issued the command 'bazel info' without a third arg. Please consider using a more specific 'bazel info xyz' command instead.");
-        } else if ("workspace".equals(commandTokens.get(2))) {
+        }
+        if ("workspace".equals(commandTokens.get(2))) {
             addSimulatedOutputToCommandStdOut("INFO: Invocation ID: a6809b5e-3fb4-462e-8fcc-2c18575122e7",
                 testWorkspaceFactory.workspaceDescriptor.workspaceRootDirectory.getAbsolutePath());
         } else if ("execution_root".equals(commandTokens.get(2))) {

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockLauncherCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockLauncherCommand.java
@@ -1,11 +1,11 @@
 package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutput;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * Simulates an invocation of a launcher script (bazel run //a/b/c) from Bazel
@@ -17,7 +17,7 @@ public class MockLauncherCommand extends MockCommand {
     /**
      * Test must provide a set of simulatedOutputLinesProvidedByTest
      */
-    public MockLauncherCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockLauncherCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory,
             List<MockCommandSimulatedOutput> simulatedOutputLinesProvidedByTest) {
         super(commandTokens, testOptions, testWorkspaceFactory);
@@ -39,9 +39,9 @@ public class MockLauncherCommand extends MockCommand {
                 commandPretty = commandPretty + token + " ";
             }
             throw new IllegalStateException(
-                    "The MockLauncherCommand does not have enough output to provide to simulate the launcher commands. There are "
-                            + simulatedOutputLinesProvidedByTest.size() + " outputs configured. Command as received:\n"
-                            + commandPretty);
+                "The MockLauncherCommand does not have enough output to provide to simulate the launcher commands. There are "
+                        + simulatedOutputLinesProvidedByTest.size() + " outputs configured. Command as received:\n"
+                        + commandPretty);
         }
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockTestCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockTestCommand.java
@@ -2,7 +2,6 @@ package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
@@ -13,12 +12,7 @@ import com.salesforce.bazel.sdk.workspace.test.TestOptions;
  */
 public class MockTestCommand extends MockCommand {
 
-    public static final String TESTOPTION_EXPLICIT_JAVA_TEST_DEPS = "EXPLICIT_JAVA_TEST_DEPS"; // search code base for this string, there are a few 
-    static {
-        TestOptions.advertise(TESTOPTION_EXPLICIT_JAVA_TEST_DEPS);
-    }
-
-    public MockTestCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockTestCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory) {
         super(commandTokens, testOptions, testWorkspaceFactory);
 
@@ -32,8 +26,8 @@ public class MockTestCommand extends MockCommand {
         // It is an odd pattern, but it is the best way to capture all of the .bazelrc options.
         // This block detects this use case and returns the appropriate response.
         // Note that some low level tests do not use this mechanism to simulate .bazelrc options, see also MockBazelWorkspaceMetadataStrategy.
-        if (commandTokens.size() == 3 && "--announce_rc".equals(commandTokens.get(2))) {
-            if ("true".equals(testOptions.get(TESTOPTION_EXPLICIT_JAVA_TEST_DEPS))) {
+        if ((commandTokens.size() == 3) && "--announce_rc".equals(commandTokens.get(2))) {
+            if (testOptions.explicitJavaTestDeps) {
                 addSimulatedOutputToCommandStdErr("   'test' options: --explicit_java_test_deps=true");
             } else {
                 addSimulatedOutputToCommandStdErr("   'test' options: --explicit_java_test_deps=false");
@@ -46,10 +40,8 @@ public class MockTestCommand extends MockCommand {
         String target = findBazelTargetInArgs();
         if (!isValidBazelTarget(target)) {
             // by default, isValidBazelTarget() will throw an exception if the package is missing, but the test may configure it to return false instead
-            errorLines = Arrays.asList(new String[] { "ERROR: no such package '" + target
-                    + "': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.",
-                    "- /fake/path/" + target }); // $SLASH_OK: bazel path
-            return;
+            errorLines = Arrays.asList("ERROR: no such package '" + target
+                + "': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.", "- /fake/path/" + target); // $SLASH_OK: bazel path
         }
 
         // TODO use testOptions to simulate fail certain tests

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockVersionCommand.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/command/test/type/MockVersionCommand.java
@@ -1,7 +1,6 @@
 package com.salesforce.bazel.sdk.command.test.type;
 
 import java.util.List;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.command.test.MockCommand;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
@@ -12,20 +11,14 @@ import com.salesforce.bazel.sdk.workspace.test.TestOptions;
  */
 public class MockVersionCommand extends MockCommand {
 
-    public static final String TESTOPTION_BAZELVERSION = "TESTOPTION_BAZELVERSION";
-    static {
-        TestOptions.advertise(TESTOPTION_BAZELVERSION);
-    }
-
-    public MockVersionCommand(List<String> commandTokens, Map<String, String> testOptions,
+    public MockVersionCommand(List<String> commandTokens, TestOptions testOptions,
             TestBazelWorkspaceFactory testWorkspaceFactory) {
         super(commandTokens, testOptions, testWorkspaceFactory);
 
         // 1.0.0 is the minimum supported Bazel version currently, tests can tell this mock to return a different value
-        String bazelVersion = testOptions.getOrDefault(TESTOPTION_BAZELVERSION, "1.0.0");
 
-        addSimulatedOutputToCommandStdOut("Build label: " + bazelVersion,
+        addSimulatedOutputToCommandStdOut("Build label: " + testOptions.bazelVersion,
             "Build time: Thu Oct 10 10:19:27 2019 (1570702767)", "Build timestamp: 1570702767",
-            "Build timestamp as int: 1570702767");
+                "Build timestamp as int: 1570702767");
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceDescriptor.java
@@ -1,6 +1,7 @@
 package com.salesforce.bazel.sdk.workspace.test;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -24,13 +25,6 @@ public class TestBazelWorkspaceDescriptor {
     // See the TestOptions class for ways to find all the available options.
     public TestOptions testOptions = new TestOptions();
 
-    // ideally this would be an extensible scheme for any type of rules to be generated
-    public int numberJavaPackages = 0;
-    public int numberGenrulePackages = 0;
-
-    // just throw a random nested workspace in the mix, to test that we ignore it
-    public boolean addFakeNestedWorkspace = true;
-
     // BUILT FIELDS (filled in after the workspace is built on disk)
 
     // directories
@@ -47,10 +41,14 @@ public class TestBazelWorkspaceDescriptor {
     // map of package path (projects/libs/javalib0) to the directory containing the package on the file system
     public Map<String, TestBazelPackageDescriptor> createdPackages = new TreeMap<>();
 
+    // map of package path (projects/libs/javalib0) to the list of source files (main and test) for the package
+    public Map<String, List<String>> createdMainSourceFilesForPackages = new TreeMap<>();
+    public Map<String, List<String>> createdTestSourceFilesForPackages = new TreeMap<>();
+
     public TestBazelPackageDescriptor getCreatedPackageByName(String packageName) {
         TestBazelPackageDescriptor desc = createdPackages.get(packageName);
         if (desc == null) {
-            System.out.println("Test caused a package to be requested that does not exist: " + packageName);
+            System.err.println("Test caused a package to be requested that does not exist: " + packageName);
         }
         return desc;
     }
@@ -96,33 +94,21 @@ public class TestBazelWorkspaceDescriptor {
 
     // CONFIGURATION
 
-    public TestBazelWorkspaceDescriptor useAltConfigFileNames(boolean useAltName) {
-        if (useAltName) {
-            workspaceFilename = "WORKSPACE.bazel";
-            buildFilename = "BUILD.bazel";
-        } else {
-            workspaceFilename = "WORKSPACE";
-            buildFilename = "BUILD";
-        }
-        return this;
-    }
-
-    public TestBazelWorkspaceDescriptor javaPackages(int count) {
-        numberJavaPackages = count;
-        return this;
-    }
-
-    public TestBazelWorkspaceDescriptor genrulePackages(int count) {
-        numberGenrulePackages = count;
-        return this;
-    }
-
     /**
      * List of options that allow you to create test workspaces with specific Mock features enabled. The features are
      * specific to each Mock*Command.
      */
     public TestBazelWorkspaceDescriptor testOptions(TestOptions options) {
         testOptions = options;
+
+        if (options.useAltConfigFileNames) {
+            workspaceFilename = "WORKSPACE.bazel";
+            buildFilename = "BUILD.bazel";
+        } else {
+            workspaceFilename = "WORKSPACE";
+            buildFilename = "BUILD";
+        }
+
         return this;
     }
 

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaFileCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaFileCreator.java
@@ -1,0 +1,43 @@
+package com.salesforce.bazel.sdk.workspace.test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+
+public class TestJavaFileCreator {
+    /**
+     * Write a Java source file that is legal Java but not very interesting.
+     *
+     */
+    static void createJavaSourceFile(File javaFile, String javaPackage, String classname) {
+        StringBuffer javaContent = new StringBuffer();
+
+        javaContent.append("// Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.\n");
+        javaContent.append("// This is a generated test java file. See TestJavaFileCreator in the Bazel Java SDK.\n");
+        // throw the parser a curve ball, make sure it doesn't mistake this for the package
+        javaContent.append("// package not.the.real.package;\n");
+
+        // write the real package, throw in some extra whitespace to be tricky
+        javaContent.append("package     ");
+        javaContent.append(javaPackage);
+        javaContent.append(";     \n\n");
+
+        // toss in some imports
+        javaContent.append("import java.io.File;\n");
+        javaContent.append("import java.io.FileOutputStream;\n");
+        javaContent.append("import java.io.PrintStream;\n\n");
+
+        javaContent.append("public class ");
+        javaContent.append(classname);
+        javaContent.append(" {\n");
+        javaContent.append("    public String testStr;\n");
+        javaContent.append("}\n");
+
+        try (PrintStream out = new PrintStream(new FileOutputStream(javaFile))) {
+            out.print(javaContent.toString());
+        } catch (Exception anyE) {
+            anyE.printStackTrace();
+        }
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestJavaRuleCreator.java
@@ -3,7 +3,6 @@ package com.salesforce.bazel.sdk.workspace.test;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import java.util.Map;
 
 import com.salesforce.bazel.sdk.path.FSPathHelper;
 
@@ -51,8 +50,8 @@ public class TestJavaRuleCreator {
         return sb.toString();
     }
 
-    private static String createJavaTestRule(String packageName, Map<String, String> commandOptions) {
-        boolean explicitJavaTestDeps = "true".equals(commandOptions.get("explicit_java_test_deps"));
+    private static String createJavaTestRule(String packageName, TestOptions commandOptions) {
+        boolean explicitJavaTestDeps = commandOptions.explicitJavaTestDeps;
         String test = FSPathHelper.osSeps("src/test/java/**/*.java"); // $SLASH_OK
         String testProps = FSPathHelper.osSeps("src/test/resources/test.properties"); // $SLASH_OK
 

--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestOptions.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestOptions.java
@@ -7,15 +7,95 @@ import java.util.HashMap;
  * alter the way the mocks behave. The TestOptions object is passed around the layers and is available to most of the
  * Mock objects.
  * <p>
- * This is its own custom type to make finding example usages easier, as the various Mock objects are only documented in
- * code.
+ * It extends Map<String, String> so you can add arbitrary test data to it. The commonly used options are explicit
+ * member variables.
  */
 public class TestOptions extends HashMap<String, String> {
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Mock code that supports a test option should call this method with that option name. This is here to help you
-     * find all the various options available throughout the code base. Just look for usages of this method.
-     */
-    public static void advertise(String optionName) {}
+    // COMMON OPTIONS
+
+    // version identifier to use in 'bazel version' commands
+    public String bazelVersion = "1.0.0";
+
+    public TestOptions bazelVersion(String version) {
+        bazelVersion = version;
+        return this;
+    }
+
+    // number of packages with Java rules to create in the test workspace
+    public int numberOfJavaPackages = 0;
+
+    public TestOptions numberOfJavaPackages(int num) {
+        numberOfJavaPackages = num;
+        return this;
+    }
+
+    // number of packages with genrules to create in the test workspace
+    public int numberGenrulePackages = 0;
+
+    public TestOptions numberGenrulePackages(int num) {
+        numberGenrulePackages = num;
+        return this;
+    }
+
+    // compute the classpaths? TODO why not
+    public boolean computeClasspaths = false;
+
+    public TestOptions computeClasspaths(boolean compute) {
+        computeClasspaths = compute;
+        return this;
+    }
+
+    // for Java packages, should test deps be listed explicitly
+    public boolean explicitJavaTestDeps = true;
+
+    public TestOptions explicitJavaTestDeps(boolean explicit) {
+        explicitJavaTestDeps = explicit;
+        return this;
+    }
+
+    // WORKSPACE and BUILD (if false), or WORKSPACE.bazel and BUILD.bazel (if true)
+    public boolean useAltConfigFileNames = false;
+
+    public TestOptions useAltConfigFileNames(boolean alt) {
+        useAltConfigFileNames = alt;
+        return this;
+    }
+
+    // non Maven layouts; if enabled, will use source/dev and source/test
+    public boolean nonStandardJavaLayout_enabled = false;
+
+    public TestOptions nonStandardJavaLayout_enabled(boolean non) {
+        nonStandardJavaLayout_enabled = non;
+        return this;
+    }
+
+    // if multiple, will also have source/dev2, source/test2
+    public boolean nonStandardJavaLayout_multipledirs = false;
+
+    public TestOptions nonStandardJavaLayout_multipledirs(boolean mult) {
+        nonStandardJavaLayout_multipledirs = mult;
+        return this;
+    }
+
+    // just throw a random nested workspace in the mix, to test that we ignore it (see bef issue #25)
+    // when we start to support nestedWorkspaces, this should default to false and only some tests will
+    // test the nested workspace
+    public boolean addFakeNestedWorkspace = true;
+
+    public TestOptions addFakeNestedWorkspace(boolean fake) {
+        addFakeNestedWorkspace = fake;
+        return this;
+    }
+
+    // almost all tests should fail if an unknown target (not found in the underlying test workspace) is passed to a command
+    // if you are testing failure cases, this can be set to "false" so that a Bazel error is simulated instead
+    public boolean failTestForUnknownTarget = true;
+
+    public TestOptions failTestForUnknownTarget(boolean fail) {
+        failTestForUnknownTarget = fail;
+        return this;
+    }
+
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabelUtil.java
@@ -1,3 +1,26 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.salesforce.bazel.sdk.model;
 
 import java.util.Collection;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
@@ -174,7 +174,12 @@ public final class FSPathHelper {
      * An example use case is looking for a directory named 'test' or 'tests' in a file system path.
      */
     public static boolean doesPathContainNamedResource(String filesystemPath, Set<String> targetNames) {
-        String[] pathElements = filesystemPath.split(File.separator);
+        String[] pathElements = null;
+        if (isUnix) {
+            pathElements = filesystemPath.split(UNIX_SLASH);
+        } else {
+            pathElements = filesystemPath.split(WINDOWS_BACKSLASH_REGEX);
+        }
         for (String element : pathElements) {
             if (targetNames.contains(element)) {
                 return true;

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/structure/BazelQueryProjectStructureStrategy.java
@@ -70,7 +70,8 @@ public class BazelQueryProjectStructureStrategy extends ProjectStructureStrategy
         File packageDir = new File(workspaceRootDir, packageRelPath); // TODO move this to the PackageLocation api
         result.projectPath = packageDir;
 
-        BazelLabel packageLabel = new BazelLabel(packageRelPath, BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR);
+        String labelPath = packageRelPath.replaceAll(FSPathHelper.WINDOWS_BACKSLASH_REGEX, "/");
+        BazelLabel packageLabel = new BazelLabel(labelPath, BazelLabel.BAZEL_WILDCARD_ALLTARGETS_STAR);
 
         // execute the expensive query, this will take a few seconds to run at least
         Collection<String> results = runBazelQueryForSourceFiles(workspaceRootDir, packageLabel, commandRunner);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
@@ -44,6 +44,7 @@ import com.salesforce.bazel.sdk.model.BazelTargetKind;
 import com.salesforce.bazel.sdk.path.FSPathHelper;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 public class BazelLauncherBuilderTest {
     @Rule
@@ -63,7 +64,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyList());
 
         addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0.*"), // $SLASH_OK
-            "fake bazel launcher script result");
+                "fake bazel launcher script result");
 
         Command command = launcherBuilder.build();
         BazelProcessBuilder processBuilder = command.getProcessBuilder();
@@ -87,7 +88,7 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
 
         addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0.*"), // $SLASH_OK
-            "fake bazel launcher script result");
+                "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
@@ -194,11 +195,14 @@ public class BazelLauncherBuilderTest {
         workspaceDir.mkdirs();
         File outputbaseDir = new File(testDir, "outputbase");
         outputbaseDir.mkdirs();
+
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(3);
+
         TestBazelWorkspaceDescriptor descriptor =
-                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).javaPackages(3);
+                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).testOptions(testOptions);
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(descriptor).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir, null);
+        env.createTestEnvironment(workspace, testDir, testOptions);
 
         return env;
     }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/internal/BazelCommandExecutorTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/internal/BazelCommandExecutorTest.java
@@ -37,6 +37,7 @@ import com.salesforce.bazel.sdk.command.test.MockWorkProgressMonitor;
 import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 public class BazelCommandExecutorTest {
     @Rule
@@ -60,7 +61,7 @@ public class BazelCommandExecutorTest {
                 new BazelCommandExecutor(env.bazelExecutable.bazelExecutableFile, env.commandBuilder);
         List<String> result =
                 executor.runBazelAndGetOutputLines(env.bazelWorkspaceCommandRunner.getBazelWorkspaceRootDirectory(),
-                    new MockWorkProgressMonitor(), args, (t) -> t, 0);
+                    new MockWorkProgressMonitor(), args, t -> t, 0);
 
         assertEquals(2, result.size());
         assertEquals("result line 1", result.get(0));
@@ -85,7 +86,7 @@ public class BazelCommandExecutorTest {
                 new BazelCommandExecutor(env.bazelExecutable.bazelExecutableFile, env.commandBuilder);
         List<String> result =
                 executor.runBazelAndGetErrorLines(env.bazelWorkspaceCommandRunner.getBazelWorkspaceRootDirectory(),
-                    new MockWorkProgressMonitor(), args, (t) -> t, 0);
+                    new MockWorkProgressMonitor(), args, t -> t, 0);
 
         assertEquals(2, result.size());
         assertEquals("result line 1", result.get(0));
@@ -116,11 +117,13 @@ public class BazelCommandExecutorTest {
         File outputbaseDir = new File(testDir, "outputbase");
         outputbaseDir.mkdirs();
 
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(1);
+
         TestBazelWorkspaceDescriptor descriptor =
-                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).javaPackages(1);
+                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir);
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(descriptor).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir, null);
+        env.createTestEnvironment(workspace, testDir, testOptions);
 
         return env;
     }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelperTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectHelperTest.java
@@ -42,6 +42,7 @@ import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * Tests various behaviors of the BazelWorkspaceAspectHelper collaborator.
@@ -63,11 +64,11 @@ public class BazelWorkspaceAspectHelperTest {
         List<BazelLabel> targets = Collections.singletonList(label);
         Map<BazelLabel, Set<AspectTargetInfo>> aspectMap =
                 aspectHelper.getAspectTargetInfos(targets, "testAspectLoading");
-        // aspect infos returned for: guava, slf4j, javalib0, javalib0-test
+        // aspect infos returned for: guava, slf4j, hamcrest, junit, javalib0, javalib0-test
         assertNotNull(aspectMap);
         assertEquals(1, aspectMap.size());
         assertNotNull(aspectMap.get(label));
-        assertEquals(4, aspectMap.get(label).size());
+        assertEquals(6, aspectMap.get(label).size());
 
         // now check that the caches are populated
         // javalib0:javalib0, javalib0:javalib0-test, javalib0:*
@@ -157,11 +158,13 @@ public class BazelWorkspaceAspectHelperTest {
         File outputbaseDir = new File(testDir, "outputbase");
         outputbaseDir.mkdirs();
 
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(1);
+
         TestBazelWorkspaceDescriptor descriptor =
-                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).javaPackages(1);
+                new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).testOptions(testOptions);
         TestBazelWorkspaceFactory workspace = new TestBazelWorkspaceFactory(descriptor).build();
         TestBazelCommandEnvironmentFactory env = new TestBazelCommandEnvironmentFactory();
-        env.createTestEnvironment(workspace, testDir, null);
+        env.createTestEnvironment(workspace, testDir, testOptions);
 
         return env;
     }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScannerTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/workspace/BazelWorkspaceScannerTest.java
@@ -36,7 +36,12 @@ import com.salesforce.bazel.sdk.init.JvmRuleInit;
 import com.salesforce.bazel.sdk.model.BazelPackageInfo;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceDescriptor;
 import com.salesforce.bazel.sdk.workspace.test.TestBazelWorkspaceFactory;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
+/**
+ * This test makes sure the workspace scanner correctly identifies packages to import. It does NOT verify the internal
+ * details of those scanned project (e.g. the classpath is correctly computed).
+ */
 public class BazelWorkspaceScannerTest {
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -53,11 +58,12 @@ public class BazelWorkspaceScannerTest {
 
         //        File tmpWorkspaceDir = new File("/tmp/bazeltest/ws"); // $SLASH_OK sample code
         //        File tmpOutputBase = new File("/tmp/bazeltest/bin"); // $SLASH_OK sample code
-        //File tmpWorkspaceDir = new File("C:\\Users\\coloradolaird\\Desktop\\dev\\tools\\temp\\ws"); // $SLASH_OK sample code
-        //File tmpOutputBase = new File("C:\\Users\\coloradolaird\\Desktop\\dev\\tools\\temp\\bin"); // $SLASH_OK sample code
+
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(5).numberGenrulePackages(2);
 
         TestBazelWorkspaceDescriptor descriptor =
-                new TestBazelWorkspaceDescriptor(tmpWorkspaceDir, tmpOutputBase).javaPackages(5).genrulePackages(2);
+                new TestBazelWorkspaceDescriptor(tmpWorkspaceDir, tmpOutputBase).testOptions(testOptions);
+
         new TestBazelWorkspaceFactory(descriptor).build();
 
         BazelWorkspaceScanner scanner = new BazelWorkspaceScanner();
@@ -66,6 +72,7 @@ public class BazelWorkspaceScannerTest {
         assertEquals(5, scanner.projects.size());
         assertEquals(5, rootWorkspacePackage.getChildPackageInfos().size());
     }
+
 
     // UNHAPPY PATHS
 
@@ -81,8 +88,10 @@ public class BazelWorkspaceScannerTest {
     public void testNoJavaProjects() throws Exception {
         File tmpWorkspaceDir = tmpFolder.newFolder().getCanonicalFile();
         File tmpOutputBase = tmpFolder.newFolder().getCanonicalFile();
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(0).numberGenrulePackages(2);
+
         TestBazelWorkspaceDescriptor descriptor =
-                new TestBazelWorkspaceDescriptor(tmpWorkspaceDir, tmpOutputBase).javaPackages(0).genrulePackages(2);
+                new TestBazelWorkspaceDescriptor(tmpWorkspaceDir, tmpOutputBase).testOptions(testOptions);
         new TestBazelWorkspaceFactory(descriptor).build();
 
         BazelWorkspaceScanner scanner = new BazelWorkspaceScanner();

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/builder/BazelBuilderFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/builder/BazelBuilderFTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
@@ -19,7 +17,7 @@ import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.mock.EclipseFunctionalTestEnvironmentFactory;
 import com.salesforce.bazel.eclipse.mock.MockEclipse;
 import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
-import com.salesforce.bazel.sdk.command.test.MockCommandBuilder;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 @SuppressWarnings("unused")
 public class BazelBuilderFTest {
@@ -36,7 +34,7 @@ public class BazelBuilderFTest {
     @Ignore // still need to fix the publishProblemMarkers() issue "Workspace is closed"
     public void testBazelBuilder_Success() throws Exception {
         MockEclipse mockEclipse = setupMockEnvironmentForClasspathTest("testBazelBuilder_Success", true);
-        MockCommandBuilder mockCommandBuilder = mockEclipse.getMockCommandBuilder();
+        mockEclipse.getMockCommandBuilder();
 
         BazelBuilder bazelBuilder = createTestBazelBuilder(javalib1_IProject);
         IProject builderProject = bazelBuilder.getProject();
@@ -63,12 +61,12 @@ public class BazelBuilderFTest {
         //testTempDir = new File("/tmp/bef/bazelws");
         //testTempDir.mkdirs();
 
-        // create the mock Eclipse runtime in the correct state
-        int numberOfJavaPackages = 2;
-        boolean computeClasspaths = true;
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(2).computeClasspaths(true)
+                .explicitJavaTestDeps(explicitJavaTestDeps);
+
         MockEclipse mockEclipse =
                 EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(testTempDir,
-                    numberOfJavaPackages, computeClasspaths, explicitJavaTestDeps);
+                    testOptions);
 
         workspace_IProject =
                 mockEclipse.getImportedProject("Bazel Workspace (" + MockEclipse.BAZEL_WORKSPACE_NAME + ")");

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/command/BazelCommandRunnerFTest.java
@@ -20,7 +20,7 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Copyright 2017 The Bazel Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
@@ -50,6 +50,7 @@ import com.salesforce.bazel.eclipse.mock.MockEclipse;
 import com.salesforce.bazel.sdk.command.BazelCommandManager;
 import com.salesforce.bazel.sdk.command.BazelWorkspaceCommandRunner;
 import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 public class BazelCommandRunnerFTest {
     @Rule
@@ -62,10 +63,12 @@ public class BazelCommandRunnerFTest {
     @Test
     public void testBazelWorkspaceCommandRunner_AtStartOfImport() throws Exception {
         File testTempDir = tmpFolder.newFolder();
+        TestOptions testOptions =
+                new TestOptions().numberOfJavaPackages(5).explicitJavaTestDeps(false).useAltConfigFileNames(false);
 
         // create the mock Eclipse runtime in the correct state
         MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory
-                .createMockEnvironment_PriorToImport_JavaPackages(testTempDir, 5, false, false);
+                .createMockEnvironment_PriorToImport_JavaPackages(testTempDir, testOptions);
 
         // the Bazel commands will run after the bazel root directory is chosen in the UI, so simulate the selection here
         BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory("test", mockEclipse.getBazelWorkspaceRoot());
@@ -96,10 +99,12 @@ public class BazelCommandRunnerFTest {
     @Test
     public void testBazelWorkspaceCommandRunner_WorkspaceDotBazel_AtStartOfImport() throws Exception {
         File testTempDir = tmpFolder.newFolder();
+        TestOptions testOptions =
+                new TestOptions().numberOfJavaPackages(5).explicitJavaTestDeps(false).useAltConfigFileNames(true);
 
         // create the mock Eclipse runtime in the correct state
         MockEclipse mockEclipse = EclipseFunctionalTestEnvironmentFactory
-                .createMockEnvironment_PriorToImport_JavaPackages(testTempDir, 5, false, true);
+                .createMockEnvironment_PriorToImport_JavaPackages(testTempDir, testOptions);
 
         // the Bazel commands will run after the bazel root directory is chosen in the UI, so simulate the selection here
         BazelPluginActivator.getInstance().setBazelWorkspaceRootDirectory("test", mockEclipse.getBazelWorkspaceRoot());

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/config/BazelEclipseProjectFactoryFTest.java
@@ -43,6 +43,7 @@ import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.mock.EclipseFunctionalTestEnvironmentFactory;
 import com.salesforce.bazel.eclipse.mock.MockEclipse;
 import com.salesforce.bazel.sdk.model.BazelConfigurationManager;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 /**
  * This FTest checks that the Eclipse workspace and Eclipse projects are configured as expected after an import. Other
@@ -66,11 +67,13 @@ public class BazelEclipseProjectFactoryFTest {
         //testTempDir.mkdirs();
 
         // create the mock Eclipse runtime in the correct state, which is two java projects javalib0 and javalib1
-        int numberOfJavaPackages = 2;
-        boolean computeClasspaths = true;
+        TestOptions testOptions =
+                new TestOptions().numberOfJavaPackages(2).computeClasspaths(true)
+                .explicitJavaTestDeps(false);
+
         MockEclipse mockEclipse =
                 EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(testTempDir,
-                    numberOfJavaPackages, computeClasspaths, false);
+                    testOptions);
         workspace_IProject =
                 mockEclipse.getImportedProject("Bazel Workspace (" + MockEclipse.BAZEL_WORKSPACE_NAME + ")");
         assertNotNull(workspace_IProject);

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationDelegateFTest.java
@@ -47,6 +47,7 @@ import com.salesforce.bazel.eclipse.runtime.impl.EclipseWorkProgressMonitor;
 import com.salesforce.bazel.sdk.command.test.MockCommandSimulatedOutputMatcher;
 import com.salesforce.bazel.sdk.command.test.TestBazelCommandEnvironmentFactory;
 import com.salesforce.bazel.sdk.path.FSPathHelper;
+import com.salesforce.bazel.sdk.workspace.test.TestOptions;
 
 public class BazelLaunchConfigurationDelegateFTest {
     @Rule
@@ -73,7 +74,7 @@ public class BazelLaunchConfigurationDelegateFTest {
         String expectedExec = FSPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
         String actualExec = cmdLine[0];
 
-        System.out.println("testHappyRunLaunch expectedExec = " + expectedExec + " actualPath = " + actualExec);
+        //System.out.println("testHappyRunLaunch expectedExec = " + expectedExec + " actualPath = " + actualExec);
 
         assertTrue(actualExec.endsWith(expectedExec) || actualExec.endsWith(expectedExec + ".exe"));
         assertTrue(cmdLine[1].contains("debug"));
@@ -145,12 +146,12 @@ public class BazelLaunchConfigurationDelegateFTest {
         //testTempDir = new File("/tmp/bef/bazelws"); // $SLASH_OK: sample code
         //testTempDir.mkdirs();
 
-        // create the mock Eclipse runtime in the correct state
-        int numberOfJavaPackages = 1;
-        boolean computeClasspaths = true;
+        TestOptions testOptions =
+                new TestOptions().numberOfJavaPackages(1).computeClasspaths(true).explicitJavaTestDeps(false);
+
         MockEclipse mockEclipse =
                 EclipseFunctionalTestEnvironmentFactory.createMockEnvironment_Imported_All_JavaPackages(testTempDir,
-                    numberOfJavaPackages, computeClasspaths, false);
+                    testOptions);
 
         return mockEclipse;
     }


### PR DESCRIPTION
This PR started as a couple of new tests for the new project structure feature (use Bazel query to determine source folders if java package does not use Maven standard layout). But I hit some tech debt and a few bugs in the test framework while expanding it to handle the new use cases.

Also the newer Eclipse SDK on my new laptop is more aggressive about code improvements, so some of these changes are courtesy of Eclipse.

Notable:
- TestOptions class is better defined, and is now the only way to pass various flags into the test framework. Eliminated the use of tedious params for that.
- Mock Bazel Query properly models the response to a bazel query for source folders for a target
- Test workspace factory can now create java packages that do not follow Maven conventions
- The Java files that test workspace factory creates now have valid Java code in them, since project structure analysis needs to parse them for the Java package.