### PR TITLE
BEF make import fail if Bazel build fails

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -352,7 +352,6 @@ public class BazelPluginActivator extends AbstractUIPlugin {
         // now forget about the workspace
         bazelWorkspace = null;
         bazelWorkspaceCommandRunner = null;
-        configurationManager.setBazelWorkspacePath(null);
     }
 
     // TEST ONLY

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
@@ -44,6 +44,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
@@ -136,6 +137,12 @@ public class EclipseResourceHelper implements ResourceHelper {
 
         if (eclipseProjectPrefs == null) {
             LOG.error("Could not find the Preferences node for the Bazel plugin for project [{}]", project.getName());
+        }
+
+        try {
+            eclipseProjectPrefs.sync();
+        } catch (BackingStoreException bse) {
+            LOG.error("Could not read Eclipse preferences for project [{}]", project.getName(), bse);
         }
 
         return eclipseProjectPrefs;
@@ -279,7 +286,7 @@ public class EclipseResourceHelper implements ResourceHelper {
             IProgressMonitor monitor) {
         try {
             LOG.debug("createFolderLink: thisFolder=" + thisFolder.getLocation().toOSString()
-                    + " bazelWorkspaceLocation=" + bazelWorkspaceLocation.toOSString());
+                + " bazelWorkspaceLocation=" + bazelWorkspaceLocation.toOSString());
             thisFolder.createLink(bazelWorkspaceLocation, updateFlags, monitor);
         } catch (Exception anyE) {
             throw new IllegalArgumentException(anyE);


### PR DESCRIPTION
We aren't doing anyone any favors by completing the import, and not populating the classpath containers. This was what was happening if the underlying Bazel workspace did not build correctly (e.g. compile error), during import. Make the import just fail in this case.