### PR TITLE
initial support for root package BUILD targets

### DIFF
--- a/bundles/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/bazel/eclipse/project/BjlsEclipseProjectCreator.java
+++ b/bundles/com.salesforce.b2eclipse.jdt.ls/src/main/java/com/salesforce/bazel/eclipse/project/BjlsEclipseProjectCreator.java
@@ -8,6 +8,7 @@ import org.eclipse.core.resources.IProject;
 import com.salesforce.bazel.eclipse.runtime.api.ResourceHelper;
 import com.salesforce.bazel.sdk.command.BazelCommandManager;
 import com.salesforce.bazel.sdk.model.BazelPackageLocation;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
 import com.salesforce.bazel.sdk.project.BazelProjectManager;
 
 public class BjlsEclipseProjectCreator extends EclipseProjectCreator {
@@ -18,8 +19,8 @@ public class BjlsEclipseProjectCreator extends EclipseProjectCreator {
     }
 
     @Override
-    protected String createProjectName(BazelPackageLocation packageLocation, List<IProject> currentImportedProjects,
-            List<IProject> existingImportedProjects) {
+    protected String createProjectName(BazelWorkspace bazelWorkspace, BazelPackageLocation packageLocation,
+            List<IProject> currentImportedProjects, List<IProject> existingImportedProjects) {
         return packageLocation.getBazelPackageNameLastSegment();
     }
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelLabel.java
@@ -58,6 +58,9 @@ public class BazelLabel {
     // All packages wildcard 
     public static final String BAZEL_ALL_REPO_PACKAGES = "//...";
 
+    // Root package wildcard 
+    public static final String BAZEL_ROOT_PACKAGE_ALLTARGETS = "//:*";
+
     // Double slash characters for root of Bazel paths
     public static final String BAZEL_ROOT_SLASHES = "//";
 
@@ -362,19 +365,21 @@ public class BazelLabel {
     public static boolean validateLabelPath(String labelPathStr, boolean throwOnError) {
         try {
             if (labelPathStr == null) {
-                throw new IllegalArgumentException(labelPathStr);
-            }
-            labelPathStr = labelPathStr.trim();
-            if (labelPathStr.length() == 0) {
-                throw new IllegalArgumentException(labelPathStr);
-            }
-            if (labelPathStr.endsWith(BAZEL_COLON)) {
-                throw new IllegalArgumentException(labelPathStr);
-            }
-            if (labelPathStr.endsWith(BAZEL_SLASH)) {
-                throw new IllegalArgumentException(labelPathStr);
+                throw new IllegalArgumentException("Illegal Bazel path string: "+labelPathStr);
             }
             if (labelPathStr.equals(BAZEL_ROOT_SLASHES)) {
+                // this is a special case, it is a legal label so we will shall let it pass
+                return true;
+            }
+            
+            labelPathStr = labelPathStr.trim();
+            if (labelPathStr.length() == 0) {
+                throw new IllegalArgumentException("Illegal Bazel path string: "+labelPathStr);
+            }
+            if (labelPathStr.endsWith(BAZEL_COLON)) {
+                throw new IllegalArgumentException("Illegal Bazel path string: "+labelPathStr);
+            }
+            if (labelPathStr.endsWith(BAZEL_SLASH)) {
                 throw new IllegalArgumentException(labelPathStr);
             }
             if (labelPathStr.contains(FSPathHelper.WINDOWS_BACKSLASH)) {

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/model/BazelPackageInfo.java
@@ -280,7 +280,6 @@ public class BazelPackageInfo implements BazelPackageLocation {
     /**
      * Provides the proper Bazel label for the Bazel package.
      * <p>
-     *
      * e.g. "//projects/libs/apple"
      */
     @Override
@@ -290,14 +289,8 @@ public class BazelPackageInfo implements BazelPackageLocation {
         }
 
         if ("".equals(relativeWorkspacePath)) {
-            // the caller is referring to the WORKSPACE root, which for build operations can
-            // (but not always) means that the user wants to build the entire workspace.
-
-            // TODO refine this, so that if the root directory contains a BUILD file with a Java package to
-            // somehow handle that workspace differently
-            // Docs should indicate that a better practice is to keep the root dir free of an actual package
-            // For now, assume that anything referring to the root dir is a proxy for 'whole repo'
-            computedPackageName = BazelLabel.BAZEL_ALL_REPO_PACKAGES;
+            // the caller is referring to the WORKSPACE root
+            computedPackageName = BazelLabel.BAZEL_ROOT_SLASHES;
             return computedPackageName;
         }
 
@@ -366,7 +359,7 @@ public class BazelPackageInfo implements BazelPackageLocation {
                             + bazelPackagePath + "]");
         }
 
-        if (BazelLabel.BAZEL_ALL_REPO_PACKAGES.equals(bazelPackagePath)) {
+        if (BazelLabel.BAZEL_ROOT_PACKAGE_ALLTARGETS.equals(bazelPackagePath)) {
             // special case
             return workspaceRootNode;
         }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/project/ProjectViewPackageLocation.java
@@ -88,14 +88,8 @@ public class ProjectViewPackageLocation implements BazelPackageLocation {
     @Override
     public String getBazelPackageName() {
         if ("".equals(packagePath)) {
-            // the caller is referring to the WORKSPACE root, which for build operations can
-            // (but not always) means that the user wants to build the entire workspace.
-
-            // TODO refine this, so that if the root directory contains a BUILD file with a Java package to
-            // somehow handle that workspace differently
-            // Docs should indicate that a better practice is to keep the root dir free of an actual package
-            // For now, assume that anything referring to the root dir is a proxy for 'whole repo'
-            return BazelLabel.BAZEL_ALL_REPO_PACKAGES;
+            // the caller is referring to the WORKSPACE root
+            return BazelLabel.BAZEL_ROOT_SLASHES;
         }
         return BazelLabel.BAZEL_ROOT_SLASHES + packagePath;
     }

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/BazelNature.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/BazelNature.java
@@ -53,6 +53,10 @@ public class BazelNature implements IProjectNature {
      */
     public static final String BAZELWORKSPACE_PROJECT_BASENAME = "Bazel Workspace";
 
+    public static String getEclipseRootProjectName(String bazelWorkspaceName) {
+        return BazelNature.BAZELWORKSPACE_PROJECT_BASENAME + " (" + bazelWorkspaceName + ")";
+    }
+    
     @Override
     public void configure() throws CoreException {
         // TODO we aren't doing anything right now for BazelNature configure hook, seems like it should be used for something

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/classpath/BazelClasspathContainerInitializer.java
@@ -50,6 +50,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.osgi.service.prefs.BackingStoreException;
 
+import com.salesforce.bazel.eclipse.BazelNature;
 import com.salesforce.bazel.eclipse.component.ComponentContext;
 import com.salesforce.bazel.eclipse.project.EclipseProjectUtils;
 import com.salesforce.bazel.eclipse.runtime.api.JavaCoreHelper;
@@ -100,7 +101,7 @@ public class BazelClasspathContainerInitializer extends ClasspathContainerInitia
                 bazelProjectManager.addProject(bazelProject);
             }
 
-            boolean isRootProject = eclipseJavaProject.getProject().getName().contains("Bazel Workspace");
+            boolean isRootProject = eclipseJavaProject.getProject().getName().contains(BazelNature.BAZELWORKSPACE_PROJECT_BASENAME);
             IClasspathContainer container = getClasspathContainer(eclipseProject, isRootProject);
 
             if (isRootProject) {

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateProjectsFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateProjectsFlow.java
@@ -83,20 +83,17 @@ public class CreateProjectsFlow extends AbstractImportFlowStep {
                 Arrays.asList(resourceHelper.getProjectsForBazelWorkspace(bazelWorkspace));
         
         for (BazelPackageLocation packageLocation : orderedModules) {
-            if (!packageLocation.isWorkspaceRoot()) {
-                List<BazelLabel> bazelTargets = ctx.getPackageLocationToTargets().get(packageLocation);
+            List<BazelLabel> bazelTargets = ctx.getPackageLocationToTargets().get(packageLocation);
 
-                // create the project
-                IProject project =
-                        projectCreator.createProject(ctx, packageLocation, bazelTargets, currentImportedProjects,
-                            existingImportedProjects, fileLinker, bazelWorkspace);
+            // create the project
+            IProject project = projectCreator.createProject(ctx, packageLocation, bazelTargets, 
+                currentImportedProjects, existingImportedProjects, fileLinker, bazelWorkspace);
 
-                if (project != null) {
-                    ctx.addImportedProject(project, packageLocation);
-                }
-
-                progressMonitor.worked(1);
+            if (project != null) {
+                ctx.addImportedProject(project, packageLocation);
             }
+
+            progressMonitor.worked(1);
         }
     }
 

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseJavaCoreHelper.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/runtime/impl/EclipseJavaCoreHelper.java
@@ -137,8 +137,8 @@ public class EclipseJavaCoreHelper implements JavaCoreHelper {
             for (IJavaProject candidate : javaProjects) {
                 IProject p = candidate.getProject();
                 if (p.getNature(BazelNature.BAZEL_NATURE_ID) != null) {
-                    if (includeBazelWorkspaceRootProject
-                            || !ComponentContext.getInstance().getResourceHelper().isBazelRootProject(p)) {
+                    boolean isRootProject = ComponentContext.getInstance().getResourceHelper().isBazelRootProject(p);
+                    if (includeBazelWorkspaceRootProject || !isRootProject) {
                         bazelProjects.add(candidate);
                     }
                 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationTab.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/launch/BazelLaunchConfigurationTab.java
@@ -58,10 +58,10 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 
-import com.salesforce.bazel.eclipse.BazelPluginActivator;
 import com.salesforce.bazel.eclipse.component.ComponentContext;
 import com.salesforce.bazel.eclipse.launch.BazelLaunchConfigurationSupport.BazelLaunchConfigAttributes;
 import com.salesforce.bazel.eclipse.launch.BazelLaunchConfigurationSupport.TypedBazelLabel;
+import com.salesforce.bazel.eclipse.runtime.api.JavaCoreHelper;
 import com.salesforce.bazel.eclipse.ui.BazelSWTFactory;
 import com.salesforce.bazel.sdk.model.BazelLabel;
 import com.salesforce.bazel.sdk.model.BazelTargetKind;
@@ -229,7 +229,9 @@ public class BazelLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
         ElementListSelectionDialog dialog = new ElementListSelectionDialog(getShell(), BAZEL_PROJECT_LABEL_PROVIDER);
         dialog.setTitle("Select Project");
         dialog.setMessage("Select Project");
-        dialog.setElements(ComponentContext.getInstance().getJavaCoreHelper().getAllBazelJavaProjects(false));
+        JavaCoreHelper javaCoreHelper = ComponentContext.getInstance().getJavaCoreHelper();
+        IJavaProject[] launchableProjects = javaCoreHelper.getAllBazelJavaProjects(true);
+        dialog.setElements(launchableProjects);
 
         IJavaProject javaProject = getSelectedProject();
         if (javaProject != null) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/main/java/com/salesforce/bazel/eclipse/wizard/BazelImportWizard.java
@@ -90,7 +90,7 @@ public class BazelImportWizard extends Wizard implements IImportWizard {
         List<Object> grayedBazelPackages = Arrays.asList(page.projectTree.projectTreeViewer.getGrayedElements());
 
         List<BazelPackageLocation> bazelPackagesToImport = Arrays.asList(selectedBazelPackages).stream()
-                .filter(bpi -> bpi != workspaceRootProject).filter(bpi -> !grayedBazelPackages.contains(bpi))
+                .filter(bpi -> !grayedBazelPackages.contains(bpi))
                 .map(bpi -> (BazelPackageInfo) bpi).collect(Collectors.toList());
 
         BazelProjectImporter.run(workspaceRootProject, bazelPackagesToImport);

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelLabelTest.java
@@ -191,8 +191,4 @@ public class BazelLabelTest {
         new BazelLabel(BazelLabel.BAZEL_SLASH);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidLabel_onlyLeadingSlashes() {
-        new BazelLabel("//");
-    }
 }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProjectInfoTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/model/BazelProjectInfoTest.java
@@ -100,7 +100,7 @@ public class BazelProjectInfoTest {
 
         assertEquals("", rootNode.getBazelPackageFSRelativePath());
         assertEquals("WORKSPACE", rootNode.getBazelPackageFSRelativePathForUI());
-        assertEquals("//...", rootNode.getBazelPackageName());
+        assertEquals("//", rootNode.getBazelPackageName());
         assertEquals("", rootNode.getBazelPackageNameLastSegment());
 
         assertTrue(rootNode.getChildPackageInfos().isEmpty());
@@ -240,7 +240,7 @@ public class BazelProjectInfoTest {
         BazelPackageInfo banana = new BazelPackageInfo(apple_web, BANANA_PROJECT_FS_PATH);
 
         assertEquals(apple_web, banana.findByPackage("//projects/libs/apple/web")); // $SLASH_OK bazel path
-        assertEquals(rootNode, apple.findByPackage("//..."));
+        assertEquals(rootNode, apple.findByPackage("//"));
     }
 
     // HELPERS


### PR DESCRIPTION
This is the initial support for import of Java targets in the root package (//:*). This is the solution for #404.

This PR does not contain a few things:
- tests
- the ability to NOT import the root package targets; right now they will always be imported

This feature is time sensitive so I will work those items in a follow up PR.