### PR TITLE
First rough support for srcjars

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelProjectFileSystemMapper.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelProjectFileSystemMapper.java
@@ -61,6 +61,28 @@ public class BazelProjectFileSystemMapper {
     }
 
     /**
+     * Returns the folder where source files links to generated sources will be created.
+     * <p>
+     * This can be used whenever there is a need to bring generated sources into a project (eg., <code>.srcjar</code> ).
+     * It is expected that this folder is used as a parent. It should only contain symlinks to folders with the
+     * generated sources. Do not copy generated sources in here.
+     * </p>
+     *
+     * @param project
+     * @return the folder to use for generated sources
+     */
+    public IFolder getGeneratedSourcesFolder(BazelProject project) {
+        return project.getProject().getFolder("generated-srcs");
+    }
+
+    /**
+     * @see #getGeneratedSourcesFolder(BazelProject)
+     */
+    public IFolder getGeneratedSourcesFolderForTests(BazelProject project) {
+        return project.getProject().getFolder("generated-test-srcs");
+    }
+
+    /**
      * @see #getVirtualSourceFolder(BazelProject)
      */
     public IFolder getOutputFolder(BazelProject project) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelWorkspace.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelWorkspace.java
@@ -200,6 +200,16 @@ public final class BazelWorkspace extends BazelElement<BazelWorkspaceInfo, Bazel
     }
 
     /**
+     * {@return absolute file system location to the <code>bazel-bin</code> symlink target}
+     *
+     * @throws CoreException
+     *             if the workspace does not exist
+     */
+    public IPath getBazelBinLocation() throws CoreException {
+        return getInfo().getBazelBin();
+    }
+
+    /**
      * Returns a Bazel package for the given label.
      * <p>
      * This is a handle-only method. The underlying package may or may not exist in the workspace.

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BuildFileAndVisibilityDrivenProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BuildFileAndVisibilityDrivenProvisioningStrategy.java
@@ -471,6 +471,9 @@ public class BuildFileAndVisibilityDrivenProvisioningStrategy extends ProjectPer
                                     .collect(joining(", ")))));
             }
 
+            // configure links
+            linkGeneratedSourcesIntoProject(project, javaInfo, monitor.split(1));
+
             // configure classpath
             configureRawClasspath(project, javaInfo, monitor.split(1));
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerPackageProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerPackageProvisioningStrategy.java
@@ -256,6 +256,9 @@ public class ProjectPerPackageProvisioningStrategy extends BaseProvisioningStrat
                                     .collect(joining(", ")))));
             }
 
+            // configure links
+            linkGeneratedSourcesIntoProject(project, javaInfo, monitor.split(1));
+
             // configure classpath
             configureRawClasspath(project, javaInfo, monitor.split(1));
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
@@ -197,6 +197,7 @@ public class ProjectPerTargetProvisioningStrategy extends BaseProvisioningStrate
 
         // configure links
         linkSourcesIntoProject(project, javaInfo, monitor.split(1));
+        linkGeneratedSourcesIntoProject(project, javaInfo, monitor.split(1));
 
         // configure classpath
         configureRawClasspath(project, javaInfo, monitor.split(1));

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaProjectInfo.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaProjectInfo.java
@@ -179,13 +179,13 @@ public class JavaProjectInfo {
     public IStatus analyzeProjectRecommendations(IProgressMonitor monitor) throws CoreException {
         var result = new MultiStatus(JavaProjectInfo.class, 0, "Java Analysis Result");
 
-        sourceInfo = new JavaSourceInfo(this.srcs, bazelPackage.getLocation());
+        sourceInfo = new JavaSourceInfo(this.srcs, bazelPackage);
         sourceInfo.analyzeSourceDirectories(result);
 
         resourceInfo = new JavaResourceInfo(resources, bazelPackage);
         resourceInfo.analyzeResourceDirectories(result);
 
-        testSourceInfo = new JavaSourceInfo(this.testSrcs, bazelPackage.getLocation(), sourceInfo);
+        testSourceInfo = new JavaSourceInfo(this.testSrcs, bazelPackage, sourceInfo);
         testSourceInfo.analyzeSourceDirectories(result);
 
         testResourceInfo = new JavaResourceInfo(testResources, bazelPackage);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaSourceEntry.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaSourceEntry.java
@@ -7,12 +7,12 @@ import java.util.Objects;
 import org.eclipse.core.runtime.IPath;
 
 /**
- * A source entry points to exactly one <code>.java</code> source file. It contains additional logic for extracting
- * the package path from the location.
+ * A source entry points to exactly one <code>.java</code> source file. It contains additional logic for extracting the
+ * package path from the location.
  */
 public class JavaSourceEntry implements Entry {
 
-    private static boolean endsWith(IPath path, IPath lastSegments) {
+    static boolean endsWith(IPath path, IPath lastSegments) {
         if (path.segmentCount() < lastSegments.segmentCount()) {
             return false;
         }
@@ -61,6 +61,13 @@ public class JavaSourceEntry implements Entry {
     }
 
     /**
+     * @return the Bazel package location this entry is contained in
+     */
+    public IPath getBazelPackageLocation() {
+        return bazelPackageLocation;
+    }
+
+    /**
      * {@return absolute location of of the container of this path entry}
      */
     public IPath getContainingFolderPath() {
@@ -93,8 +100,8 @@ public class JavaSourceEntry implements Entry {
     }
 
     /**
-     * @return first few segments of {@link #getPathParent()} which could be the source directory, or
-     *         <code>null</code> if unlikely
+     * @return first few segments of {@link #getPathParent()} (relative to {@link #getBazelPackageLocation()}) which
+     *         could be the source directory, or <code>null</code> if unlikely
      */
     public IPath getPotentialSourceDirectoryRoot() {
         var detectedPackagePath = getDetectedPackagePath();
@@ -111,6 +118,14 @@ public class JavaSourceEntry implements Entry {
     @Override
     public int hashCode() {
         return Objects.hash(bazelPackageLocation, relativePath);
+    }
+
+    /**
+     * {@return <code>true</code> if the entry is generated, i.e. located outside a Bazel package, <code>false</code>
+     * otherwise}
+     */
+    public boolean isExternalOrGenerated() {
+        return false;
     }
 
     @Override

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaSrcJarEntry.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/JavaSrcJarEntry.java
@@ -1,0 +1,70 @@
+/*-
+ * Copyright (c) 2023 Salesforce and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *      Salesforce - adapted from M2E, JDT or other Eclipse project
+ */
+package com.salesforce.bazel.eclipse.core.model.discovery.projects;
+
+import org.eclipse.core.runtime.IPath;
+
+/**
+ * An entry inside a <code>.srcjar</code>.
+ * <p>
+ * In contrast to a standard {@link JavaSourceEntry} this specialization overrides the contract of
+ * {@link #getPotentialSourceDirectoryRoot()} to be an absolute path to a directory somewhere on the file system.
+ * Additional, the {@link #getBazelPackageLocation()} is also not really a Bazel package but the directory of the
+ * explosed srcjar.
+ * </p>
+ */
+public class JavaSrcJarEntry extends JavaSourceEntry {
+
+    public JavaSrcJarEntry(IPath relativePath, IPath srcJarDirectory) {
+        super(relativePath, srcJarDirectory);
+    }
+
+    /**
+     * {@retun the location to the exploded srcjar}
+     */
+    @Override
+    public IPath getBazelPackageLocation() {
+        return super.getBazelPackageLocation();
+    }
+
+    /**
+     * @return first few segments of {@link #getPathParent()} (within {@link #getSrcJarDirectoryLocation()}) which could
+     *         be the source directory, or <code>null</code> if unlikely
+     */
+    @Override
+    public IPath getPotentialSourceDirectoryRoot() {
+        var detectedPackagePath = getDetectedPackagePath();
+
+        // note, we check the full path because we *want* to identify files from targets defined within a Java package
+        var absolutePathToJavaFileDirectory = getSrcJarDirectoryLocation().append(getPathParent());
+        if (endsWith(absolutePathToJavaFileDirectory, detectedPackagePath)) {
+            return absolutePathToJavaFileDirectory.removeLastSegments(detectedPackagePath.segmentCount());
+        }
+
+        return getSrcJarDirectoryLocation(); // assume srcjar directory
+    }
+
+    /**
+     * {@retun the location to the exploded srcjar}
+     */
+    public IPath getSrcJarDirectoryLocation() {
+        // the package location is the src jar directory
+        return getBazelPackageLocation();
+    }
+
+    @Override
+    public boolean isExternalOrGenerated() {
+        return true;
+    }
+}

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/LabelEntry.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/projects/LabelEntry.java
@@ -30,6 +30,13 @@ public class LabelEntry implements Entry {
         return Objects.equals(label, other.label);
     }
 
+    /**
+     * @return the label
+     */
+    public BazelLabel getLabel() {
+        return label;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(label);


### PR DESCRIPTION
This will extract the `srcjar` found in `srcs` label references and add them to the classpath.
Lacks a delta/diff mechanism to detect removed files.