### PR TITLE
Replace lists for sets when contains is required

### DIFF
--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/BazelClasspathManager.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/BazelClasspathManager.java
@@ -331,7 +331,7 @@ public class BazelClasspathManager {
             // update classpath container (this will re-set classpath on JavaProject)
             updateClasspath(
                 bazelProject.getBazelWorkspace(),
-                List.of(bazelProject),
+                Set.of(bazelProject),
                 monitor.split(1, SUPPRESS_ALL_LABELS));
         } finally {
             if (progress != null) {
@@ -387,7 +387,7 @@ public class BazelClasspathManager {
      * @param progress
      * @throws CoreException
      */
-    void updateClasspath(BazelWorkspace bazelWorkspace, List<BazelProject> projects, IProgressMonitor progress)
+    void updateClasspath(BazelWorkspace bazelWorkspace, Set<BazelProject> projects, IProgressMonitor progress)
             throws CoreException {
         try {
             var monitor =

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/InitializeOrRefreshClasspathJob.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/classpath/InitializeOrRefreshClasspathJob.java
@@ -5,9 +5,10 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.groupingBy;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IMarker;
@@ -54,7 +55,7 @@ public final class InitializeOrRefreshClasspathJob extends WorkspaceJob {
         }
     }
 
-    private final Map<BazelWorkspace, List<BazelProject>> bazelProjects;
+    private final Map<BazelWorkspace, Set<BazelProject>> bazelProjects;
     private final BazelClasspathManager classpathManager;
 
     private final boolean forceRefresh;
@@ -101,7 +102,7 @@ public final class InitializeOrRefreshClasspathJob extends WorkspaceJob {
             } catch (CoreException e) {
                 throw new IllegalStateException(format("Invalid project '%s': %s", p, e.getMessage()), e);
             }
-        }));
+        }, Collectors.toSet()));
         setPriority(Job.BUILD); // process after others
         setRule(getRuleFactory().buildRule()); // ensure not build is running in parallel
     }
@@ -143,7 +144,7 @@ public final class InitializeOrRefreshClasspathJob extends WorkspaceJob {
                     0,
                     "Some Bazel build paths could not be initialized.");
 
