### PR TITLE
avoid importing root targets unless explicitly requested

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateRootProjectFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/CreateRootProjectFlow.java
@@ -106,16 +106,8 @@ public class CreateRootProjectFlow extends AbstractImportFlowStep {
         List<BazelPackageLocation> selectedBazelPackages = ctx.getSelectedBazelPackages();
         ProjectViewUtils.writeProjectViewFile(bazelWorkspaceRootDirectory, rootProject, selectedBazelPackages);
 
-        boolean isImportingRootPackage = false;
-        for (BazelPackageLocation pkg : selectedBazelPackages) {
-            if (pkg.isWorkspaceRoot()) {
-                isImportingRootPackage = true;
-                break;
-            }
-        }
-        
         // we only create a dummy source folder if we aren't importing the root package //:*
-        if (!isImportingRootPackage) {
+        if (!ctx.isExplicitImportRootProject()) {
             createDummySourceFolder(rootProject);
         }
 

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportContext.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/ImportContext.java
@@ -52,6 +52,7 @@ public class ImportContext {
 
     private final BazelPackageLocation bazelWorkspaceRootPackageInfo;
     private final List<BazelPackageLocation> selectedBazelPackages;
+    private boolean isExplicitImportRootProject = false;
     private final ProjectOrderResolver projectOrderResolver;
     private final Map<String, ProjectStructure> ProjectSourceStructureCache = new HashMap<>();
 
@@ -73,6 +74,13 @@ public class ImportContext {
         this.bazelWorkspaceRootPackageInfo = Objects.requireNonNull(bazelWorkspaceRootPackageInfo);
         this.selectedBazelPackages = Objects.requireNonNull(selectedBazelPackages);
         this.projectOrderResolver = Objects.requireNonNull(projectOrderResolver);
+        
+        for (BazelPackageLocation pkg : selectedBazelPackages) {
+            if (pkg.isWorkspaceRoot()) {
+                isExplicitImportRootProject = true;
+                break;
+            }
+        }
     }
 
     public void init(File bazelWorkspaceRootDirectory, BazelProjectManager bazelProjectManager,
@@ -89,6 +97,16 @@ public class ImportContext {
 
     public List<BazelPackageLocation> getSelectedBazelPackages() {
         return selectedBazelPackages;
+    }
+    
+    /**
+     * We always create an Eclipse project for the root package (//:*) in the Bazel workspace as a holder for
+     * Bazel workspace level config (e.g. Global Search Classpath). But if the user has targets in the root
+     * package (in the BUILD file) they may explicitly ask us to import the root package. If the user has
+     * explicitly asked for the root package to be imported, this will return true.
+     */
+    public boolean isExplicitImportRootProject() {
+        return isExplicitImportRootProject;
     }
 
     public Map<BazelPackageLocation, List<BazelLabel>> getPackageLocationToTargets() {

--- a/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
+++ b/bundles/com.salesforce.bazel.eclipse.common/src/main/java/com/salesforce/bazel/eclipse/projectimport/flow/SetupClasspathContainersFlow.java
@@ -79,6 +79,14 @@ public class SetupClasspathContainersFlow extends AbstractImportFlowStep {
         List<IProject> importedProjects = ctx.getImportedProjects();
         for (IProject project : importedProjects) {
             BazelPackageLocation packageLocation = ctx.getPackageLocationForProject(project);
+            
+            if (packageLocation.isWorkspaceRoot() && !ctx.isExplicitImportRootProject()) {
+                // we always create an Eclipse project for the root Bazel package to hold workspace level
+                // things. but in this case the user didn't ask us to import the root package targets, 
+                // so we don't want to setup the classpath container for the root package here
+                continue;
+            }
+            
             ProjectStructure structure =
                     ctx.getProjectStructure(packageLocation, getBazelWorkspace(), getCommandManager());
             String packageFSPath = packageLocation.getBazelPackageFSRelativePath();


### PR DESCRIPTION
Refinement of feature #404 

This allows the user to intentionally unselect the targets in the root package. The previous commit made it so the root targets would always be imported.

Still need unit tests and Windows testing before closing out #404.