### PR TITLE
Revert "Dependabot: Bump actions/deploy-pages from 3 to 4"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,7 @@ jobs:
           
       - name: Deploy Update Site 🚀
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3
           
       - name: Trigger VS Code Extension publish workflow
         uses: actions/github-script@v7


### PR DESCRIPTION
Reverts salesforce/bazel-eclipse#481

See https://github.com/actions/deploy-pages/issues/286