### PR TITLE
fix BEF project open when there is no prefs file

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/BazelJvmClasspath.java
@@ -185,7 +185,7 @@ public class BazelJvmClasspath implements JvmClasspath {
                     String targetInfoLabelPath = jvmTargetInfo.getLabelPath();
                     String kind = jvmTargetInfo.getKind();
                     if ("java_import".equals(kind)) {
-                        logger.info("Found java_import rule");
+                        logger.info("Found java_import target with label {}", targetInfoLabelPath);
                     }
 
                     if (actualActivatedTargets.contains(targetInfoLabelPath)) {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProject.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/BazelProject.java
@@ -90,6 +90,10 @@ public class BazelProject {
     public ProjectStructure getProjectStructure() {
         return projectStructure;
     }
+    
+    public List<BazelPackageInfo> getProjectPackages() {
+        return bazelPackages;
+    }
 
     /**
      * Merges this project with the passed project. For each element, this project will win out if it has meaningful

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizardPage.java
@@ -72,7 +72,7 @@ public class BazelImportWizardPage extends WizardPage {
 
         IPreferenceStore prefs = BazelPluginActivator.getInstance().getPreferenceStore();
         locationControl = new BazelImportWizardLocationControl(this, prefs);
-        boolean scanAfterBuild = locationControl.addLocationControl(composite);
+        boolean hasWorkspaceLocation = locationControl.addLocationControl(composite);
 
         labelProvider = new BazelImportWizardLabelProvider(this);
 
@@ -85,7 +85,9 @@ public class BazelImportWizardPage extends WizardPage {
         advancedSettingsControl = new BazelImportWizardAdvancedSettingsControl(this);
         advancedSettingsControl.addAdvancedSettingsControl(composite);
 
-        if (scanAfterBuild) {
+        if (hasWorkspaceLocation) {
+            // this dialog had been opened before, and a Bazel workspace path from history was
+            // loaded into the view; populate the dialog and mark the ones not already open for import
             scanProjects();
         }
     }


### PR DESCRIPTION
Resolves a bug when user opens a project and the prefs file is not available to list the configured targets.