### PR TITLE
rewire error parsing and expose BUILD file errors as Problems

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/ArgumentSplitter.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/ArgumentSplitter.java
@@ -34,7 +34,7 @@
 package com.salesforce.bazel.sdk.command;
 
  import java.util.ArrayList;
- import java.util.List;
+import java.util.List;
 
  public class ArgumentSplitter {
 
@@ -49,4 +49,5 @@ package com.salesforce.bazel.sdk.command;
          }
          return args;
      }
- }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/command/BazelOutputParser.java
@@ -40,41 +40,198 @@ import com.salesforce.bazel.sdk.logging.LogHelper;
 import com.salesforce.bazel.sdk.model.BazelProblem;
 
 /**
- * Parses Bazel output.
+ * Parses Bazel output. 
  */
 public class BazelOutputParser {
+    // TODO LOGGING TO stdout/err doesnt work here because the command runner output is redirected
     private static final LogHelper LOG = LogHelper.log(BazelOutputParser.class);
 
+    private static enum FailureType {
+        BUILD_FILE,
+        JAVA_FILE,
+        UNKNOWN;
+    }
+
+    public List<BazelProblem> convertErrorOutputToProblems(List<String> stderrOutputLines) {
+        List<BazelProblem> problems = null;
+
+        FailureType failType = assessFailureType(stderrOutputLines);
+        switch (failType) {
+        case BUILD_FILE:
+            problems = parseBuildFileErrorsAsProblems(stderrOutputLines);
+            break;
+        case JAVA_FILE:
+            problems = parseJavaFileErrorsAsProblems(stderrOutputLines);
+            break;
+        default:
+            problems = new ArrayList<>();
+            if (stderrOutputLines.size() > 0) {
+                // create a generic error entry, hopefully the user can make sense of it
+                problems.add(BazelProblem.createError("", 1, stderrOutputLines.get(0)));
+            }
+            break;
+        }
+            
+        return problems;
+    }
+    
+    // GENERAL PURPOSE HELPER UTILS FOR ALL FAILURE TYPES
+    
+    private FailureType assessFailureType(List<String> stderrOutputLines) {
+        
+        // TODO is there a more robust way to determining the type of package build failure rather than string matches?
+        for (String line : stderrOutputLines) {
+            if (line.startsWith("ERROR: error loading package")) {
+                return FailureType.BUILD_FILE;
+            }
+            if (line.contains(".java:")) {
+                return FailureType.JAVA_FILE;
+            }
+        }
+        
+        return FailureType.UNKNOWN;
+    }
+    
+    boolean isErrorStatusLine(String line) {
+        return line.startsWith("ERROR:");
+    }
+
+    boolean isNonErrorStatusLine(String line) {
+        return isInfoStatusLine(line) || isFailedStatusLine(line);
+    }
+
+    boolean isInfoStatusLine(String line) {
+        return line.startsWith("INFO:");
+    }
+
+    boolean isFailedStatusLine(String line) {
+        return line.startsWith("FAILED:");
+    }
+
+    protected String capitalize(String s) {
+        if (s.length() > 1) {
+            return s.substring(0, 1).toUpperCase() + s.substring(1);
+        }
+        return s;
+    }
+    
+    /**
+     * Slice a standard error line of the form:
+     * 
+     * ERROR: [filepath]:[linenumber]:[column]: [description]
+     * 
+     * and create a BazelProblem and add it to the list.
+     */
+    public void sliceErrorLine(String line, List<BazelProblem> problemList) {
+        // strip 'ERROR: '
+        line = line.substring(7);
+
+        // isolate filename
+        int colon = line.indexOf(":");
+        if (colon == -1) {
+            problemList.add(BazelProblem.createError("", 1, line.trim()));
+            return;
+        }
+        String filename = line.substring(0, colon);
+        
+        // isolate line number
+        line = line.substring(colon+1);
+        colon = line.indexOf(":");
+        if (colon == -1) {
+            problemList.add(BazelProblem.createError(filename, 1, line.trim()));
+            return;
+        }
+        String lineNumberStr = line.substring(0, colon);
+        int lineNumber = 1;
+        try {
+            lineNumber = Integer.parseInt(lineNumberStr);
+        } catch (Exception anyE) {}
+        
+        // isolate description
+        line = line.substring(colon+1);
+        colon = line.indexOf(":");
+        if (colon != -1) {
+            line = line.substring(colon+1);
+        }
+        
+        // create the problem
+        problemList.add(BazelProblem.createError(filename, lineNumber, line.trim()));
+        
+    }
+    
+    // BUILD FILE FAILURES
+    
+    List<BazelProblem> parseBuildFileErrorsAsProblems(List<String> stderrOutputLines) { 
+        List<BazelProblem> problems = new ArrayList<>();
+
+        for (String line : stderrOutputLines) {
+            parseBuildFileErrorLine(line, problems);
+        }
+        return problems;
+    }
+    
+    
+    // ERROR: /Users/plaird/dev/bazel-demo/main_usecases/java/simplejava-mvninstall/projects/libs/apple/apple-api/BUILD:16:5: positional argument may not follow keyword argument
+    // ERROR: /Users/plaird/dev/bazel-demo/main_usecases/java/simplejava-mvninstall/projects/libs/apple/apple-api/BUILD:16:5: name 'xyx' is not defined
+    // ERROR: error loading package 'projects/libs/apple/apple-api': Package 'projects/libs/apple/apple-api' contains errors
+
+    private void parseBuildFileErrorLine(String line, List<BazelProblem> problemList) {
+        if (!isErrorStatusLine(line)) {
+            return;
+        }
+        if (line.startsWith("ERROR: error loading package")) {
+            // this is just a summary of the error, the previous lines had the details
+            return;
+        }
+        
+        // parse the error line and create a Problem record
+        sliceErrorLine(line, problemList);
+    }
+    
+    // JAVA SOURCE FILE FAILURES
+    
+    // TODO refactor (remove stateful variables) and move this Java error parsing out to a jvm specific package
     private static final String JAVA_FILE_PATH_SUFFX = ".java";
-    private boolean parsingErrors = false;
+    private boolean haveSkippedFirstLine = false;
     private String errorSourcePathLine = null;
     private String moreDetailsLine = null;
+    
 
-    public List<BazelProblem> getErrorBazelMarkerDetails(String latestLine) {
-        List<BazelProblem> allBazelMarkerDetails = new ArrayList<>();
-        String line = latestLine.trim();
-        if (parsingErrors) {
+    List<BazelProblem> parseJavaFileErrorsAsProblems(List<String> stderrOutputLines) {
+        List<BazelProblem> problems = new ArrayList<>();
+
+        for (String line : stderrOutputLines) {
+            parseJavaFileErrorLine(line, problems);
+        }
+        return problems;
+    }
+    
+    private void parseJavaFileErrorLine(String line, List<BazelProblem> problemList) {
+        line = line.trim();
+        
+        // the first error line in a Java file failure output is contains confusing information and should be skipped
+        if (haveSkippedFirstLine) {
             if (line.isEmpty()) {
                 if (errorSourcePathLine != null) {
-                    allBazelMarkerDetails.add(buildErrorDetails(errorSourcePathLine, moreDetailsLine));
+                    problemList.add(buildProblemDetailsForJavaError(errorSourcePathLine, moreDetailsLine));
                     errorSourcePathLine = null;
                     moreDetailsLine = null;
                 }
             }
 
-            else if (isInitialErrorSourcePathLine(line)) {
+            else if (isInitialJavaErrorSourcePathLine(line)) {
                 if (errorSourcePathLine == null) {
                     errorSourcePathLine = line;
                 } else {
-                    allBazelMarkerDetails.add(buildErrorDetails(errorSourcePathLine, moreDetailsLine));
+                    problemList.add(buildProblemDetailsForJavaError(errorSourcePathLine, moreDetailsLine));
                     errorSourcePathLine = line;
                     moreDetailsLine = null;
                 }
 
             } else if (isNonErrorStatusLine(line)) {
-                parsingErrors = false;
+                haveSkippedFirstLine = false;
                 if (errorSourcePathLine != null) {
-                    allBazelMarkerDetails.add(buildErrorDetails(errorSourcePathLine, moreDetailsLine));
+                    problemList.add(buildProblemDetailsForJavaError(errorSourcePathLine, moreDetailsLine));
                     errorSourcePathLine = null;
                     moreDetailsLine = null;
                 }
@@ -89,41 +246,24 @@ public class BazelOutputParser {
             }
         } else {
             if (isErrorStatusLine(line)) {
-                parsingErrors = true;
+                haveSkippedFirstLine = true;
             }
         }
 
         if (moreDetailsLine != null) {
-            allBazelMarkerDetails.add(buildErrorDetails(errorSourcePathLine, moreDetailsLine));
+            problemList.add(buildProblemDetailsForJavaError(errorSourcePathLine, moreDetailsLine));
             errorSourcePathLine = null;
             moreDetailsLine = null;
         }
-
-        return allBazelMarkerDetails;
     }
 
-    public List<BazelProblem> getErrors(List<String> lines) {
-        parsingErrors = false;
-        errorSourcePathLine = null;
-        moreDetailsLine = null;
-        List<BazelProblem> errors = new ArrayList<>();
-
-//        LOG.info("START Bazel Command Output");
-//        for (String line : lines) {
-//            LOG.info("  > "+line);
-//        }
-//        LOG.info("END Bazel Command Output");
-        
-        for (String line : lines) {
-            List<BazelProblem> bazelMarkerDetails = getErrorBazelMarkerDetails(line);
-            errors.addAll(bazelMarkerDetails);
-        }
-        return errors;
-    }
-
-    private BazelProblem buildErrorDetails(String errorSourcePathLine, String moreDetailsLine) {
+    private BazelProblem buildProblemDetailsForJavaError(String errorSourcePathLine, String moreDetailsLine) {
         String sourcePath = "";
         int lineNumber = 1;
+        
+        // Java Compilation Error looks like this, written on its own line:
+        // projects/libs/apple/apple-api/src/main/java/demo/apple/api/Apple.java:55: error: ';' expected
+        
         String description = moreDetailsLine;
         try {
             int i = errorSourcePathLine.lastIndexOf(JAVA_FILE_PATH_SUFFX);
@@ -145,7 +285,6 @@ public class BazelOutputParser {
                 description += ": " + moreDetailsLine;
             }
         } catch (Exception anyE) {
-            // BUILD file update error TODO
             // errorSourcePathLine: ERROR: /Users/plaird/dev/myrepo/a/b/c/BUILD:81:1: Target '//a/b/c:src/main/java/com/salesforce/jetty/Foo.java' contains an error and its package is in error and referenced by '//a/b/d:f'
             // moreDetailsLine: null
             LOG.error("Failed to parse line: " + errorSourcePathLine + " with details: " + moreDetailsLine);
@@ -154,31 +293,9 @@ public class BazelOutputParser {
         return BazelProblem.createError(sourcePath, lineNumber, description);
     }
 
-    private boolean isInitialErrorSourcePathLine(String line) {
+    private boolean isInitialJavaErrorSourcePathLine(String line) {
         return line.lastIndexOf(JAVA_FILE_PATH_SUFFX) != -1;
     }
 
-    boolean isErrorStatusLine(String line) {
-        return line.startsWith("ERROR:");
-    }
-
-    boolean isNonErrorStatusLine(String line) {
-        return isInfoStatusLine(line) || isFailedStatusLine(line);
-    }
-
-    boolean isInfoStatusLine(String line) {
-        return line.startsWith("INFO:");
-    }
-
-    boolean isFailedStatusLine(String line) {
-        return line.startsWith("FAILED:");
-    }
-
-    private static String capitalize(String s) {
-        if (s.length() > 1) {
-            return s.substring(0, 1).toUpperCase() + s.substring(1);
-        }
-        return s;
-    }
 
 }

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/builder/BazelErrorPublisherTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/builder/BazelErrorPublisherTest.java
@@ -58,14 +58,15 @@ public class BazelErrorPublisherTest {
 
     @Test
     public void testUnassignedErrors() throws Exception {
+        IProject rootProject = getMockedProject("ROOT").getProject();
         IProject project1 = getMockedProject("P1").getProject();
         BazelLabel l1 = new BazelLabel("projects/libs/lib1:*"); // $SLASH_OK: bazel path
+        Map<BazelLabel, BazelProject> labelToProject = Collections.singletonMap(l1, new BazelProject("P1", project1));
+
         BazelProblem error1 =
                 BazelProblem.createError(FSPathHelper.osSeps("projects/libs/lib1/src/Test.java"), 21, "foo"); // $SLASH_OK
-        Map<BazelLabel, BazelProject> labelToProject = Collections.singletonMap(l1, new BazelProject("P1", project1));
         BazelProblem error2 =
                 BazelProblem.createError(FSPathHelper.osSeps("projects/libs/lib2/src/Test2.java"), 22, "blah"); // $SLASH_OK
-        IProject rootProject = getMockedProject("ROOT").getProject();
 
         Map<IProject, List<BazelProblem>> projectToErrors = BazelErrorPublisher
                 .assignErrorsToOwningProject(Arrays.asList(error1, error2), labelToProject, rootProject);


### PR DESCRIPTION
This PR allows BUILD file errors to surface in the Problems view #141. We were also swallowing unhandled build errors, they will now blow back into the UI.

I was working on this for a few days, there was some refactoring and more complexity about resolving paths than expected.