### PR TITLE
CI to check for broken links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,20 @@
+name: Check for broken markdown links
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+      - cron: '0 10 * * *'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-verbose-mode: 'yes'

--- a/bundles/com.salesforce.bazel-java-sdk/aspect/README.md
+++ b/bundles/com.salesforce.bazel-java-sdk/aspect/README.md
@@ -10,5 +10,4 @@ It is developed by the Bazel IntelliJ plugin team, and we copy it into Bazel SDK
 It is tempting to move this to *src/main/resources* but these files need to remain extracted on the file system.
 This likely means you need to install these files in addition to the java_binary that you build.
 
-The [BazelAspectLocationImpl](../src/main/java/com/salesforce/bazel/eclipse/config/BazelAspectLocationImpl.java#L96)
-  depends on finding the *bzljavasdk_aspect.bzl* file on the file system.
+The class _BazelAspectLocationImpl_ depends on finding the *bzljavasdk_aspect.bzl* file on the file system.

--- a/bundles/com.salesforce.bazel.eclipse.core/README.md
+++ b/bundles/com.salesforce.bazel.eclipse.core/README.md
@@ -1,6 +1,6 @@
 ## Bazel Eclipse Feature: Core Plugin
 
-In the [architecture](../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across a few Eclipse plugins.
+In the [architecture](../../docs/dev/architecture.md) of the Bazel Eclipse Feature, the implementation is spread across a few Eclipse plugins.
 
 - **plugin-core**: this plugin is the one that is integrated with Eclipse APIs, and contains classes such as the activator
 - **bazel-java-sdk**: handles model abstractions and command execution for Bazel

--- a/bundles/com.salesforce.bazel.eclipse.deps/README.md
+++ b/bundles/com.salesforce.bazel.eclipse.deps/README.md
@@ -1,17 +1,4 @@
 ### Plugin Dependencies
 
-Why are there jars checked into the Git repository instead of using Bazel maven_jar rules?
-Because we support [two different build systems in parallel](../../docs/dev/threebuilds.md)
-  and having the jar files here makes it easiest to ensure both systems use the same deps.
-
 This directory is for *main* dependencies.
-There is a separate directory for [test dependencies](../plugin-testdeps)
-
-If you want to add/change a jar file, you will need to:
-
-- **Bazel Build:** open the [BUILD](BUILD) file here and add/change it. There are examples in the file, so it should be obvious what to do.
-- **Eclipse SDK Build:** open the [.classpath](.classpath) file here and add/change it. There are examples in the file, so it should be obvious what to do.
-
-If you just added a jar file, you will now need to reference it from the projects that need it.
-Grep around the plugin project to find examples.
-Be sure to add it for both builds (Bazel, Eclipse SDK) by touching *BUILD* and *MANIFEST.MF* files.
+TODO This is deprecated and should be removed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,4 +8,4 @@ Most user and developer docs for BEF are rooted here.
 - [Known Issues](issues.md)
 
 For developers that want to contribute to BEF:
-- [BEF Dev Guide](dev/README.md) (if you would like to build/modify the BEF)
+- [BEF Dev Guide](dev/dev_guide.md) (if you would like to build/modify the BEF)

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -100,7 +100,7 @@ Before doing any work on BEF, it is important to understand what the SDK is, how
 It makes sense to look over the fence at the Maven plugins to see how they have implemented the same
   functionality.
 
-- [M2Eclipse plugins](https://github.com/eclipse/m2e-core)
+- [M2Eclipse plugins](https://github.com/eclipse-m2e/m2e-core)
 
 ### The plugins that compose the Bazel Eclipse Feature
 

--- a/docs/dev/bazeljavasdk.md
+++ b/docs/dev/bazeljavasdk.md
@@ -11,7 +11,7 @@ Roughly 90% of the code to support Bazel in Eclipse is not specific to Eclipse, 
 
 For that reason, a vendored (static copy) version of the SDK lives in this repository.
 As changes are made to the SDK in either repository, the changes are copied across
-  using scripts such as [sdk_copybara.sh](../../sdk_copybara.sh).
+  using scripts such as [sdk_copybara.sh](../../sdk-copybara.sh).
 
 More details can be found in these places:
 - [Bazel Java SDK](https://github.com/salesforce/bazel-java-sdk)

--- a/docs/dev/dev_guide.md
+++ b/docs/dev/dev_guide.md
@@ -37,7 +37,6 @@ See [this installation document](../install.md) for details.
 In addition to the installation steps above, you need to install the **Eclipse SDK** which is more
   than just the typical Java IDE download that you normally use.
 The SDK includes the [Plugin Development Environment](http://www.eclipse.org/pde/)
-The correct version to use is tracked in our build toolchain [here](../../tools/eclipse_jars).
 
 - [Download the Eclipse SDK](http://download.eclipse.org/eclipse/downloads/)
 

--- a/docs/dev/logging.md
+++ b/docs/dev/logging.md
@@ -16,7 +16,7 @@ Finally, all log events go to the SLF4J/Logback file that is discussed below.
 
 ### How To
 To log, simply create a LogHelper instance with the class that will log to it.
-This is just like SLF4J's LoggerFactory.getLog(Class<?>) method.
+This is just like SLF4J's *LoggerFactory.getLog(Class<?>)* method.
 ```java
 import com.salesforce.bazel.eclipse.logging.LogHelper;
 ...
@@ -32,7 +32,7 @@ public void warn(String message, Object... args);
 public void info(String message, Object... args);
 public void debug(String message, Object... args);
 ```
-These methods can be found [here](../../bzl-java-sdk/src/main/java/com/salesforce/bazel/eclipse/logging/LogHelper.java).
+These methods can be found in *LogHelper.java*.
 
 These methods should be familiar to SLF4j users.
 The ```message```and ```args``` work just like SLF4J where ```{}``` is used to substitute values in the ```args```.
@@ -77,10 +77,10 @@ LOG.debug("Health check was successful");
 ### Log Configuration
 The SLF4J/Logback log can be configured to change format, log rolling, log size, etc.
 To learn more about configuration, please read the [Logback documentation](https://logback.qos.ch/manual/configuration.html).
-The configuration file is located in [logback.xml](../../plugin-core/logback.xml).
+The configuration file is located in *logback.xml* in the Core plugin.
 
 #### Enable debug events to be seen
-If you want to turn on debug level events in the SLF4J/Loback log, change the following xml in the [logback.xml](../../plugin-core/logback.xml) from INFO to DEBUG.
+If you want to turn on debug level events in the SLF4J/Loback log, change the following xml in the *logback.xml* from INFO to DEBUG.
 ```xml
 <root level="INFO">
 ```

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -60,7 +60,9 @@ Note that we have two update sites, one for the official releases and one for re
 Deploy a release candidate and test it prior to releasing the official release.
 
 - [Update Instructions](https://opensource.salesforce.com/bazel-eclipse/) are written [here](https://github.com/salesforce/bazel-eclipse/blob/master/.github/update-site-index.html)
+<!-- markdown-link-check-disable-next-line -->
 - Official release update site: https://opensource.salesforce.com/bazel-eclipse/update-site
+<!-- markdown-link-check-disable-next-line -->
 - Release candidate (RC) update site: http://opensource.salesforce.com/bazel-eclipse/update-site-release-candidate
 
 :fire: The update site is our live installation location for our users. If you are doing
@@ -92,6 +94,7 @@ First, check that our landing page is available and has correct instructions:
 - [BEF Update Site landing page](https://opensource.salesforce.com/bazel-eclipse/)
 
 Next, follow the instructions on the page and install BEF into a fresh copy of Eclipse.
+<!-- markdown-link-check-disable-next-line -->
 If you are testing a release candidate, remember to use the RC update site http://opensource.salesforce.com/bazel-eclipse/update-site-release-candidate.
 Finally, repeat the install test with the zip file that is in the root directory of the *gh-pages* branch
 
@@ -140,6 +143,7 @@ The BEF record is here, which will have an _Edit_ button if you are entitled:
 
 When you create a new _Solution Version_, use these data points:
 - Version: use the full version like *1.4.0.v20210707-0040*
+<!-- markdown-link-check-disable-next-line -->
 - Update site: https://opensource.salesforce.com/bazel-eclipse/update-site
 - Feature id: *com.salesforce.bazel.eclipse.feature*
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -5,6 +5,7 @@
 The project is sponsored by Salesforce.
 Salesforce has opened the repository as open source as of November 20, 2019, with contributors located here:
 
+<!-- markdown-link-check-disable-next-line -->
 - [Bazel Eclipse Feature contributors](https://github.com/salesforce/bazel-eclipse/settings/collaboration)
 
 For more information about open source at Salesforce, see this page:

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ More details of our JDK support strategy can be [found here](dev/jdk.md).
 ### Installing Eclipse
 
 Download the latest release of [Eclipse IDE for Java Developers](https://www.eclipse.org/downloads/packages/release/2018-09/r/eclipse-ide-java-developers).
-The feature is built against a [recent version](../tools/eclipse_jars) of the Eclipse SDK, so older versions won't work.
+The feature is built against a of the Eclipse SDK, so older versions won't work.
 
 **Launching Eclipse**
 
@@ -43,7 +43,7 @@ Consult [this doc](macos.md) if your Eclipse fails to launch on Mac.
 The Bazel Eclipse Feature does not come with an embedded install of Bazel.
 You must have Bazel installed on your machine and in your shell path.
 
-The [BazelVersionChecker](../plugin-libs/plugin-command/src/main/java/com/salesforce/bazel/eclipse/command/internal/BazelVersionChecker.java) has a version check when setting the Bazel executable in the Eclipse preferences.
+The BazelVersionChecker class has a version check when setting the Bazel executable in the Eclipse preferences.
 Choose a version of Bazel that is at least as high as that check.
 
 ### Installing the Bazel Eclipse feature into Eclipse
@@ -65,6 +65,7 @@ If you want to install the latest version of BEF, follow these steps to install 
 - Start Eclipse.
 - In Eclipse, go to *Help* -> *Install New Software*
 - Click the *Add* button
+<!-- markdown-link-check-disable-next-line -->
 - For the location, enter: **https://opensource.salesforce.com/bazel-eclipse/update-site**
 - Give the location a name, like *Bazel-Eclipse updatesite*
 - Check the box next to the *Bazel Eclipse* item, then hit *Next*

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,6 +17,7 @@ Our list of releases is here:
 We maintain our latest release on our public update site. The update site is available here:
 
 - [Bazel Eclipse Update Site Instructions](https://opensource.salesforce.com/bazel-eclipse/)
+<!-- markdown-link-check-disable-next-line -->
 - Bazel Eclipse Update Site: https://opensource.salesforce.com/bazel-eclipse/update-site
 
 If you prefer, we also attach a built binary archive of each release that you can install.

--- a/features/com.salesforce.b2eclipse.jdt.ls.feature/README.md
+++ b/features/com.salesforce.b2eclipse.jdt.ls.feature/README.md
@@ -2,7 +2,7 @@
 
 This is the logical container of all the plugins related to the Bazel integration with Eclipse.
 In Eclipse, such a container is known as a *feature*.
-See the [architecture document](../docs/dev/architecture.md) for more information about features.
+See the [architecture document](../../docs/dev/architecture.md) for more information about features.
 
 ### Static Files
 
@@ -14,14 +14,3 @@ This packages contains a number of static files that are used by the Eclipse SDK
 
 As you develop the Bazel Eclipse Feature, you may need to update these files.
 Make sure to commit them back to the Git repo.
-
-### Bazel Build
-
-We currently do not use the Feature artifacts built by the [Bazel build](BUILD).
-Instead, we are relying on the Eclipse SDK to build and export the feature.
-We might use Bazel to build the feature artifacts in the future, however.
-
-We are also not using Bazel to build the feature *updatesite*, and likely never will.
-There are Bazel rules [in the repo](../tools/eclipse_updatesite) for doing this, but we have no plans to revive it.
-
-See [this doc](../docs/dev/threebuilds.md) file for an explanation.

--- a/features/com.salesforce.bazel.eclipse.feature/README.md
+++ b/features/com.salesforce.bazel.eclipse.feature/README.md
@@ -2,7 +2,7 @@
 
 This is the logical container of all the plugins related to the Bazel integration with Eclipse.
 In Eclipse, such a container is known as a *feature*.
-See the [architecture document](../docs/dev/architecture.md) for more information about features.
+See the [architecture document](../../docs/dev/architecture.md) for more information about features.
 
 ### Static Files
 
@@ -14,14 +14,3 @@ This packages contains a number of static files that are used by the Eclipse SDK
 
 As you develop the Bazel Eclipse Feature, you may need to update these files.
 Make sure to commit them back to the Git repo.
-
-### Bazel Build
-
-We currently do not use the Feature artifacts built by the [Bazel build](BUILD).
-Instead, we are relying on the Eclipse SDK to build and export the feature.
-We might use Bazel to build the feature artifacts in the future, however.
-
-We are also not using Bazel to build the feature *updatesite*, and likely never will.
-There are Bazel rules [in the repo](../tools/eclipse_updatesite) for doing this, but we have no plans to revive it.
-
-See [this doc](../docs/dev/threebuilds.md) file for an explanation.


### PR DESCRIPTION
With the Language Server move-in, I will need to do a lot of shuffling of docs. This new CI job will guard against broken links as I do that.

Also fixes 15 existing broken doc links in the repo.