### PR TITLE
Fix import error when project is closed

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseResourceHelper.java
@@ -114,12 +114,8 @@ public class EclipseResourceHelper implements ResourceHelper {
 
     @Override
     public boolean isBazelRootProject(IProject project) {
-        try {
-            // fix to not be based on string comparison?
-            return project.getDescription().getName().startsWith(BazelNature.BAZELWORKSPACE_PROJECT_BASENAME);
-        } catch (CoreException ex) {
-            throw new IllegalStateException(ex);
-        }
+        // fix to not be based on string comparison?
+        return project.getName().startsWith(BazelNature.BAZELWORKSPACE_PROJECT_BASENAME);
     }
 
     /**

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateRootProjectFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateRootProjectFlow.java
@@ -23,11 +23,14 @@
  */
 package com.salesforce.bazel.eclipse.projectimport.flow;
 
+import static java.lang.String.format;
+
 import java.io.File;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.SubMonitor;
 
 import com.salesforce.bazel.eclipse.BazelPluginActivator;
@@ -71,6 +74,12 @@ public class CreateRootProjectFlow implements ImportFlow {
             String rootProjectName =
                     BazelProjectConstants.BAZELWORKSPACE_PROJECT_BASENAME + " (" + bazelWorkspace.getName() + ")";
             rootProject = ctx.getEclipseProjectCreator().createRootProject(rootProjectName);
+        } else if (!rootProject.isOpen()) {
+            try {
+                rootProject.open(progressMonitor.newChild(1));
+            } catch (CoreException e) {
+                throw new IllegalStateException(format("Unable to open root project '%s'!", rootProject.getName()), e);
+            }
         }
 
         // link all files in the workspace root into the Eclipse project

--- a/releng/target-platform/target-platform-dev.target
+++ b/releng/target-platform/target-platform-dev.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="bazel-eclipse-feature-target-platform" sequenceNumber="1636373983">
+<target name="bazel-eclipse-feature-target-platform-for-development" sequenceNumber="1636373983">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.e4.rcp.feature.group" version="4.21.0.v20210906-0842"/>
@@ -77,6 +77,32 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.buildship.feature.group" version="3.1.6.v20210909-1001-s"/>
       <repository location="https://download.eclipse.org/buildship/updates/e420/snapshots/3.x/3.1.6.v20210909-1001-s/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.egit.feature.group" version="5.13.0.202109080827-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.13.0.202109080827-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="5.13.0.202109080827-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.13.0.202109080827-r"/>
+      <unit id="org.eclipse.egit.gitflow.feature.feature.group" version="5.13.0.202109080827-r"/>
+      <repository location="https://download.eclipse.org/egit/updates/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="1.18.0.v20210617-1748"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.27.0.v20210816-1137"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="3.11.0.201606061308"/>
+      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.26.0.v20210617-1750"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="5.4.0.202109071933"/>
+      <unit id="org.eclipse.linuxtools.docker.editor.ls.feature.feature.group" version="5.4.0.202109071933"/>
+      <unit id="org.eclipse.tm4e.feature.feature.group" version="0.4.1.202008270629"/>
+      <repository location="https://download.eclipse.org/releases/2021-09/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="3.0.39.202102270010"/>
+      <unit id="org.eclipse.mylyn.wikitext.editors_feature.feature.group" version="3.0.39.202102270010"/>
+      <unit id="org.eclipse.mylyn.wikitext.sdk.feature.group" version="3.0.39.202102270010"/>
+      <unit id="org.eclipse.mylyn.wikitext.markdown" version="3.0.39.20210227000941"/>
+      <unit id="org.eclipse.mylyn.wikitext.markdown.ui" version="3.0.39.202102270010"/>
+      <repository location="https://download.eclipse.org/mylyn/docs/releases/3.0.39/"/>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/releng/target-platform/target-platform-dev.tpd
+++ b/releng/target-platform/target-platform-dev.tpd
@@ -1,0 +1,42 @@
+target "bazel-eclipse-feature-target-platform-for-development" with source configurePhase requirements
+
+environment JavaSE-11
+
+
+// import "build" target platform
+
+include "target-platform.tpd"
+
+
+// add additional stuff to allow running in a self-hosted environment for convenience
+
+location "https://download.eclipse.org/egit/updates/" {
+    org.eclipse.egit.feature.group
+    org.eclipse.jgit.feature.group
+    org.eclipse.jgit.http.apache.feature.group
+    org.eclipse.jgit.ssh.apache.feature.group
+    org.eclipse.egit.gitflow.feature.feature.group
+}
+
+location "https://download.eclipse.org/releases/2021-09/" {
+	// EMF & Co
+    org.eclipse.emf.ecore.xcore.sdk.feature.group
+    org.eclipse.emf.sdk.feature.group
+    org.eclipse.gef.sdk.feature.group
+    org.eclipse.xsd.sdk.feature.group
+
+    // Docker Tools
+    org.eclipse.linuxtools.docker.feature.feature.group
+    org.eclipse.linuxtools.docker.editor.ls.feature.feature.group
+
+    // Terminal
+    org.eclipse.tm4e.feature.feature.group
+}
+
+location "https://download.eclipse.org/mylyn/docs/releases/3.0.39/" {
+    org.eclipse.mylyn.wikitext_feature.feature.group
+    org.eclipse.mylyn.wikitext.editors_feature.feature.group
+    org.eclipse.mylyn.wikitext.sdk.feature.group
+    org.eclipse.mylyn.wikitext.markdown
+    org.eclipse.mylyn.wikitext.markdown.ui
+}

--- a/releng/target-platform/target-platform.tpd
+++ b/releng/target-platform/target-platform.tpd
@@ -69,6 +69,7 @@ location "https://download.eclipse.org/lsp4j/updates/releases/0.12.0/" {
 location "https://download.eclipse.org/technology/m2e/releases/1.18.1/" {
 	org.eclipse.m2e.feature.feature.group
 	org.eclipse.m2e.logback.feature.feature.group
+	org.eclipse.m2e.sdk.feature.feature.group
 }
 
 location "https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/" {


### PR DESCRIPTION
Description cannot be used when project is closed. Thus, just the project name should be used.