-            nextProjectSet: for (Entry<BazelWorkspace, List<BazelProject>> projectSet : bazelProjects.entrySet()) {
+            nextProjectSet: for (Entry<BazelWorkspace, Set<BazelProject>> projectSet : bazelProjects.entrySet()) {
                 try {
                     // we only process projects with a valid workspace
                     if (projectSet.getKey() == null) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelVisibility.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/BazelVisibility.java
@@ -13,11 +13,12 @@
  */
 package com.salesforce.bazel.eclipse.core.model;
 
-import static java.util.List.copyOf;
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Describes visibility information in the Bazel graph.
@@ -32,20 +33,20 @@ public class BazelVisibility {
     public static final String PKG = "__pkg__";
     public static final String SUBPACKAGES = "__subpackages__";
 
-    private final List<String> labels;
+    private final Set<String> labels;
 
     public BazelVisibility(List<String> labels) {
         if ((labels == null) || labels.isEmpty()) {
             throw new IllegalArgumentException("At least one visibility label must be provided!");
         }
-        this.labels = copyOf(requireNonNull(labels));
+        this.labels = new HashSet<>(requireNonNull(labels));
     }
 
     public BazelVisibility(String... labels) {
         if ((labels == null) || (labels.length == 0)) {
             throw new IllegalArgumentException("At least one visibility label must be provided!");
         }
-        this.labels = List.of(labels);
+        this.labels = Set.of(labels);
     }
 
     @Override

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizationParticipant.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizationParticipant.java
@@ -13,7 +13,7 @@
  */
 package com.salesforce.bazel.eclipse.core.model;
 
-import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -34,11 +34,11 @@ public interface SynchronizationParticipant {
      * @param bazelWorkspace
      *            the Bazel workspace the was synchronized
      * @param bazelProjects
-     *            the list of Bazel projects provisioned/updated during synchronization
+     *            the set of Bazel projects provisioned/updated during synchronization
      * @param monitor
      *            progress monitor for reporting progress and checking for cancellation
      */
-    void afterSynchronizationCompleted(BazelWorkspace bazelWorkspace, List<BazelProject> bazelProjects,
+    void afterSynchronizationCompleted(BazelWorkspace bazelWorkspace, Set<BazelProject> bazelProjects,
             IProgressMonitor monitor) throws CoreException;
 
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizeProjectViewJob.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/SynchronizeProjectViewJob.java
@@ -151,7 +151,7 @@ public class SynchronizeProjectViewJob extends WorkspaceJob {
         setRule(getWorkspaceRoot());
     }
 
-    private void callSynParticipants(List<BazelProject> targetProjects, TracingSubMonitor monitor, int work)
+    private void callSynParticipants(Set<BazelProject> targetProjects, TracingSubMonitor monitor, int work)
             throws CoreException {
         var synchronizationParticipants = getSynchronizationParticipants();
         if (synchronizationParticipants.isEmpty()) {
@@ -504,7 +504,7 @@ public class SynchronizeProjectViewJob extends WorkspaceJob {
         }
     }
 
-    private void initializeClasspaths(List<BazelProject> projects, BazelWorkspace workspace, TracingSubMonitor monitor,
+    private void initializeClasspaths(Set<BazelProject> projects, BazelWorkspace workspace, TracingSubMonitor monitor,
             int work) throws CoreException {
         monitor = monitor.split(work, format("Initializing Classpaths for %d projects", projects.size()));
 
@@ -529,7 +529,7 @@ public class SynchronizeProjectViewJob extends WorkspaceJob {
             lines.stream().collect(joining(System.lineSeparator())));
     }
 
-    private List<BazelProject> provisionProjectsForTarget(Set<BazelTarget> targets, TracingSubMonitor monitor, int work)
+    private Set<BazelProject> provisionProjectsForTarget(Set<BazelTarget> targets, TracingSubMonitor monitor, int work)
             throws CoreException {
         return getTargetProvisioningStrategy()
                 .provisionProjectsForSelectedTargets(targets, workspace, monitor.split(work, "Provisioning Projects"));
@@ -594,7 +594,7 @@ public class SynchronizeProjectViewJob extends WorkspaceJob {
         }
     }
 
-    private void removeObsoleteProjects(List<BazelProject> provisionedProjects, TracingSubMonitor monitor, int work)
+    private void removeObsoleteProjects(Set<BazelProject> provisionedProjects, TracingSubMonitor monitor, int work)
             throws CoreException {
         var obsoleteProjects = new ArrayList<IProject>();
         for (IProject project : getWorkspaceRoot().getProjects()) {

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BaseProvisioningStrategy.java
@@ -1171,11 +1171,11 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
      *            collection of targets
      * @param monitor
      *            monitor for reporting progress
-     * @return list of provisioned projects
+     * @return set of provisioned projects
      * @throws CoreException
      */
-    protected abstract List<BazelProject> doProvisionProjects(Collection<BazelTarget> targets,
-            TracingSubMonitor monitor) throws CoreException;
+    protected abstract Set<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
+            throws CoreException;
 
     private void ensureFolderLinksToTarget(IFolder folderWhichShouldBeALink, IPath linkTarget, SubMonitor monitor)
             throws CoreException {
@@ -1706,7 +1706,7 @@ public abstract class BaseProvisioningStrategy implements TargetProvisioningStra
     }
 
     @Override
-    public List<BazelProject> provisionProjectsForSelectedTargets(Collection<BazelTarget> targets,
+    public Set<BazelProject> provisionProjectsForSelectedTargets(Collection<BazelTarget> targets,
             BazelWorkspace workspace, IProgressMonitor progress) throws CoreException {
         try {
             var monitor = TracingSubMonitor.convert(progress, "Provisioning projects", 3);

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BuildFileAndVisibilityDrivenProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/BuildFileAndVisibilityDrivenProvisioningStrategy.java
@@ -380,7 +380,7 @@ public class BuildFileAndVisibilityDrivenProvisioningStrategy extends ProjectPer
     }
 
     @Override
-    protected List<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
+    protected Set<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
             throws CoreException {
         // group into packages
         Map<BazelPackage, List<BazelTarget>> targetsByPackage =
@@ -388,7 +388,7 @@ public class BuildFileAndVisibilityDrivenProvisioningStrategy extends ProjectPer
 
         monitor.beginTask("Provisioning projects", targetsByPackage.size() * 3);
 
-        var result = new ArrayList<BazelProject>();
+        var result = new HashSet<BazelProject>();
         for (Entry<BazelPackage, List<BazelTarget>> entry : targetsByPackage.entrySet()) {
             var bazelPackage = entry.getKey();
             var packageTargets = entry.getValue();

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerPackageProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerPackageProvisioningStrategy.java
@@ -309,7 +309,7 @@ public class ProjectPerPackageProvisioningStrategy extends BaseProvisioningStrat
     }
 
     @Override
-    protected List<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
+    protected Set<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
             throws CoreException {
         // initialize the list of allowed java like rules
         var javaLikeRulesValue = getFileSystemMapper().getBazelWorkspace()
@@ -329,7 +329,7 @@ public class ProjectPerPackageProvisioningStrategy extends BaseProvisioningStrat
 
         monitor.setWorkRemaining(targetsByPackage.size() * 3);
 
-        var result = new ArrayList<BazelProject>();
+        var result = new HashSet<BazelProject>();
         for (Entry<BazelPackage, List<BazelTarget>> entry : targetsByPackage.entrySet()) {
             var bazelPackage = entry.getKey();
             var packageTargets = entry.getValue();

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/ProjectPerTargetProvisioningStrategy.java
@@ -142,10 +142,10 @@ public class ProjectPerTargetProvisioningStrategy extends BaseProvisioningStrate
     }
 
     @Override
-    protected List<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
+    protected Set<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
             throws CoreException {
         monitor.setWorkRemaining(targets.size());
-        List<BazelProject> result = new ArrayList<>();
+        Set<BazelProject> result = new HashSet<>();
         for (BazelTarget target : targets) {
             monitor.subTask(target.getLabel().toString());
 

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/TargetProvisioningStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/TargetProvisioningStrategy.java
@@ -1,8 +1,8 @@
 package com.salesforce.bazel.eclipse.core.model.discovery;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -126,9 +126,9 @@ public interface TargetProvisioningStrategy {
      *            the workspace all targets belong to (never <code>null</code>)
      * @param progress
      *            a monitor for tracking progress and observing cancellations (never <code>null</code>)
-     * @return a list of provisioned projects (never <code>null</code>)
+     * @return a set of provisioned projects (never <code>null</code>)
      */
-    List<BazelProject> provisionProjectsForSelectedTargets(Collection<BazelTarget> targets, BazelWorkspace workspace,
+    Set<BazelProject> provisionProjectsForSelectedTargets(Collection<BazelTarget> targets, BazelWorkspace workspace,
             IProgressMonitor progress) throws CoreException;
 
 }

--- a/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/WorkspaceClasspathStrategy.java
+++ b/bundles/com.salesforce.bazel.eclipse.core/src/com/salesforce/bazel/eclipse/core/model/discovery/WorkspaceClasspathStrategy.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -140,7 +141,7 @@ public class WorkspaceClasspathStrategy extends BaseProvisioningStrategy {
     }
 
     @Override
-    protected List<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
+    protected Set<BazelProject> doProvisionProjects(Collection<BazelTarget> targets, TracingSubMonitor monitor)
             throws CoreException {
         throw new IllegalStateException("this method must not be called");
     }


### PR DESCRIPTION
Found some places where we are calling .contains() on list of items which can be optimized to use sets instead. I assumed that order is not needed, let me know if there are areas that order is important and can update to a linked hashset