### PR TITLE
major refactor of indexing subsystem

### DIFF
--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexReporter.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexReporter.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.salesforce.bazel.sdk.index.model.CodeLocationDescriptor;
+
+/**
+ * Utilities to analyze and generate a report about the files in an index.
+ */
+public class CodeIndexReporter {
+    protected CodeIndex index;
+    
+    public CodeIndexReporter(CodeIndex index) {
+        this.index = index;
+    }
+    
+    // SIMPLE REPORT
+    
+    public void printIndexAsText() {
+        println("");
+        println("ARTIFACT INDEX (" + index.artifactDictionary.size() + " entries)");
+        println("----------------------------------------");
+        for (String artifact : index.artifactDictionary.keySet()) {
+            printArtifact(artifact, index.artifactDictionary.get(artifact));
+        }
+        println("");
+        println("FILE INDEX (" + index.fileDictionary.size() + " entries)");
+        println("----------------------------------------");
+        for (String filename : index.fileDictionary.keySet()) {
+            printArtifact(filename, index.fileDictionary.get(filename));
+        }
+        println("");
+        println("TYPE INDEX (" + index.typeDictionary.size() + " entries)");
+        println("----------------------------------------");
+        for (String classname : index.typeDictionary.keySet()) {
+            printArtifact(classname, index.typeDictionary.get(classname));
+        }
+        println("");
+    }
+
+    private void printArtifact(String artifact, CodeIndexEntry entry) {
+        println("  " + artifact);
+        if (entry.singleLocation != null) {
+            println("    " + entry.singleLocation.id.locationIdentifier);
+        } else {
+            for (CodeLocationDescriptor loc : entry.multipleLocations) {
+                println("    " + loc.id.locationIdentifier);
+            }
+        }
+    }
+
+    private void println(String line) {
+        System.out.println(line);
+    }
+
+    
+    // CSV REPORT
+    
+    /**
+     * Provides the list of artifacts in the index. Format: CSV
+     */
+    public List<String> buildArtifactReportAsCSV() {
+        List<String>  rows = new ArrayList<>();
+        Set<String> artifactNames = index.artifactDictionary.keySet();
+        artifactNames = new TreeSet<>(artifactNames);
+        
+        if (index.getOptions().doComputeArtifactAges()) {
+            rows.add("Artifact Name, Bazel Label, Version, Age (in days)");
+        } else {
+            rows.add("Artifact Name, Bazel Label, Version");
+        }
+        
+        for (String artifactName : artifactNames) {
+            CodeIndexEntry entry = index.artifactDictionary.get(artifactName);
+            
+            if (entry.singleLocation != null) {
+                rows.add(writeArtifactRow(artifactName, entry.singleLocation));
+            } else {
+                for (CodeLocationDescriptor location : entry.multipleLocations) {
+                    rows.add(writeArtifactRow(artifactName, location));
+                }
+            }
+        }
+        
+        return rows;
+    }
+        
+    private String writeArtifactRow(String artifactName, CodeLocationDescriptor location) {
+        if (index.getOptions().doComputeArtifactAges()) {
+            return artifactName + ", " + location.bazelLabel + ", " + location.version + ", " + location.ageInDays;
+        }
+        return artifactName + ", " + location.bazelLabel + ", " + location.version;
+    }
+    
+    
+    // HISTOGRAM
+    
+    /**
+     * Provides the age histogram of artifacts in the index. 
+     */
+    public IndexArtifactHistogram buildArtifactAgeHistogramReport() {
+        Set<String> artifactNames = index.artifactDictionary.keySet();
+        artifactNames = new TreeSet<>(artifactNames);
+        IndexArtifactHistogram histogram = new IndexArtifactHistogram();
+        
+        for (String artifactName : artifactNames) {
+            CodeIndexEntry entry = index.artifactDictionary.get(artifactName);
+            
+            if (entry.singleLocation != null) {
+                histogram.recordArtifactAge(entry.singleLocation.ageInDays);
+            } else {
+                for (CodeLocationDescriptor location : entry.multipleLocations) {
+                    histogram.recordArtifactAge(location.ageInDays);
+                }
+            }
+        }
+        
+        return histogram;
+    }
+
+    /**
+     * Provides the age histogram of artifacts in the index. Format: CSV
+     */
+    public List<String> buildArtifactAgeHistogramReportAsCSV() {
+        List<String>  rows = new ArrayList<>();
+        IndexArtifactHistogram histogram = buildArtifactAgeHistogramReport();
+
+        if (!index.indexOptions.doComputeArtifactAges()) {
+            rows.add("Dependency age histogram could not be computed because age computation for dependencies is disabled.");
+            return rows;
+        }
+        rows.add("Age (in Years), Number of Dependencies");
+        
+        for (int i = 0; i<histogram.MAX_YEAR_AGE; i++) {
+            rows.add("" + i +", "+ histogram.countsPerYearOfAge[i]);
+        }
+        
+        rows.add("-1, "+histogram.undeterminedAgeCount);
+        
+        return rows;
+    }
+
+    /**
+     * Simple histogram, buckets divided by year. Over time this should become more sophisticated.
+     * Please resist the temptation to bring in a dependency to provide a better histogram, as we
+     * don't allow dependencies in the Bazel Java SDK.
+     */
+    public static class IndexArtifactHistogram {
+        public final int MAX_YEAR_AGE = 40;
+        public int[] countsPerYearOfAge = new int[MAX_YEAR_AGE];
+        public int undeterminedAgeCount = 0;
+        
+        public void recordArtifactAge(int ageInDays) {
+            if (ageInDays == -1) {
+                // age not determined
+                undeterminedAgeCount++;
+                return;
+            }
+            int ageInYears = ageInDays / 365; // I will ignore your protests about leap years!
+            
+            if (ageInYears >= MAX_YEAR_AGE) {
+                // some bogus future date was recorded as the age
+                undeterminedAgeCount++;
+                return;
+            }
+            countsPerYearOfAge[ageInYears] = countsPerYearOfAge[ageInYears] + 1;
+        }
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexer.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, Salesforce.com, Inc. All rights reserved.
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met:
@@ -20,18 +20,23 @@
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
  */
 package com.salesforce.bazel.sdk.index;
 
-import java.io.File;
-
 /**
- * A code index can take some time to generate, so this class can persist/read the index to/from file.
- * TODO this is not implemented yet
+ * Base class for all processors that can compute CodeIndex objects.
  */
-public class CodeIndexPersister {
-
-    public CodeIndexPersister(File outputDirectory) {
-        // TODO CodeIndexPersister is not implemented yet. Consider reusing the CodeIndexReport class, it does more or less what we need
-    }
+public class CodeIndexer {
+    // currently just a marker interface to help you find the impls
+    // over time, we will probably find some common members/methods we can move down into here
 }

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexerOptions.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/CodeIndexerOptions.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.index;
+
+/**
+ * The caller may choose to enable various options that controls the behavior of the indexer.
+ * For example, expensive computations may be suppressed by default.
+ * <p>
+ * It is expected for some indexers to be multithreaded. See the setLock() method for how this is implemented.
+ * This is to avoid strange concurrency bugs if the indexer is changing configuration in flight
+ * across threads.   
+ */
+public class CodeIndexerOptions {
+
+    /**
+     * Enable if you want the indexer to build the type index. This takes a lot more memory
+     * and time to build, so only enable if you will be CodeIndex.typeDictionary.
+     */
+    protected boolean doComputeTypeDictionary = false; 
+    
+    /**
+     * Since indexers are likely to be multithreaded, we want the options to be immutable once the indexing begins
+     * to avoid weird concurrency bugs. The indexer should set to this to true before starting.
+     */
+    protected boolean isLocked = false;
+    
+    // CTOR
+    
+    public CodeIndexerOptions() {}
+    
+    // SETTERS
+    
+    public void setDoComputeTypeDictionary(boolean doTypes) {
+        if (isLocked) {
+            return;
+        }
+        this.doComputeTypeDictionary = doTypes;
+    }
+    
+    // LOCK
+    
+    /**
+     * Since indexers are likely to be multithreaded, we want the options to be immutable once the indexing begins
+     * to avoid weird concurrency bugs. The indexer should set to this to true before starting.
+     * <p>
+     * This could be done by just making this entire class immutable, but there are possibly cases where multiple collaborators
+     * will change the options prior to the start of indexing.
+     */
+    public void setLock() {
+        this.isLocked = true;
+    }
+
+    // BEHAVIORS
+    
+    /**
+     * Generally indexing operates on the libary level (jar file, module, etc) but in some cases the caller wants
+     * to index at the Type level. For example, track all .class files in a jar file. This is expensive, so not always
+     * wanted. But if enabled, this method will return true.
+     */
+    public boolean doComputeTypeDictionary() {
+        return doComputeTypeDictionary;
+    }
+
+    /**
+     * In some implementations, it may be possible to compute the age of an artifact. It may be expensive to do
+     * so however. It will therefore be an optional behavior to enable on the subclass. This method is provided
+     * to allow users of an index to know whether an age may be available for an artifact. For example, for a 
+     * tool that generates a report on an index, this method can be used to determine whether an age field should be
+     * rendered. The age is captured in the CodeLocationDescriptor class.
+     */
+    public boolean doComputeArtifactAges() {
+        return false;
+    }
+
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndexer.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndexer.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+package com.salesforce.bazel.sdk.index.jvm;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.salesforce.bazel.sdk.index.CodeIndexer;
+import com.salesforce.bazel.sdk.index.jvm.jar.JarIdentiferResolver;
+import com.salesforce.bazel.sdk.index.jvm.jar.JavaJarCrawler;
+import com.salesforce.bazel.sdk.lang.jvm.external.BazelExternalJarRuleManager;
+import com.salesforce.bazel.sdk.lang.jvm.external.BazelExternalJarRuleType;
+import com.salesforce.bazel.sdk.logging.LogHelper;
+import com.salesforce.bazel.sdk.model.BazelWorkspace;
+import com.salesforce.bazel.sdk.util.WorkProgressMonitor;
+
+/**
+ * Indexes the code and dependencies in a Bazel workspace. It uses a combination of 
+ * underlying crawlers to collect information.
+ */
+public class JvmCodeIndexer extends CodeIndexer {
+    private static final LogHelper LOG = LogHelper.log(JvmCodeIndexer.class);
+    
+    /**
+     * Builds an index for an entire workspace, which can be a very expensive operation.
+     */
+    public synchronized JvmCodeIndex buildWorkspaceIndex(BazelWorkspace bazelWorkspace,
+            BazelExternalJarRuleManager externalJarRuleManager, JvmCodeIndexerOptions indexerOptions,
+            List<File> additionalJarLocations, WorkProgressMonitor progressMonitor) {
+
+        // TODO we should not return a cache index if the indexOptions don't match
+        JvmCodeIndex index = JvmCodeIndex.getWorkspaceIndex(bazelWorkspace);
+        if (index != null) {
+            return index;
+        }
+        
+        LOG.info("Building the type index for workspace {}, this may take some time...", bazelWorkspace.getName());
+        List<File> locations = new ArrayList<>();
+        index = new JvmCodeIndex(indexerOptions);
+        
+        // lock the options, as we don't want the caller to change them while we are indexing
+        indexerOptions.setLock();
+
+        // for each jar downloading rule type in the workspace, add the appropriate local directories of the downloaded jars
+        List<BazelExternalJarRuleType> ruleTypes = externalJarRuleManager.findInUseExternalJarRuleTypes(bazelWorkspace);
+        for (BazelExternalJarRuleType ruleType : ruleTypes) {
+            List<File> ruleSpecificLocations = ruleType.getDownloadedJarLocations(bazelWorkspace);
+            locations.addAll(ruleSpecificLocations);
+        }
+
+        // add internal location (jars built by the bazel workspace
+        addInternalLocations(index, locations);
+
+        // add the additional directories the user wants to search
+        if (additionalJarLocations != null) {
+            locations.addAll(additionalJarLocations);
+        }
+
+        // now build the index
+        for (File location : locations) {
+            processLocation(bazelWorkspace, externalJarRuleManager, index, location, progressMonitor);
+        }
+
+        JvmCodeIndex.addWorkspaceIndex(bazelWorkspace, index);
+
+        LOG.info("Finished building the type index for workspace {}", bazelWorkspace.getName());
+        return index;
+
+    }
+
+    void processLocation(BazelWorkspace bazelWorkspace, BazelExternalJarRuleManager externalJarRuleManager,
+            JvmCodeIndex index, File location, WorkProgressMonitor progressMonitor) {
+        if ((location != null) && location.exists()) {
+            JarIdentiferResolver jarResolver = new JarIdentiferResolver();
+            JavaJarCrawler jarCrawler = new JavaJarCrawler(bazelWorkspace, index, jarResolver, externalJarRuleManager);
+            jarCrawler.index(location);
+        }
+    }
+
+    protected void addInternalLocations(JvmCodeIndex index, List<File> locations) {
+        // TODO INTERNAL (jars produced by Bazel)
+        // this needs to be implemented to make the Dynamic classpath work
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndexerOptions.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/jvm/JvmCodeIndexerOptions.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.index.jvm;
+
+import com.salesforce.bazel.sdk.index.CodeIndexerOptions;
+
+public class JvmCodeIndexerOptions extends CodeIndexerOptions {
+    /**
+     * Enable if you would like the Jar indexer to try to determine age by looking at file timestamps of files 
+     * inside the jar. This is a reasonably cheap operation so it is enabled by default.
+     */
+    protected boolean doJvmComputeJarAgeUsingInternalFiles = false;
+
+    /**
+     * Some build systems (Bazel!) intentionally suppress this information from being written
+     * into the jar file for hermeticity reasons. Normally this is a really old date so it is
+     * not mistaken for a real date. Different build systems have different fake dates. Generally
+     * you will not be working with anything with a real date older than Jan 1, 2000 so that is what
+     * we are using. Anything before this date is consider fake.
+     */
+    // default value is midnight Jan 1 2000 GMT
+    protected long jvmComputeJarAgeUsingInternalFiles_earliestTimestamp = 946684800000L; 
+    
+    /**
+     * If jvmComputeJarAgeUsingInternalFiles == true, how many times should the indexer try to find
+     * a file with a valid timestamp before giving up for that jar?
+     */
+    protected int jvmComputeJarAgeUsingInternalFiles_tries = 5;
+    
+    /**
+     * Maven repositories (Nexus, Artifactory) sometimes have jar age information. Enable that by setting
+     * it to true. This is very expensive to use because it makes a remote call.
+     */
+    protected boolean doJvmComputeJarAgeUsingRemoteMavenRepo = false;
+    
+
+    // CTORS
+    
+    public JvmCodeIndexerOptions() {
+    }
+    
+    /**
+     * Factory pattern to create the options used for Global Type Search use cases. This is a common use case
+     * where the user has imported only some of the Bazel packages into an IDE, but they want type search
+     * to cover all jars in the Bazel workspace.
+     */
+    public static JvmCodeIndexerOptions buildJvmGlobalSearchOptions() {
+        
+        // currently we just use the defaults, but this would be the central place to change that
+        
+        return new JvmCodeIndexerOptions();
+    }
+
+    
+    // SETTERS
+    
+    public void setDoComputeJarAgeUsingInternalFiles(boolean doJvmComputeJarAgeUsingInternalFiles) {
+        if (isLocked) {
+            return;
+        }
+        this.doJvmComputeJarAgeUsingInternalFiles = doJvmComputeJarAgeUsingInternalFiles;
+    }
+
+    public void setEarliestTimestampForComputeJarAgeUsingInternalFiles(
+            long jvmComputeJarAgeUsingInternalFiles_earliestTimestamp) {
+        if (isLocked) {
+            return;
+        }
+        this.jvmComputeJarAgeUsingInternalFiles_earliestTimestamp = jvmComputeJarAgeUsingInternalFiles_earliestTimestamp;
+    }
+
+    public void setTriesForComputeJarAgeUsingInternalFiles(int jvmComputeJarAgeUsingInternalFiles_tries) {
+        if (isLocked) {
+            return;
+        }
+        this.jvmComputeJarAgeUsingInternalFiles_tries = jvmComputeJarAgeUsingInternalFiles_tries;
+    }
+
+    public void setDoComputeJarAgeUsingRemoteMavenRepo(boolean doJvmComputeJarAgeUsingRemoteMavenRepo) {
+        if (isLocked) {
+            return;
+        }
+        this.doJvmComputeJarAgeUsingRemoteMavenRepo = doJvmComputeJarAgeUsingRemoteMavenRepo;
+    }
+
+    
+    // GETTERS
+
+    public boolean doComputeJarAgeUsingInternalFiles() {
+        return doJvmComputeJarAgeUsingInternalFiles;
+    }
+
+    public long getEarliestTimestampForComputeJarAgeUsingInternalFiles() {
+        return jvmComputeJarAgeUsingInternalFiles_earliestTimestamp;
+    }
+
+    public int getTriesForComputeJarAgeUsingInternalFiles() {
+        return jvmComputeJarAgeUsingInternalFiles_tries;
+    }
+
+
+    public boolean doComputeJarAgeUsingRemoteMavenRepo() {
+        return doJvmComputeJarAgeUsingRemoteMavenRepo;
+    }
+
+    /**
+     * Is any form of age computation enabled for JVM Jars?
+     */
+    @Override
+    public boolean doComputeArtifactAges() {
+        return doJvmComputeJarAgeUsingInternalFiles || doJvmComputeJarAgeUsingRemoteMavenRepo;
+    }
+}

--- a/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptor.java
+++ b/bundles/com.salesforce.bazel-java-sdk/src/main/java/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptor.java
@@ -34,9 +34,32 @@ import java.util.List;
 public class CodeLocationDescriptor {
     public CodeLocationIdentifier id; // e.g. org.slf4j:slf4j-api:1.3.4
     public String bazelLabel; // e.g. @maven//:org_slf4j_slf4j_api
+    public String version; // optional: contains the version, if available from the filepath (e.g. com/foo/bar/1.3.4/bar.jar)
     public File locationOnDisk;
     public List<ClassIdentifier> containedClasses;
+    
+    /** 
+     * ageInDays - how many days ago was this code artifact built.
+     * <p>
+     * This is used for reporting functions, for example to look for outdated components being used in a build.
+     * <p>
+     * This generally should not be the file creation/modification times unless you know your build/source control
+     * system preserves the correct data. There may be more authoritative sources for this data.
+     * <p>
+     * For example, for jar files, we can look at the creation date of the files *inside* the jar.
+     * If it cannot be determined, this value will be -1.
+     * <p>
+     * Note that some build systems (Bazel!) intentionally suppress this information from being written
+     * into the jar file for hermeticity reasons, so it is not expected to always be available.
+     * <p>
+     * Note that in some cases we can reach out to an external system (e.g. Maven Central) and ask for
+     * this information. It is up to the indexer implementation to determine if that happens (it is slow!)
+     * so not to be used in all cases.
+     */
+    public int ageInDays = -1;
 
+    public CodeLocationDescriptor() {}
+    
     public CodeLocationDescriptor(File locationOnDisk, CodeLocationIdentifier id) {
         this.locationOnDisk = locationOnDisk;
         this.id = id;
@@ -48,10 +71,43 @@ public class CodeLocationDescriptor {
         this.bazelLabel = bazelLabel;
     }
 
+    public CodeLocationDescriptor(File locationOnDisk, CodeLocationIdentifier id, String bazelLabel, String version) {
+        this.locationOnDisk = locationOnDisk;
+        this.id = id;
+        this.bazelLabel = bazelLabel;
+        this.version = version;
+    }
+
     public void addClass(ClassIdentifier classId) {
         if (containedClasses == null) {
             containedClasses = new ArrayList<>(5);
         }
         containedClasses.add(classId);
     }
+    
+    /**
+     * Helper utility used to compute ageInDays, given a valid writtenTimeMillis.
+     * <p>
+     * @param writtenTimeMillis the candidate time in millis when we think this artifact was created
+     * @param currentTimeMillis from System.currentTimeMillis except when running tests
+     * @param earliestRealTimestampMillis written time is ignored if less than this time
+     * @return true if a reliable age was probably found, false if not
+     */
+    public boolean computeAge(long writtenTimeMillis, long currentTimeMillis,  long earliestRealTimestampMillis) {
+        // writtenTime is computed from epoch (Jan 1 1970) and we can assume anything really old is a bogus
+        // date written by a build system that intentionally suppresses the date for hermeticity reasons
+        if (writtenTimeMillis < earliestRealTimestampMillis) {
+            return false;
+        }
+        
+        long elapsedTimeMillis = currentTimeMillis - writtenTimeMillis;
+        if (elapsedTimeMillis < 0) {
+            // some bogus future date in the jar, ignore
+            return false;
+        }
+        ageInDays = (int) (elapsedTimeMillis / 86400000); // TODO 24*60*60*1000 be more precise
+        
+        return true;
+    }
+    
 }

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawlerTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/index/jvm/jar/JavaJarCrawlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.index.jvm.jar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class JavaJarCrawlerTest {
+
+    @Test
+    public void testSkipDirectory() {
+        boolean result = JavaJarCrawler.doSkipDirectory("com/salesforce/foo.runfiles/Bar.jar"); // we don't index runfiles
+        assertTrue(result);
+
+        result = JavaJarCrawler.doSkipDirectory("com/salesforce/foo/Bar.jar");
+        assertFalse(result);
+    }
+
+    @Test
+    public void testHasClassfileName() {
+        boolean result = JavaJarCrawler.hasClassfileName("com/salesforce/foo/Bar.class");
+        assertTrue(result);
+
+        result = JavaJarCrawler.hasClassfileName("Bar.class");
+        assertTrue(result);
+
+        result = JavaJarCrawler.hasClassfileName("com/foo/Bar.java");
+        assertFalse(result);
+
+        result = JavaJarCrawler.hasClassfileName("com/foo/Bar.txt");
+        assertFalse(result);
+
+        // by design, this method is not interested in inner classes
+        result = JavaJarCrawler.hasClassfileName("com/foo/Bar$Inner.class");
+        assertFalse(result);
+
+        result = JavaJarCrawler.hasClassfileName("");
+        assertFalse(result);
+
+        result = JavaJarCrawler.hasClassfileName(null);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testConvertClassfileNameToClassname() {
+        String result = JavaJarCrawler.convertClassfileNameToClassname("com/salesforce/foo/Bar.class");
+        assertEquals("com.salesforce.foo.Bar", result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname("Bar.class");
+        assertEquals("Bar", result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname("");
+        assertNull(result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname("a/b/c");
+        assertNull(result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname(".class");
+        assertNull(result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname("class");
+        assertNull(result);
+
+        result = JavaJarCrawler.convertClassfileNameToClassname(null);
+        assertNull(result);
+    }
+}

--- a/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptorModelTest.java
+++ b/tests/com.salesforce.bazel-java-sdk.tests/src/com/salesforce/bazel/sdk/index/model/CodeLocationDescriptorModelTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2022, Salesforce.com, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.bazel.sdk.index.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CodeLocationDescriptorModelTest {
+
+    private static final long ONE_DAY_MILLIS = 24 * 60 * 60 * 1000L;
+
+    public void testJarAgeComputations() {
+        CodeLocationDescriptor jarLocationDescriptor = new CodeLocationDescriptor();
+
+        long currentTimeMillis = 1000000000000L; // fixed time such that tests are reproducible
+        long earlistValidTimeMillis = 945000000000L;
+        final int UNKNOWN_DAYS = -1;
+
+        // verify default age is unknown (-1)
+        assertEquals(UNKNOWN_DAYS, jarLocationDescriptor.ageInDays);
+
+        // happy path: 0 days old (written 10 seconds ago)
+        long writtenTimeMillis = currentTimeMillis - 10000L; // tens seconds before now
+        boolean success =
+                jarLocationDescriptor.computeAge(writtenTimeMillis, currentTimeMillis, earlistValidTimeMillis);
+        assertTrue(success);
+        assertEquals(0, jarLocationDescriptor.ageInDays);
+
+        // happy path: 5 days old
+        writtenTimeMillis = currentTimeMillis - (5 * ONE_DAY_MILLIS) - 10000L;
+        success = jarLocationDescriptor.computeAge(writtenTimeMillis, currentTimeMillis, earlistValidTimeMillis);
+        assertTrue(success);
+        assertEquals(5, jarLocationDescriptor.ageInDays);
+
+        // unhappy path: written time of entry is older than earliest valid time (earlistValidTimeMillis) which is
+        // likely a fake date provided by a hermetic build system
+        writtenTimeMillis = 0;
+        success = jarLocationDescriptor.computeAge(writtenTimeMillis, currentTimeMillis, earlistValidTimeMillis);
+        assertFalse(success);
+        assertEquals(UNKNOWN_DAYS, jarLocationDescriptor.ageInDays);
+
+        // unhappy path: written time of entry is bogus future date
+        writtenTimeMillis = currentTimeMillis + (3 * ONE_DAY_MILLIS);
+        success = jarLocationDescriptor.computeAge(writtenTimeMillis, currentTimeMillis, earlistValidTimeMillis);
+        assertFalse(success);
+        assertEquals(UNKNOWN_DAYS, jarLocationDescriptor.ageInDays);
+    }
+
+}


### PR DESCRIPTION
Adds the ability to optionally compute an age for each jar in the Global Search index. This isn't surfaced in BEF yet, but can be output in a report (not enabled by default).

While adding optional age computation to the global index, found that the simplistic implementation would benefit from a more robust redesign. Now there is an IndexOptions object to capture runtime options for indexing, there is a CodeIndexer type, and more improvements.