### PR TITLE
launchers refer to absolute path to target

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestOptions.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestOptions.java
@@ -87,6 +87,15 @@ public class TestOptions extends HashMap<String, String> {
         return this;
     }
 
+    // add a java_binary rule to the generated java projects
+    public boolean addJavaBinary = false;
+    public static final String JAVA_BINARY_TARGET_NAME = "thejavabinary";
+
+    public TestOptions addJavaBinaryRule(boolean addBinary) {
+        addJavaBinary = addBinary;
+        return this;
+    }
+
     // just throw a random nested workspace in the mix, to test that we ignore it (see bef issue #25)
     // when we start to support nestedWorkspaces, this should default to false and only some tests will
     // test the nested workspace

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilder.java
@@ -46,10 +46,15 @@ public class BazelOutputDirectoryBuilder {
      *
      * This method returns the filesystem path to that shell script, relative to the Bazel WORKSPACE root.
      */
-    public String getRunScriptPath(BazelLabel label) {
+    public String getRunScriptPath(BazelLabel label, boolean includeBazelBin) {
         StringBuilder sb = new StringBuilder();
-        sb.append("bazel-bin");
-        sb.append(FSPathHelper.UNIX_SLASH);
+        
+        if (includeBazelBin) {
+            // if you want to generate the path from the root of the workspace, and dont mind using the bazel-bin
+            // convenience soft link, passing true for includeBazelBin will do that
+            sb.append("bazel-bin");
+            sb.append(FSPathHelper.UNIX_SLASH);
+        }
         sb.append(label.getPackagePath());
         sb.append(FSPathHelper.UNIX_SLASH);
         sb.append(label.getTargetName());

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/DetermineTargetsFlow.java
@@ -69,13 +69,12 @@ public class DetermineTargetsFlow implements ImportFlow {
             List<BazelLabel> targets = packageLocation.getBazelTargets();
             if (targets == null) {
                 ProjectStructure structure = ctx.getProjectStructure(packageLocation);
-                if (structure != null) {
-                    targets = structure.getBazelTargets();
-                } else {
-                    LOG.warn("Could not determine the project structure of package {}. Ignoring...",
+                if (structure == null) {
+                    LOG.warn("Could not determine the project structure of package [{}]. Ignoring...",
                         packageLocation.getBazelPackageFSRelativePath());
                     continue;
                 }
+                targets = structure.getBazelTargets();
             }
             packageLocationToTargets.put(packageLocation, Collections.unmodifiableList(targets));
             LOG.info("Configured targets for " + packageLocation.getBazelPackageFSRelativePath() + ": " + targets);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelLauncherBuilderTest.java
@@ -55,7 +55,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildRunCommand() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//projects/libs/javalib0"); // $SLASH_OK bazel path
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0:" + TestOptions.JAVA_BINARY_TARGET_NAME); // $SLASH_OK bazel path
         BazelTargetKind targetKind = JvmRuleInit.KIND_JAVA_BINARY;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -63,13 +63,15 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setTargetKind(targetKind);
         launcherBuilder.setArgs(Collections.emptyList());
 
-        addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0.*"), // $SLASH_OK
+        addBazelCommandOutput(env, 0,
+            FSPathHelper.osSeps(".*bin/projects/libs/javalib0/" + TestOptions.JAVA_BINARY_TARGET_NAME + ".*"), // $SLASH_OK
                 "fake bazel launcher script result");
 
         Command command = launcherBuilder.build();
         BazelProcessBuilder processBuilder = command.getProcessBuilder();
         List<String> cmdTokens = processBuilder.command();
-        String filesystemPath = FSPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
+        String filesystemPath =
+                FSPathHelper.osSeps("bin/projects/libs/javalib0/" + TestOptions.JAVA_BINARY_TARGET_NAME); // $SLASH_OK
         String commandStr = cmdTokens.get(0);
         assertTrue(commandStr.endsWith(filesystemPath) || commandStr.endsWith(filesystemPath+".exe"));
         assertFalse(cmdTokens.contains("debug"));
@@ -78,7 +80,7 @@ public class BazelLauncherBuilderTest {
     @Test
     public void testBuildRunCommandWithDebug() throws Exception {
         TestBazelCommandEnvironmentFactory env = createEnv();
-        BazelLabel label = new BazelLabel("//projects/libs/javalib0"); // $SLASH_OK bazel path
+        BazelLabel label = new BazelLabel("//projects/libs/javalib0:" + TestOptions.JAVA_BINARY_TARGET_NAME); // $SLASH_OK bazel path
         BazelTargetKind targetKind = JvmRuleInit.KIND_JAVA_BINARY;
 
         BazelLauncherBuilder launcherBuilder = env.bazelWorkspaceCommandRunner.getBazelLauncherBuilder();
@@ -87,12 +89,14 @@ public class BazelLauncherBuilderTest {
         launcherBuilder.setArgs(Collections.emptyList());
         launcherBuilder.setDebugMode(true, "localhost", DEBUG_PORT);
 
-        addBazelCommandOutput(env, 0, FSPathHelper.osSeps(".*bazel-bin/projects/libs/javalib0/javalib0.*"), // $SLASH_OK
+        addBazelCommandOutput(env, 0,
+            FSPathHelper.osSeps(".*bin/projects/libs/javalib0/" + TestOptions.JAVA_BINARY_TARGET_NAME + ".*"), // $SLASH_OK
                 "fake bazel launcher script result");
 
         List<String> cmdTokens = launcherBuilder.build().getProcessBuilder().command();
 
-        String filesystemPath = FSPathHelper.osSeps("bazel-bin/projects/libs/javalib0/javalib0"); // $SLASH_OK
+        String filesystemPath =
+                FSPathHelper.osSeps("bin/projects/libs/javalib0/" + TestOptions.JAVA_BINARY_TARGET_NAME); // $SLASH_OK
         String command = cmdTokens.get(0);
         assertTrue(command.endsWith(filesystemPath) || command.endsWith(filesystemPath+".exe"));
         assertFalse(cmdTokens.contains("debug=" + DEBUG_PORT));
@@ -196,7 +200,7 @@ public class BazelLauncherBuilderTest {
         File outputbaseDir = new File(testDir, "outputbase");
         outputbaseDir.mkdirs();
 
-        TestOptions testOptions = new TestOptions().numberOfJavaPackages(3);
+        TestOptions testOptions = new TestOptions().numberOfJavaPackages(3).addJavaBinaryRule(true);
 
         TestBazelWorkspaceDescriptor descriptor =
                 new TestBazelWorkspaceDescriptor(workspaceDir, outputbaseDir).testOptions(testOptions);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/command/BazelOutputDirectoryBuilderTest.java
@@ -45,15 +45,28 @@ public class BazelOutputDirectoryBuilderTest {
     private final BazelOutputDirectoryBuilder builder = new BazelOutputDirectoryBuilder();
 
     @Test
-    public void testGetRunScriptPath() {
+    public void testGetRunScriptPath_withBazelBin() {
         BazelLabel label = new BazelLabel("//projects/services/apple:projects/services/apple_apprun"); // $SLASH_OK bazel path
-        String path = builder.getRunScriptPath(label);
+        String path = builder.getRunScriptPath(label, true);
         String osPath = FSPathHelper.osSeps("bazel-bin/projects/services/apple/projects/services/apple_apprun"); // $SLASH_OK
         assertEquals(osPath, path);
 
         label = new BazelLabel("//projects/services/apple:test"); // $SLASH_OK bazel path
-        path = builder.getRunScriptPath(label);
+        path = builder.getRunScriptPath(label, true);
         osPath = FSPathHelper.osSeps("bazel-bin/projects/services/apple/test"); // $SLASH_OK
+        assertEquals(osPath, path);
+    }
+
+    @Test
+    public void testGetRunScriptPath_withoutBazelBin() {
+        BazelLabel label = new BazelLabel("//projects/services/apple:projects/services/apple_apprun"); // $SLASH_OK bazel path
+        String path = builder.getRunScriptPath(label, false);
+        String osPath = FSPathHelper.osSeps("projects/services/apple/projects/services/apple_apprun"); // $SLASH_OK
+        assertEquals(osPath, path);
+
+        label = new BazelLabel("//projects/services/apple:test"); // $SLASH_OK bazel path
+        path = builder.getRunScriptPath(label, false);
+        osPath = FSPathHelper.osSeps("projects/services/apple/test"); // $SLASH_OK
         assertEquals(osPath, path);
     }
 }


### PR DESCRIPTION
I was improving our test coverage for our Eclipse launchers. I saw that our launchers were using the bazel-bin convenience soft-link, instead of using the actual bazel-bin absolute path. Since everything else uses the absolute paths to bazel-out dirs, I switched the launchers to use absolute path now.