### PR TITLE
Adding StartTime into Span so we can add proper hierarchical spans in to telemetry

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/Trace.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/Trace.java
@@ -34,6 +34,7 @@ public final class Trace {
     public static final class Span {
 
         private final String name;
+        private final long startTime;
         private final StopWatch stopWatch;
         private final List<Span> children = new ArrayList<>();
         private boolean done = false;
@@ -43,7 +44,7 @@ public final class Trace {
             if (name.isBlank()) {
                 throw new IllegalArgumentException("A blank name is not allowed!");
             }
-
+            startTime = System.currentTimeMillis();
             stopWatch = new StopWatch();
             stopWatch.start();
         }
@@ -66,6 +67,10 @@ public final class Trace {
 
         public long getDuration(TimeUnit timeUnit) {
             return stopWatch.getDuration(timeUnit);
+        }
+
+        public long getStartTime() {
+            return startTime;
         }
 
         public String getName() {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/Trace.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/Trace.java
@@ -34,7 +34,7 @@ public final class Trace {
     public static final class Span {
 
         private final String name;
-        private final long startTime;
+        private final long startTimeEpocMilli;
         private final StopWatch stopWatch;
         private final List<Span> children = new ArrayList<>();
         private boolean done = false;
@@ -44,7 +44,7 @@ public final class Trace {
             if (name.isBlank()) {
                 throw new IllegalArgumentException("A blank name is not allowed!");
             }
-            startTime = System.currentTimeMillis();
+            startTimeEpocMilli = System.currentTimeMillis();
             stopWatch = new StopWatch();
             stopWatch.start();
         }
@@ -69,8 +69,8 @@ public final class Trace {
             return stopWatch.getDuration(timeUnit);
         }
 
-        public long getStartTime() {
-            return startTime;
+        public long getStartTimeEpocMilli() {
+            return startTimeEpocMilli;
         }
 
         public String getName() {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/TraceTree.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/TraceTree.java
@@ -53,11 +53,13 @@ public class TraceTree {
 
     public static record SpanNode(
             String name,
+            long startTime,
             long durationNanos,
             double percentageOfRoot,
             java.util.List<SpanNode> children) {
-        public SpanNode(String name, long durationNanos, double percentageOfRoot, java.util.List<SpanNode> children) {
+        public SpanNode(String name, long startTime, long durationNanos, double percentageOfRoot, java.util.List<SpanNode> children) {
             this.name = requireNonNull(name);
+            this.startTime = startTime;
             this.durationNanos = durationNanos;
             this.percentageOfRoot = percentageOfRoot;
             this.children = requireNonNull(children);
@@ -73,6 +75,7 @@ public class TraceTree {
         public JsonObject toJson() {
             var node = new JsonObject();
             node.addProperty("name", name());
+            node.addProperty("startTime", startTime());
             node.addProperty("durationNanos", durationNanos());
             node.addProperty("persentageOfRoot", percentageOfRoot());
             if (!children().isEmpty()) {
@@ -102,7 +105,8 @@ public class TraceTree {
         }
 
         var durationNanos = span.getDuration(TimeUnit.NANOSECONDS);
-        return new SpanNode(span.getName(), durationNanos, percentage(durationNanos, rootDurationNanos), children);
+        var startTime = span.getStartTime();
+        return new SpanNode(span.getName(), startTime, durationNanos, percentage(durationNanos, rootDurationNanos), children);
     }
 
     private static double percentage(long duration, long rootDuration) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/TraceTree.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/util/trace/TraceTree.java
@@ -53,13 +53,13 @@ public class TraceTree {
 
     public static record SpanNode(
             String name,
-            long startTime,
+            long startTimeEpocMilli,
             long durationNanos,
             double percentageOfRoot,
             java.util.List<SpanNode> children) {
-        public SpanNode(String name, long startTime, long durationNanos, double percentageOfRoot, java.util.List<SpanNode> children) {
+        public SpanNode(String name, long startTimeEpocMilli, long durationNanos, double percentageOfRoot, java.util.List<SpanNode> children) {
             this.name = requireNonNull(name);
-            this.startTime = startTime;
+            this.startTimeEpocMilli = startTimeEpocMilli;
             this.durationNanos = durationNanos;
             this.percentageOfRoot = percentageOfRoot;
             this.children = requireNonNull(children);
@@ -75,7 +75,7 @@ public class TraceTree {
         public JsonObject toJson() {
             var node = new JsonObject();
             node.addProperty("name", name());
-            node.addProperty("startTime", startTime());
+            node.addProperty("startTimeEpocMilli", startTimeEpocMilli());
             node.addProperty("durationNanos", durationNanos());
             node.addProperty("persentageOfRoot", percentageOfRoot());
             if (!children().isEmpty()) {
@@ -105,8 +105,8 @@ public class TraceTree {
         }
 
         var durationNanos = span.getDuration(TimeUnit.NANOSECONDS);
-        var startTime = span.getStartTime();
-        return new SpanNode(span.getName(), startTime, durationNanos, percentage(durationNanos, rootDurationNanos), children);
+        var startTimeEpocMilli = span.getStartTimeEpocMilli();
+        return new SpanNode(span.getName(), startTimeEpocMilli, durationNanos, percentage(durationNanos, rootDurationNanos), children);
     }
 
     private static double percentage(long duration, long rootDuration) {

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/core/util/trace/TraceGraphDumperTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/core/util/trace/TraceGraphDumperTest.java
@@ -34,11 +34,12 @@ public class TraceGraphDumperTest {
     private TraceTree simpleSampleTree() {
         var rootNode = new TraceTree.SpanNode(
                 "Root",
+                1999999L,
                 100000L,
                 80.0F,
                 List.of(
-                    new TraceTree.SpanNode("Child 1", 50000L, 3.0F, Collections.emptyList()),
-                    new TraceTree.SpanNode("Child 2", 30000L, 5.0F, Collections.emptyList())));
+                    new TraceTree.SpanNode("Child 1", 1999999L,50000L, 3.0F, Collections.emptyList()),
+                    new TraceTree.SpanNode("Child 2", 1999999L,30000L, 5.0F, Collections.emptyList())));
 
         return new TraceTree(rootNode);
     }

--- a/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/core/util/trace/TraceGraphDumperTest.java
+++ b/tests/com.salesforce.bazel.eclipse.core.tests/src/com/salesforce/bazel/eclipse/core/util/trace/TraceGraphDumperTest.java
@@ -38,8 +38,8 @@ public class TraceGraphDumperTest {
                 100000L,
                 80.0F,
                 List.of(
-                    new TraceTree.SpanNode("Child 1", 1999999L,50000L, 3.0F, Collections.emptyList()),
-                    new TraceTree.SpanNode("Child 2", 1999999L,30000L, 5.0F, Collections.emptyList())));
+                    new TraceTree.SpanNode("Child 1", 1999999L, 50000L, 3.0F, Collections.emptyList()),
+                    new TraceTree.SpanNode("Child 2", 1999999L, 30000L, 5.0F, Collections.emptyList())));
 
         return new TraceTree(rootNode);
     }


### PR DESCRIPTION
Adding StartTime into Span so we can add proper hierarchical spans in to telemetry.
This allows to represent the actual hierarchy of calls, because some of them are running in parallel.

<img width="1496" alt="image" src="https://github.com/salesforce/bazel-eclipse/assets/53876213/5f539177-1d5d-4c4d-8ffe-d76bbd983d7a">
