### PR TITLE
test perf, eliminate deploy jars from test classpath

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/logging/BasicLoggerFacade.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/logging/BasicLoggerFacade.java
@@ -48,6 +48,13 @@ public class BasicLoggerFacade extends LoggerFacade {
     @Override
     protected void error(Class<?> from, String message, Object... args) {
         // LoggerFactory.getLogger(from).error(message, args);
+        if (args != null && args.length > 0) {
+            Object firstArg = args[0]; 
+            if (firstArg instanceof Throwable) {
+                Throwable anyE = (Throwable)firstArg;
+                anyE.printStackTrace();
+            }
+        }
         System.err.println("ERROR " + formatMsg(from, message, args));
     }
 

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
@@ -72,6 +72,7 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
     @Override
     public void initialize(IPath eclipseProjectPath, IJavaProject eclipseJavaProject) throws CoreException {
         IProject eclipseProject = eclipseJavaProject.getProject();
+        String eclipseProjectName = eclipseProject.getName();
         try {
             //remove projects added to the workspace after a corrupted package in identified
             if (isCorrupt.get()) {
@@ -81,7 +82,7 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
 
             // create the BazelProject if necessary
             BazelProjectManager bazelProjectManager = ComponentContext.getInstance().getProjectManager();
-            BazelProject bazelProject = bazelProjectManager.getProject(eclipseProject.getName());
+            BazelProject bazelProject = bazelProjectManager.getProject(eclipseProjectName);
             if (bazelProject == null) {
                 bazelProject = new BazelProject(eclipseProject.getName(), eclipseProject);
                 bazelProjectManager.addProject(bazelProject);
@@ -95,10 +96,10 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
             } else {
                 setClasspathContainerForProject(eclipseProjectPath, eclipseJavaProject, container);
             }
-        } catch (IOException | InterruptedException | BackingStoreException e) {
-            LOG.error("Error while creating Bazel classpath container.", e);
         } catch (BazelCommandLineToolConfigurationException e) {
             LOG.error("Bazel not found: " + e.getMessage());
+        } catch (Exception anyE) {
+            LOG.error("Error while initializing Bazel classpath container for project {}", anyE, eclipseProjectName);
         }
     }
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestClasspathProvider.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelTestClasspathProvider.java
@@ -177,9 +177,12 @@ public class BazelTestClasspathProvider extends StandardClasspathProvider {
             BazelJvmTestClasspathHelper.ParamFileResult testParamFilesResult) throws CoreException {
         List<IRuntimeClasspathEntry> result = new ArrayList<>();
 
-        // assemble the de-duplicated list of jar files that are used across all the test targets
-        // these paths are listed in the param files, and are relative to the Bazel workspace exec root
-        Set<String> jarPaths = bazelJvmTestClasspathHelper.aggregateJarFilesFromParamFiles(testParamFilesResult);
+        // Assemble the de-duplicated list of jar files that are used across all the test targets
+        // these paths are listed in the param files, and are relative to the Bazel workspace exec root.
+        // We don't want deploy jars, because those are bloated and kill performance. Eclipse passes the project classpath
+        // to the RemoteTestRunner JVM so we don't need the self-contained deploy jars.
+        boolean includeDeployJars = false;
+        List<String> jarPaths = bazelJvmTestClasspathHelper.aggregateJarFilesFromParamFiles(testParamFilesResult.paramFiles, includeDeployJars);
         for (String rawPath : jarPaths) {
             String canonicalPath = FSPathHelper.getCanonicalPathStringSafely(new File(execRootDir, rawPath));
             IPath eachPath = new Path(canonicalPath);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/lang/jvm/BazelJvmTestClasspathHelperTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/lang/jvm/BazelJvmTestClasspathHelperTest.java
@@ -28,16 +28,15 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
-import java.util.Set;
 import java.util.TreeSet;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.salesforce.bazel.sdk.lang.jvm.BazelJvmTestClasspathHelper;
 import com.salesforce.bazel.sdk.path.FSPathHelper;
 
 public class BazelJvmTestClasspathHelperTest {
@@ -82,7 +81,7 @@ public class BazelJvmTestClasspathHelperTest {
     @Test
     public void testClasspathAggregation() throws Exception {
         BazelJvmTestClasspathHelper.ParamFileResult result = new BazelJvmTestClasspathHelper.ParamFileResult();
-        result.paramFiles = new TreeSet<>();
+        result.paramFiles = new ArrayList<>();
         result.unrunnableLabels = new TreeSet<>();
         File tdir = tmpDir.newFolder("paramFiles");
         File pdir = new File(tdir, "paramFiles");
@@ -95,9 +94,14 @@ public class BazelJvmTestClasspathHelperTest {
             result.paramFiles.add(createParamFile(pdir, i));
         }
 
-        Set<String> jarPaths = bazelJvmTestClasspathHelper.aggregateJarFilesFromParamFiles(result);
-
+        boolean includeDeployJars = true;
+        List<String> jarPaths =
+                bazelJvmTestClasspathHelper.aggregateJarFilesFromParamFiles(result.paramFiles, includeDeployJars);
         assertEquals(7, jarPaths.size());
+
+        includeDeployJars = false;
+        jarPaths = bazelJvmTestClasspathHelper.aggregateJarFilesFromParamFiles(result.paramFiles, includeDeployJars);
+        assertEquals(5, jarPaths.size());
     }
 
     private static File createParamFile(File dir, int index) {


### PR DESCRIPTION
Found the major culprit for #381 

When Bazel builds a java_test target, it can in some cases produce two jars, the normal test jar (with just the compiled test classes) and sometimes a _deploy.jar which is a self contained runnable test executable. The deploy jar has all the deps built in.

For our internal test case, the tests each have 300+ dependencies, so the deploy jars were huge. When launching the tests from Eclipse, Eclipse spawns a new JVM and passes in the proper classpath via the -classpath arg. Also, the Eclipse test launcher is bundled inside. There is no need for the huge bloated deploy jars. So the fix in this PR is to **prevent the deploy jars from being added to the test classpath**.

Also, when running a whole suite of tests at the same time, we created a union classpath of all tests. That meant the test runner had 100 deploy jars built in (because there are 100 tests in this package).

Also reverted my change to use Sets to hold classpath elements. Classpaths are order sensitive. Packages should not have overlapping dependencies (two jars with the same class) but some packages don't follow best practices. Reverting to using Lists to maintain order is prudent.