### PR TITLE
hook into JDT to propose BUILD file update for Autodeps

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndex.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndex.java
@@ -27,9 +27,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.salesforce.bazel.sdk.index.CodeIndex;
+import com.salesforce.bazel.sdk.index.CodeIndexEntry;
 import com.salesforce.bazel.sdk.index.jvm.jar.JarIdentiferResolver;
 import com.salesforce.bazel.sdk.index.jvm.jar.JavaJarCrawler;
 import com.salesforce.bazel.sdk.lang.jvm.external.BazelExternalJarRuleManager;
@@ -43,10 +45,13 @@ import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
  * types. This is useful for tools that need to have a full list of available JVM types. For example, a Bazel IDE will
  * want to be able to list all types imported by the workspace.
  * <p>
- * There are two parts to the index: the artifactDictionary and the typeDictionary.
+ * There are three parts to the index: the artifactDictionary, fileDictionary and the typeDictionary.
  * <p>
- * The artifactDictionary maps the Maven style artifactId to the one or more jar files found that contains that
- * artifactId. If your directories contains multiple versions of the same artifactId, this will be a list of artifacts.
+ * The artifactDictionary maps the Maven style artifactId (e.g. junit, hamcrest-core, slf4j-api) to the one or more jar 
+ * files found that contains that artifactId. If your directories contains multiple versions of the same artifactId, this 
+ * will be a list of artifacts.
+ * <p>
+ * The fileDictionary maps the filename (e.g. junit-4.12.jar) to the one or more locations where that filename was found.
  * <p>
  * The typeDictionary maps each found classname to the discovered location in jar files or raw source files.
  * <p>
@@ -56,8 +61,17 @@ import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
 public class JvmCodeIndex extends CodeIndex {
     private static final LogHelper LOG = LogHelper.log(JvmCodeIndex.class);
 
+    /**
+     * Global collection of indices for each workspace
+     */
     protected static Map<String, JvmCodeIndex> workspaceIndices = new ConcurrentHashMap<>();
 
+    // See superclass for the collections
+    //public Map<String, CodeIndexEntry> artifactDictionary = new TreeMap<>();
+    //public Map<String, CodeIndexEntry> fileDictionary = new TreeMap<>();
+    //public Map<String, CodeIndexEntry> typeDictionary = new TreeMap<>();
+
+    
     public static JvmCodeIndex getWorkspaceIndex(BazelWorkspace bazelWorkspace) {
         return workspaceIndices.get(bazelWorkspace.getName());
     }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawler.java
@@ -109,10 +109,10 @@ public class JavaJarCrawler {
         }
     }
 
