### PR TITLE
retain last location in import wizard dialog

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardLocationControl.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardLocationControl.java
@@ -66,7 +66,7 @@ public class BazelImportWizardLocationControl {
     protected Combo rootDirectoryCombo;
 
     private String rootDirectory;
-    protected List<String> rootDirHistoryList = new ArrayList<>();
+    protected static List<String> rootDirHistoryList = new ArrayList<>();
 
     protected IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 
@@ -83,7 +83,8 @@ public class BazelImportWizardLocationControl {
         }
     }
 
-    public void addLocationControl(Composite composite) {
+    public boolean addLocationControl(Composite composite) {
+        boolean hasLocationOnCreate = false;
         fieldsWithHistory = new HashMap<String, List<Combo>>();
 
         if (rootDirectoryCombo == null) {
@@ -98,6 +99,7 @@ public class BazelImportWizardLocationControl {
         if (!rootDirHistoryList.isEmpty()) {
             rootDirectoryCombo.setText(rootDirHistoryList.get(0));
             rootDirectory = rootDirHistoryList.get(0);
+            hasLocationOnCreate = true;
         }
         rootDirectoryCombo.setFocus();
 
@@ -181,6 +183,8 @@ public class BazelImportWizardLocationControl {
                 }
             }
         });
+
+        return hasLocationOnCreate;
     }
 
     protected String getRootDirectory() {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -72,7 +72,7 @@ public class BazelImportWizardPage extends WizardPage {
 
         IPreferenceStore prefs = BazelPluginActivator.getInstance().getPreferenceStore();
         locationControl = new BazelImportWizardLocationControl(this, prefs);
-        locationControl.addLocationControl(composite);
+        boolean scanAfterBuild = locationControl.addLocationControl(composite);
 
         labelProvider = new BazelImportWizardLabelProvider(this);
 
@@ -84,6 +84,10 @@ public class BazelImportWizardPage extends WizardPage {
 
         advancedSettingsControl = new BazelImportWizardAdvancedSettingsControl(this);
         advancedSettingsControl.addAdvancedSettingsControl(composite);
+
+        if (scanAfterBuild) {
+            scanProjects();
+        }
     }
 
     /**
@@ -130,7 +134,7 @@ public class BazelImportWizardPage extends WizardPage {
                 }
             }
 
-            locationControl.rootDirHistoryList = newFilesystemLocations;
+            BazelImportWizardLocationControl.rootDirHistoryList = newFilesystemLocations;
 
             setPageComplete();
             setErrorMessage(null);


### PR DESCRIPTION
basic ui stuff; when the user opens the import dialog a second time, load the last workspace directory path from the first time through the dialog