### PR TITLE
compute bazel label for indexed external jars

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndex.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndex.java
@@ -99,7 +99,7 @@ public class JvmCodeIndex extends CodeIndex {
 
         // now build the index
         for (File location : locations) {
-            processLocation(index, location, progressMonitor);
+            processLocation(bazelWorkspace, externalJarRuleManager, index, location, progressMonitor);
         }
 
         workspaceIndices.put(bazelWorkspace.getName(), index);
@@ -109,10 +109,11 @@ public class JvmCodeIndex extends CodeIndex {
 
     }
 
-    static void processLocation(JvmCodeIndex index, File location, WorkProgressMonitor progressMonitor) {
+    static void processLocation(BazelWorkspace bazelWorkspace, BazelExternalJarRuleManager externalJarRuleManager, JvmCodeIndex index, 
+            File location, WorkProgressMonitor progressMonitor) {
         if ((location != null) && location.exists()) {
             JarIdentiferResolver jarResolver = new JarIdentiferResolver();
-            JavaJarCrawler jarCrawler = new JavaJarCrawler(index, jarResolver);
+            JavaJarCrawler jarCrawler = new JavaJarCrawler(bazelWorkspace, index, jarResolver, externalJarRuleManager);
             jarCrawler.index(location, false);
         }
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
@@ -32,7 +32,10 @@ import java.util.zip.ZipFile;
 import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
 import com.salesforce.bazel.sdk.index.model.ClassIdentifier;
 import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
+import com.salesforce.bazel.sdk.lang.jvm.external.BazelExternalJarRuleManager;
+import com.salesforce.bazel.sdk.lang.jvm.external.BazelExternalJarRuleType;
 import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
 import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 /**
@@ -41,12 +44,16 @@ import com.salesforce.bazel.sdk.path.FSPathHelper;
 public class JavaJarCrawler {
     private static final LogHelper LOG = LogHelper.log(JavaJarCrawler.class);
 
+    private BazelWorkspace bazelWorkspace;
     private final JvmCodeIndex index;
     private final JarIdentiferResolver resolver;
+    private BazelExternalJarRuleManager externalJarRuleManager;
 
-    public JavaJarCrawler(JvmCodeIndex index, JarIdentiferResolver resolver) {
+    public JavaJarCrawler(BazelWorkspace bazelWorkspace, JvmCodeIndex index, JarIdentiferResolver resolver, BazelExternalJarRuleManager externalJarRuleManager) {
+        this.bazelWorkspace = bazelWorkspace;
         this.index = index;
         this.resolver = resolver;
+        this.externalJarRuleManager = externalJarRuleManager; 
     }
 
     public void index(File basePath, boolean doIndexClasses) {
@@ -110,7 +117,13 @@ public class JavaJarCrawler {
             // this jar is not part of the typical dependencies (e.g. it is a jar used in the build toolchain); ignore
             return;
         }
-        CodeLocationDescriptor jarLocationDescriptor = new CodeLocationDescriptor(jarFile, jarId);
+        String bazelLabel = null;
+        String absoluteFilepath = jarFile.getAbsolutePath();
+        BazelExternalJarRuleType ruleType = externalJarRuleManager.findOwningRuleType(bazelWorkspace, absoluteFilepath);
+        if (ruleType != null) {
+            bazelLabel = ruleType.deriveBazelLabel(bazelWorkspace, absoluteFilepath, jarId);
+        }
+        CodeLocationDescriptor jarLocationDescriptor = new CodeLocationDescriptor(jarFile, jarId, bazelLabel);
 
         // add to our index using artifact name
         index.addArtifactLocation(jarId.artifact, jarLocationDescriptor);

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptor.java
@@ -32,7 +32,8 @@ import java.util.List;
  * form.
  */
 public class CodeLocationDescriptor {
-    public CodeLocationIdentifier id;
+    public CodeLocationIdentifier id; // e.g. org.slf4j:slf4j-api:1.3.4
+    public String bazelLabel; // e.g. @maven//:org_slf4j_slf4j_api
     public File locationOnDisk;
     public List<ClassIdentifier> containedClasses;
 
@@ -41,6 +42,12 @@ public class CodeLocationDescriptor {
         this.id = id;
     }
 
+    public CodeLocationDescriptor(File locationOnDisk, CodeLocationIdentifier id, String bazelLabel) {
+        this.locationOnDisk = locationOnDisk;
+        this.id = id;
+        this.bazelLabel = bazelLabel;
+    }
+    
     public void addClass(ClassIdentifier classId) {
         if (containedClasses == null) {
             containedClasses = new ArrayList<>(5);

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/external/BazelExternalJarRuleManager.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/external/BazelExternalJarRuleManager.java
@@ -111,4 +111,15 @@ public class BazelExternalJarRuleManager {
         return inUseRuleTypes;
     }
 
+    /**
+     * Find the rule type that downloaded the passed file
+     */
+    public BazelExternalJarRuleType findOwningRuleType(BazelWorkspace bazelWorkspace, String absoluteFilepath) {
+        for (BazelExternalJarRuleType type : availableTypes.values()) {
+            if (type.doesBelongToRuleType(bazelWorkspace, absoluteFilepath)) {
+                return type;
+            }
+        }
+        return null;
+    }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/external/BazelExternalJarRuleType.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/lang/jvm/external/BazelExternalJarRuleType.java
@@ -36,7 +36,8 @@ package com.salesforce.bazel.sdk.lang.jvm.external;
  import java.io.File;
  import java.util.List;
 
- import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.index.jvm.jar.JarIdentifier;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
  import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
 
  /**
@@ -92,6 +93,22 @@ package com.salesforce.bazel.sdk.lang.jvm.external;
       * discard the work for all workspaces.
       */
      public void discardComputedWork(BazelWorkspace bazelWorkspace) {
-
      }
+     
+     /**
+      * Is the passed file path a file downloaded by this rule type?
+      */
+     public boolean doesBelongToRuleType(BazelWorkspace bazelWorkspace, String absoluteFilepath) {
+         return false;
+     }
+
+     /**
+      * Attempt to derive the Bazel label for this external jar file based solely on filepath.
+      * \@maven//:org_slf4j_slf4j_api
+      * This won't be possible in all cases; returning null is acceptable.
+      */
+     public String deriveBazelLabel(BazelWorkspace bazelWorkspace, String absoluteFilepath, JarIdentifier jarId) {
+         return null;
+     }
+
  }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/path/FSPathHelper.java
@@ -221,6 +221,16 @@ public final class FSPathHelper {
         }
         return "";
     }
+    
+    /**
+     * Splits the passed absolute or relative path using the correct OS specific regex
+     */
+    public static String[] split(String filesystemPath) {
+        if (isUnix) {
+            return filesystemPath.split(UNIX_SLASH_REGEX);
+        }
+        return filesystemPath.split(WINDOWS_BACKSLASH_REGEX);
+    }
 
     /**
      * Utility to find all files in a tree with a particular extension.


### PR DESCRIPTION
Iterative work towards Autodeps implementation. We need to compute and track the Bazel label for each external jar, since we will need to add the label to the target that needs the dep. The hardest part of this is figuring out the maven_install namespace.