### PR TITLE
fix a bug in BEF activation caused by common plugin refactor

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/component/ComponentContext.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/component/ComponentContext.java
@@ -21,6 +21,7 @@ import com.salesforce.bazel.sdk.workspace.OperatingEnvironmentDetectionStrategy;
 
 public class ComponentContext {
     private static ComponentContext instance;
+    private static boolean initialized = false;
 
     /** ProjectManager manages all of the imported projects */
     private BazelProjectManager projectManager;
@@ -72,6 +73,11 @@ public class ComponentContext {
         setBazelExecutablePath(bazelExecutablePath);
         setBazelCommandManager(
             new BazelCommandManager(aspectLocation, commandBuilder, consoleFactory, bazelExecutablePath));
+        initialized = true;
+    }
+    
+    public boolean isInitialized() {
+        return initialized;
     }
 
     public BazelProjectManager getProjectManager() {

--- a/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
+++ b/bundles/com.salesforce.bazel.eclipse.core/plugin.xml
@@ -4,14 +4,14 @@
    <extension
          point="org.eclipse.jdt.core.classpathContainerInitializer">
       <classpathContainerInitializer
-            class="com.salesforce.bazel.eclipse.classpath.BazelClasspathContainerInitializer"
+            class="com.salesforce.bazel.eclipse.classpath.BazelCoreClasspathContainerInitializer"
             id="com.salesforce.bazel.eclipse.BAZEL_CONTAINER">
       </classpathContainerInitializer>
    </extension>
    <extension
          point="org.eclipse.jdt.core.classpathContainerInitializer">
       <classpathContainerInitializer
-            class="com.salesforce.bazel.eclipse.classpath.BazelClasspathContainerInitializer"
+            class="com.salesforce.bazel.eclipse.classpath.BazelCoreClasspathContainerInitializer"
             id="com.salesforce.bazel.eclipse.BAZEL_GLOBAL_SEARCH_CONTAINER">
       </classpathContainerInitializer>
    </extension>

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelCoreClasspathContainerInitializer.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelCoreClasspathContainerInitializer.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.eclipse.classpath;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IJavaProject;
+
+/**
+ * This is just a wrapper around the BazelClasspathContainerInitializer. This is done to ensure activation of the
+ * Bazel Core Eclipse plugin before this initializer is used. This is required because the Core plugin initilizes a
+ * set of collaborators that are used by the initializer.
+ * <p>
+ * By placing the BazelCoreClasspathContainerInitializer in the Bazel Core plugin, this ensures that the Core plugin
+ * is activated on first use. The BazelClasspathContainerInitializer is in the Bazel Common plugin. Without this wrapper
+ * the Common plugin would be activated but not the Core plugin on first use.
+ * <p>
+ * The use case where this matters is when you: 1. create a new Eclipse workspace 2. import a Bazel workspace 
+ * 3. close Eclipse 4. launch Eclipse and open the existing Eclipse workspace
+ */
+public class BazelCoreClasspathContainerInitializer extends BazelClasspathContainerInitializer {
+
+    @Override
+    public void initialize(IPath eclipseProjectPath, IJavaProject eclipseJavaProject) throws CoreException {
+        super.initialize(eclipseProjectPath, eclipseJavaProject);
+    }
+}


### PR DESCRIPTION
Fix an issue in BEF caused by the recent refactor of common Bazel Eclipse classes into the Common plugin. We need to make sure the BEF Core plugin is activated before any code in the Core/Common plugins are used. This is because the Core plugin activation establishes all of the collaborators that are used throughout the code base.

The use case where this was failing was:
1. create a new Eclipse workspace 
2. import a Bazel workspace 
3. close Eclipse 
4. launch Eclipse and open the existing Eclipse workspace

This wasn't a problem with the Import Bazel Workspace flow (i.e. new Eclipse workspace use case) because the act of opening the Bazel Import wizard activates the BEF Core plugin.

@AlexeiShmidman I don't know if you need to also have a similar solution for this on the BJLS side, just FYI