### PR TITLE
error msg when no java_test rule

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
+++ b/bundles/com.salesforce.bazel-java-sdk.testframework/src/com/salesforce/bazel/sdk/workspace/test/TestBazelWorkspaceFactory.java
@@ -236,6 +236,13 @@ public class TestBazelWorkspaceFactory {
             packageAspectFiles.add(aspectFilePath_import);
             createFakeImportJars(importLibsDir, "liborange");
             extraDeps.add(":orange");
+
+            // create an unused java_import (nothing depends on it) to see how that affects the classpath (it shouldn't)
+            aspectFilePath_import =
+                    TestAspectFileCreator.createJavaAspectFileForImportLocalJar(workspaceDescriptor.outputBaseDirectory,
+                        packageRelativeBazelPath, relativeImportLibsDir, "unsed", "libunused");
+            packageAspectFiles.add(aspectFilePath_import);
+            createFakeImportJars(importLibsDir, "libunused");
         }
 
         // main source

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java
@@ -36,12 +36,14 @@ package com.salesforce.bazel.sdk.command;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelProblem;
 
 /**
  * Parses Bazel output.
  */
 public class BazelOutputParser {
+    private static final LogHelper LOG = LogHelper.log(BazelOutputParser.class);
 
     private static final String JAVA_FILE_PATH_SUFFX = ".java";
     private boolean parsingErrors = false;
@@ -105,6 +107,13 @@ public class BazelOutputParser {
         errorSourcePathLine = null;
         moreDetailsLine = null;
         List<BazelProblem> errors = new ArrayList<>();
+
+//        LOG.info("START Bazel Command Output");
+//        for (String line : lines) {
+//            LOG.info("  > "+line);
+//        }
+//        LOG.info("END Bazel Command Output");
+        
         for (String line : lines) {
             List<BazelProblem> bazelMarkerDetails = getErrorBazelMarkerDetails(line);
             errors.addAll(bazelMarkerDetails);
@@ -139,7 +148,7 @@ public class BazelOutputParser {
             // BUILD file update error TODO
             // errorSourcePathLine: ERROR: /Users/plaird/dev/myrepo/a/b/c/BUILD:81:1: Target '//a/b/c:src/main/java/com/salesforce/jetty/Foo.java' contains an error and its package is in error and referenced by '//a/b/d:f'
             // moreDetailsLine: null
-            System.err.println("Failed to parse line: " + errorSourcePathLine + " with details: " + moreDetailsLine);
+            LOG.error("Failed to parse line: " + errorSourcePathLine + " with details: " + moreDetailsLine);
             description = "BUILD file error";
         }
         return BazelProblem.createError(sourcePath, lineNumber, description);

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectProcessor.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/internal/BazelWorkspaceAspectProcessor.java
@@ -409,15 +409,20 @@ public class BazelWorkspaceAspectProcessor {
     public static Map<BazelLabel, AspectTargetInfo> loadAspectFilePaths(List<String> aspectFilePaths)
             throws IOException, InterruptedException {
         Map<String, AspectTargetInfo> lToAtis = AspectTargetInfoFactory.loadAspectFilePaths(aspectFilePaths);
+        if (lToAtis.isEmpty()) {
+            LOG.error("No results returned from running aspects. This normally means there is a build error in the BUILD file. Please run 'bazel build //...' to verify that the workspace is valid.");
+        }
         Map<BazelLabel, AspectTargetInfo> bzToAtis = new HashMap<>(lToAtis.size());
         for (Map.Entry<String, AspectTargetInfo> e : lToAtis.entrySet()) {
             String key = e.getKey();
             if (key == null) {
                 // bug
+                LOG.error("Null key returned from AspectTargetInfoFactory.loadAspectFilePaths");
                 continue;
             }
             AspectTargetInfo value = e.getValue();
             bzToAtis.put(new BazelLabel(key), value);
+            LOG.debug("Aspect for {} generated successfully.", key);
         }
         return bzToAtis;
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmTestClasspathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmTestClasspathHelper.java
@@ -229,8 +229,9 @@ public class BazelJvmTestClasspathHelper {
         // we can now sanity check the request - does this test class even have java_test target?
         if (labels.size() == 0) {
             // no, this is a dangling test class without a java_test rule
-            LOG.error("The test class {} does not have a target defined in the BUILD file.", className);
-            return paramFiles;
+            String message = "The test class "+className+" does not have a java_test target defined in the BUILD file.";
+            LOG.error(message);
+            throw new IllegalStateException(message);
         }
 
         // TODO we can have multiple labels if the same test class is used multiple times in a BUILD file? perhaps with different resource files to test different cases? figure this out


### PR DESCRIPTION
If a java test class is not covered by a java_test rule, we should put up a nice error message instead of class not found.