-    protected void foundJar(File gavRoot, File jarFile, ZipFile zipFile, boolean doIndexClasses) {
+    protected void foundJar(File gavRootDir, File jarFile, ZipFile zipFile, boolean doIndexClasses) {
         // precisely identify the jar file
         LOG.debug("found jar: [{}]", jarFile.getName());
-        JarIdentifier jarId = resolver.resolveJarIdentifier(gavRoot, jarFile, zipFile);
+        JarIdentifier jarId = resolver.resolveJarIdentifier(gavRootDir, jarFile, zipFile);
         if (jarId == null) {
             // this jar is not part of the typical dependencies (e.g. it is a jar used in the build toolchain); ignore
             return;
@@ -125,8 +125,10 @@ public class JavaJarCrawler {
         }
         CodeLocationDescriptor jarLocationDescriptor = new CodeLocationDescriptor(jarFile, jarId, bazelLabel);
 
-        // add to our index using artifact name
+        // add to our index using artifact name (eg. junit, hamcrest-core, slf4j-api) 
         index.addArtifactLocation(jarId.artifact, jarLocationDescriptor);
+        // add to our index using file name (eg. junit-4.12.jar) 
+        index.addFileLocation(jarFile.getName(), jarLocationDescriptor);
 
         // if we don't want an index of each class found in a jar, bail here and save a lot of work
         if (!doIndexClasses) {

--- a/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
+++ b/bundles/com.salesforce.bazel.eclipse.core/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Require-Bundle: org.eclipse.ui.console;bundle-version="3.8.100.v20180821-1744",
  org.eclipse.ui.ide;bundle-version="3.14.100.v20180828-1350",
  org.eclipse.jdt.core;bundle-version="3.15.0.v20180905-0317",
  org.eclipse.jdt;bundle-version="3.11.0.v20180827-1040",
+ org.eclipse.jdt.ui;bundle-version="3.24.0",
  org.eclipse.core.resources;bundle-version="3.13.100.v20180828-0158",
  org.eclipse.debug.core;bundle-version="3.13.0.v20180821-1744",
  org.eclipse.debug.ui;bundle-version="3.13.100.v20180827-0649",
@@ -29,7 +30,8 @@ Require-Bundle: org.eclipse.ui.console;bundle-version="3.8.100.v20180821-1744",
  org.slf4j.api;bundle-version="1.7.30",
  ch.qos.logback.core;bundle-version="1.2.3",
  ch.qos.logback.classic;bundle-version="1.2.3",
- com.salesforce.bazel.eclipse.common
+ com.salesforce.bazel.eclipse.common,
+ org.eclipse.ltk.core.refactoring
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: bin/,

--- a/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
+++ b/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
@@ -26,17 +26,17 @@
          </activeWhen>
       </projectConfigurator>
    </extension>
-   
+
    <extension point="org.eclipse.jdt.launching.classpathProviders">
-      <classpathProvider 
+      <classpathProvider
           id="com.salesforce.bazel.eclipse.launchconfig.classpathProvider"
           class="com.salesforce.bazel.eclipse.launch.BazelTestClasspathProvider"/>
-      <classpathProvider 
+      <classpathProvider
           id="com.salesforce.bazel.eclipse.launchconfig.sourcepathProvider"
           class="org.eclipse.jdt.launching.StandardSourcePathProvider"/>
    </extension>
-   
-   
+
+
    <extension point="org.eclipse.ui.importWizards">
      <category id="org.eclipse.ui.Basic" name="%category.general.name"/>
      <category id="org.eclipse.bazel" name="Bazel"/>
@@ -49,8 +49,8 @@
         <description>Import Bazel Workspace</description>
      </wizard>
    </extension>
-   
-   
+
+
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
@@ -59,20 +59,20 @@
             name="Bazel">
       </page>
    </extension>
-   
+
    <extension
          point="org.eclipse.core.runtime.preferences">
       <initializer
             class="com.salesforce.bazel.eclipse.preferences.BazelPreferenceInitializer">
       </initializer>
    </extension>
-   
+
    <extension id="com.salesforce.bazel.eclipse.bazelmarker"
          point="org.eclipse.core.resources.markers">
          <super type="org.eclipse.core.resources.problemmarker"/>
          <persistent value="false"/>
     </extension>
-   
+
    <extension
          id="com.salesforce.bazel.eclipse.builder"
          point="org.eclipse.core.resources.builders">
@@ -86,7 +86,7 @@
          </run>
       </builder>
    </extension>
-   
+
    <extension
          id="com.salesforce.bazel.eclipse.launch"
          point="org.eclipse.debug.core.launchConfigurationTypes">
@@ -97,7 +97,7 @@
             name="Bazel Target">
       </launchConfigurationType>
    </extension>
-   
+
    <extension
         point="org.eclipse.debug.ui.launchConfigurationTypeImages">
         <launchConfigurationTypeImage
@@ -105,8 +105,8 @@
                 configTypeID="com.salesforce.bazel.eclipse.launch"
                 icon="resources/bazelicon.gif">
         </launchConfigurationTypeImage>
-   </extension>   
-   
+   </extension>
+
    <extension
          id="com.salesforce.bazel.eclipse.launch.tab"
          point="org.eclipse.debug.ui.launchConfigurationTabGroups">
@@ -116,7 +116,7 @@
             type="com.salesforce.bazel.eclipse.launch">
       </launchConfigurationTabGroup>
    </extension>
-   
+
    <extension
     point="org.eclipse.debug.ui.launchShortcuts">
         <shortcut
@@ -140,7 +140,7 @@
             </contextualLaunch>
         </shortcut>
    </extension>
-    
+
    <extension
          point="org.eclipse.debug.core.launchDelegates">
       <launchDelegate
@@ -152,7 +152,7 @@
             id="bazel.junit.launcher">
       </launchDelegate>
    </extension>
-   
+
    <extension
          point="org.eclipse.jdt.junit.testRunListeners">
       <testRunListener
@@ -167,13 +167,13 @@
             id="com.salesforce.bazel.eclipse.launch.shortcut.run"/>
    </extension>
    <extension point="org.eclipse.ui.bindings">
-     <key 
+     <key
          sequence="M1+M3+X B"
          contextId="org.eclipse.ui.contexts.window"
          commandId="com.salesforce.bazel.eclipse.launch.shortcut.run"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
    </extension>
-   
+
    <extension point="org.eclipse.ui.commands">
       <command
             name="Bazel Target"
@@ -185,13 +185,13 @@
          find="M4"
          replace="M2"
          platforms="gtk,motif" />
-    <key 
+    <key
          sequence="M4+M1+M3+D B"
          contextId="org.eclipse.ui.contexts.window"
          commandId="com.salesforce.bazel.eclipse.launch.shortcut.debug"
          schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
    </extension>
-   
+
    <extension point="org.eclipse.core.expressions.propertyTesters">
     <propertyTester
         id="org.eclipse.jdt.ui.IJavaElementTypeExtender"
@@ -234,5 +234,13 @@
       <projectManager
             class="com.salesforce.bazel.eclipse.config.EclipseBazelProjectManager">
       </projectManager>
+    </extension>
+    <extension
+         point="org.eclipse.jdt.ui.classpathFixProcessors">
+      <classpathFixProcessor
+            class="com.salesforce.bazel.eclipse.classpath.BazelClasspathFixProcessor"
+            id="com.salesforce.bazel.eclipse.core.bazelClasspathFixProcessor"
+            name="BazelClasspathFixProcessor">
+      </classpathFixProcessor>
    </extension>
 </plugin>

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/BazelPluginActivator.java
@@ -42,9 +42,11 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import com.salesforce.bazel.eclipse.classpath.BazelGlobalSearchClasspathContainer;
 import com.salesforce.bazel.eclipse.component.BazelAspectLocationComponentFacade;
 import com.salesforce.bazel.eclipse.component.ProjectManagerComponentFacade;
 import com.salesforce.bazel.eclipse.component.ResourceHelperComponentFacade;
+import com.salesforce.bazel.eclipse.config.BazelAspectLocationImpl;
 import com.salesforce.bazel.eclipse.config.EclipseBazelConfigurationManager;
 import com.salesforce.bazel.eclipse.project.BazelPluginResourceChangeListener;
 import com.salesforce.bazel.eclipse.runtime.api.JavaCoreHelper;
@@ -135,6 +137,11 @@ public class BazelPluginActivator extends AbstractUIPlugin {
      * Manager for working with external jars
      */
     private static BazelExternalJarRuleManager externalJarRuleManager;
+
+    /**
+     * Global search index of classes
+     */
+    private static BazelGlobalSearchClasspathContainer globalSearchContainer;
 
     // LIFECYCLE
 
@@ -352,6 +359,14 @@ public class BazelPluginActivator extends AbstractUIPlugin {
 
     public BazelExternalJarRuleManager getBazelExternalJarRuleManager() {
         return externalJarRuleManager;
+    }
+
+    public void setGlobalSearchClasspathContainer(BazelGlobalSearchClasspathContainer index) {
+        globalSearchContainer = index;
+    }
+
+    public BazelGlobalSearchClasspathContainer getGlobalSearchClasspathContainer() {
+        return globalSearchContainer;
     }
 
     // DANGER ZONE

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
@@ -227,7 +227,16 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
     private static IClasspathContainer getClasspathContainer(IProject project, boolean isRootProject)
             throws JavaModelException, IOException, InterruptedException, BackingStoreException,
             BazelCommandLineToolConfigurationException {
-        return isRootProject ? new BazelGlobalSearchClasspathContainer(project) : new BazelClasspathContainer(project);
+
+        IClasspathContainer cp = null;
+        if (isRootProject) {
+            BazelGlobalSearchClasspathContainer searchIndex = new BazelGlobalSearchClasspathContainer(project);
+            BazelPluginActivator.getInstance().setGlobalSearchClasspathContainer(searchIndex);
+            cp = searchIndex;
+        } else {
+            cp = new BazelClasspathContainer(project);
+        }
+        return cp;
     }
 
     private static void setClasspathContainerForProject(IPath projectPath, IJavaProject project,

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathFixProcessor.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathFixProcessor.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2021, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.eclipse.classpath;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
+import org.eclipse.jdt.internal.ui.text.correction.DefaultClasspathFixProcessor;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.swt.graphics.Image;
+
+import com.salesforce.bazel.eclipse.BazelPluginActivator;
+import com.salesforce.bazel.sdk.index.CodeIndexEntry;
+import com.salesforce.bazel.sdk.index.jvm.BazelJvmIndexClasspath;
+import com.salesforce.bazel.sdk.index.jvm.JvmCodeIndex;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+
+/**
+ * Class to be implemented by contributors to the extension point
+ * <code>org.eclipse.jdt.ui.classpathFixProcessors</code>.
+ *
+ * @since 3.4
+ */
+public class BazelClasspathFixProcessor extends DefaultClasspathFixProcessor {
+    private static final LogHelper LOG = LogHelper.log(BazelClasspathFixProcessor.class);
+
+    @Override
+    public ClasspathFixProposal[] getFixImportProposals(IJavaProject javaProject, String missingType) throws CoreException {
+        IProject iproject = javaProject.getProject();
+        LOG.info("Invoked BazelClasspathFixProcessor for project {} and missingType {}", iproject.getName(),
+            missingType);
+
+        // super does some heavy lifting, it tracks down the missing type to the correct jar
+        ClasspathFixProposal[] proposals = super.getFixImportProposals(javaProject, missingType);
+
+        if (proposals.length == 0) {
+            return proposals;
+        }
+        BazelPluginActivator activator = BazelPluginActivator.getInstance();
+        if (!activator.getConfigurationManager().isGlobalClasspathSearchEnabled()) {
+            // no point in trying to improve on the advice, since we dont have the search index
+            return proposals;
+        }
+
+        // often Eclipse will see multiple paths to the same jar, which emits multiple proposals, just use the first
+        ClasspathFixProposal proposal = rewriteProposal(iproject, missingType, proposals[0]);
+
+        return new ClasspathFixProposal[] { proposal };
+    }
+
+    private ClasspathFixProposal rewriteProposal(IProject iproject, String missingType, ClasspathFixProposal proposal) {
+        // Add archive 'guava-23.0.jar - /private/var/tmp/_bazel_plaird/21626313aa1530b4323d3b57fdf300e9/external/maven/v1/https/repo1.maven.org/maven2/com/google/guava/guava/23.0' to build path of 'old-guava'
+        String pText = proposal.getDisplayString();
+        if (pText.startsWith("Add archive '")) {
+            int endOfJar = pText.indexOf(" ", 14);
+            String jarName = pText.substring(13, endOfJar);
+
+            // get access to the underlying index data
+            BazelPluginActivator activator = BazelPluginActivator.getInstance();
+            BazelGlobalSearchClasspathContainer searchContainer = activator.getGlobalSearchClasspathContainer();
+            BazelJvmIndexClasspath indexCP = searchContainer.getIndexClasspath();
+            JvmCodeIndex index = indexCP.getIndex(null);
+
+            CodeIndexEntry indexEntry = index.fileDictionary.get(jarName);
+            String bazelLabel = null;
+            if (indexEntry != null) {
+                if (indexEntry.singleLocation != null) {
+                    bazelLabel = indexEntry.singleLocation.bazelLabel;
+                } else if (indexEntry.multipleLocations.size() > 0) {
+                    bazelLabel = indexEntry.multipleLocations.get(0).bazelLabel;
+                }
+                if (bazelLabel != null) {
+                    LOG.info("Found Bazel label {} for project {} and missingType {}", bazelLabel, iproject.getName(),
+                        missingType);
+                    BazelClasspathFixProposal newProposal = new BazelClasspathFixProposal(proposal);
+                    newProposal.fRelevance = 1;
+                    newProposal.fName =
+                            "Bazel BUILD fix: add " + bazelLabel + " to the target in the [" + iproject.getName()
+                            + "] project.";
+                    proposal = newProposal;
+                }
+            }
+        }
+        return proposal;
+    }
+
+    protected static class BazelClasspathFixProposal extends ClasspathFixProposal {
+
+        public String fName;
+        public Change fChange;
+        public String fDescription;
+        public int fRelevance;
+
+        public BazelClasspathFixProposal(String name, Change change, String description, int relevance) {
+            fName = name;
+            fChange = change;
+            fDescription = description;
+            fRelevance = relevance;
+        }
+
+        public BazelClasspathFixProposal(ClasspathFixProposal clone) {
+            fName = clone.getDisplayString();
+            fDescription = clone.getAdditionalProposalInfo();
+            fRelevance = clone.getRelevance();
+
+            try {
+                fChange = clone.createChange(null);
+            } catch (Exception anyE) {}
+        }
+
+        @Override
+        public String getAdditionalProposalInfo() {
+            return fDescription;
+        }
+
+        @Override
+        public Change createChange(IProgressMonitor monitor) {
+            return fChange;
+        }
+
+        @Override
+        public String getDisplayString() {
+            return fName;
+        }
+
+        @Override
+        public Image getImage() {
+            return JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+        }
+
+        @Override
+        public int getRelevance() {
+            return fRelevance;
+        }
+    }
+}

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelGlobalSearchClasspathContainer.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelGlobalSearchClasspathContainer.java
@@ -147,6 +147,14 @@ public class BazelGlobalSearchClasspathContainer extends BaseBazelClasspathConta
     }
 
     /**
+     * Returns a copy of the underlying index classpath. This is provided so the caller may do inquiries into the data.
+     * Callers are not expected to modify this index.
+     */
+    public BazelJvmIndexClasspath getIndexClasspath() {
+        return bazelJvmIndexClasspath;
+    }
+
+    /**
      * Uses the preference store in Eclipse to get additional locations in which to look for jars.
      */
     public static List<File> loadAdditionalLocations() {


### PR DESCRIPTION
Autodeps is starting to take shape. In this PR we can now query the global search index to retrieve the Bazel label of the jar that needs to be added. 

This PR also uses an Eclipse extension point to hook into JDT to get notified when there is a type that Eclipse detects is in the Eclipse Workspace but not added to the project classpath. BazelClasspathFixProcessor is the JDT hook implementation, and presents the solution to the user ("add jar @maven//:XYZ to the BUILD target"). 

The next step is to automatically apply the fix to the right target in the right build file. This will take some effort, as there are a number of complexities.